### PR TITLE
perf: cut runtime allocations, process scans and IPC round-trips

### DIFF
--- a/crates/accshift-core/src/logging.rs
+++ b/crates/accshift-core/src/logging.rs
@@ -37,59 +37,60 @@ fn log_lock_file_handle() -> &'static Mutex<Option<File>> {
 /// Holds the OS-level exclusive lock on the log sidecar for as long as it is
 /// alive; releases on drop. Acquisition is best-effort: if the sidecar can't be
 /// opened or locked we proceed without it rather than dropping log records,
-/// since logging must not become a hard failure path.
+/// since logging must not become a hard failure path. `Some` means the lock is
+/// held on the canonical cached handle, whose mutex stays held for the
+/// guard's lifetime so the unlock targets that same handle.
 struct CrossProcessLogGuard {
-    file: Option<File>,
+    guard: Option<std::sync::MutexGuard<'static, Option<File>>>,
 }
 
 impl CrossProcessLogGuard {
     fn acquire(app_handle: &dyn AppContext) -> Self {
-        // Get our own handle to the sidecar, then drop the in-process mutex
-        // before blocking on the OS lock: blocking while holding the mutex
-        // would needlessly stall sibling threads that haven't reached the OS
-        // wait yet.
-        let clone = {
-            let mut guard = log_lock_file_handle()
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
+        let mut guard = log_lock_file_handle()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
 
-            if guard.is_none() {
-                if let Ok(lock_path) = log_lock_file_path(app_handle) {
-                    if ensure_log_parent(&lock_path).is_ok() {
-                        if let Ok(file) = OpenOptions::new()
-                            .create(true)
-                            .read(true)
-                            .write(true)
-                            .truncate(false)
-                            .open(&lock_path)
-                        {
-                            *guard = Some(file);
-                        }
+        if guard.is_none() {
+            if let Ok(lock_path) = log_lock_file_path(app_handle) {
+                if ensure_log_parent(&lock_path).is_ok() {
+                    if let Ok(file) = OpenOptions::new()
+                        .create(true)
+                        .read(true)
+                        .write(true)
+                        .truncate(false)
+                        .open(&lock_path)
+                    {
+                        *guard = Some(file);
                     }
                 }
             }
+        }
 
-            // Clone rather than move: the OnceLock keeps the canonical handle
-            // open for reuse across calls.
-            guard.as_ref().and_then(|file| file.try_clone().ok())
+        // Blocking acquire on the canonical handle, taken while still holding
+        // the in-process mutex. That wait can't stall a sibling thread: every
+        // acquire site takes the `log_sink` mutex first and keeps it for the
+        // guard's lifetime (lock order log_sink -> LOG_LOCK_FILE everywhere),
+        // so siblings are already serialized before reaching this point.
+        // Best-effort: if the sidecar can't be opened or locked we drop the
+        // mutex and proceed unlocked rather than failing the log write, and
+        // the open is retried on the next call.
+        let locked = match guard.as_ref() {
+            Some(file) => FileExt::lock_exclusive(file).is_ok(),
+            None => false,
         };
 
-        // Blocking acquire: serialize against the other process. Best-effort.
-        // If the lock can't be taken we proceed unlocked rather than failing
-        // the log write.
-        let locked = clone.and_then(|file| {
-            FileExt::lock_exclusive(&file).ok()?;
-            Some(file)
-        });
-
-        CrossProcessLogGuard { file: locked }
+        CrossProcessLogGuard {
+            guard: locked.then_some(guard),
+        }
     }
 }
 
 impl Drop for CrossProcessLogGuard {
     fn drop(&mut self) {
-        if let Some(file) = self.file.take() {
-            let _ = FileExt::unlock(&file);
+        if let Some(guard) = self.guard.take() {
+            if let Some(file) = guard.as_ref() {
+                let _ = FileExt::unlock(file);
+            }
         }
     }
 }
@@ -128,6 +129,12 @@ fn replace_case_insensitive(haystack: &str, needle: &str, replacement: &str) -> 
     let lower_haystack = haystack.to_lowercase();
     let lower_needle = needle.to_lowercase();
 
+    // Nothing to replace: skip the offset map entirely. It costs 8 bytes per
+    // lowercased byte and the loop below would just copy `haystack` verbatim.
+    let Some(first_match) = lower_haystack.find(&lower_needle) else {
+        return haystack.to_string();
+    };
+
     // For every byte offset in `lower_haystack` that starts a char, record the
     // matching byte offset in `haystack`. `to_lowercase` maps each source char
     // to one or more chars without reordering, so the char streams stay
@@ -165,8 +172,9 @@ fn replace_case_insensitive(haystack: &str, needle: &str, replacement: &str) -> 
     let mut out = String::with_capacity(haystack.len());
     let mut search_start = 0usize;
     let mut copied_orig = 0usize;
+    let mut relative_match = Some(first_match);
 
-    while let Some(relative_index) = lower_haystack[search_start..].find(&lower_needle) {
+    while let Some(relative_index) = relative_match {
         let lower_start = search_start + relative_index;
         let lower_end = lower_start + lower_needle.len();
         let orig_start = orig_starts[lower_start];
@@ -175,6 +183,7 @@ fn replace_case_insensitive(haystack: &str, needle: &str, replacement: &str) -> 
         out.push_str(replacement);
         copied_orig = orig_end;
         search_start = lower_end;
+        relative_match = lower_haystack[search_start..].find(&lower_needle);
     }
 
     out.push_str(&haystack[copied_orig..]);
@@ -182,6 +191,11 @@ fn replace_case_insensitive(haystack: &str, needle: &str, replacement: &str) -> 
 }
 
 fn redact_email_like_tokens(value: &str) -> String {
+    // No `@`, no email: skip the char vector and the rewind table.
+    if !value.contains('@') {
+        return value.to_string();
+    }
+
     let chars: Vec<char> = value.chars().collect();
     let mut out = String::with_capacity(value.len());
     // `out_len_at[i]` is the byte length of `out` right before the char at
@@ -264,6 +278,11 @@ fn redact_email_like_tokens(value: &str) -> String {
 /// some locales accented letters) followed by `#` and 4-5 digits; we match
 /// that shape and ignore other `#` uses (e.g. `#define`, `channel #42`).
 fn redact_battletags(value: &str) -> String {
+    // A BattleTag always carries a `#`; without one the loop just copies.
+    if !value.contains('#') {
+        return value.to_string();
+    }
+
     let chars: Vec<char> = value.chars().collect();
     let mut out = String::with_capacity(value.len());
     let mut i = 0usize;
@@ -319,6 +338,26 @@ fn redact_battletags(value: &str) -> String {
 /// approximated by requiring the surrounding chars to be non-hex / non-dash so
 /// we don't clip a longer hex blob (hashes, keys) mid-stream.
 fn redact_uuid_like_tokens(value: &str) -> String {
+    // Both forms need at least 8 consecutive hex digits (first dashed group is
+    // 8, the bare form is 32). ASCII hex digits are single bytes, so a byte
+    // scan is equivalent to a char scan and avoids the char vector.
+    let mut hex_run = 0usize;
+    let mut has_hex_run = false;
+    for byte in value.bytes() {
+        if byte.is_ascii_hexdigit() {
+            hex_run += 1;
+            if hex_run >= 8 {
+                has_hex_run = true;
+                break;
+            }
+        } else {
+            hex_run = 0;
+        }
+    }
+    if !has_hex_run {
+        return value.to_string();
+    }
+
     let chars: Vec<char> = value.chars().collect();
     let mut out = String::with_capacity(value.len());
     let mut i = 0usize;
@@ -388,6 +427,50 @@ fn match_dashed_uuid(chars: &[char], start: usize) -> Option<usize> {
     Some(i)
 }
 
+// Env vars whose values are user-identifying paths, with the placeholder that
+// replaces them. Order matters and is preserved by the resolver below:
+// USERPROFILE first, HOME before the XDG dirs.
+const ENV_SCRUB_KEYS: [(&str, &str); 10] = [
+    ("USERPROFILE", "%USERPROFILE%"),
+    ("OneDrive", "%ONEDRIVE%"),
+    ("APPDATA", "%APPDATA%"),
+    ("LOCALAPPDATA", "%LOCALAPPDATA%"),
+    ("PROGRAMDATA", "%PROGRAMDATA%"),
+    ("TEMP", "%TEMP%"),
+    ("TMP", "%TEMP%"),
+    // Linux/macOS: AppContext::app_data_dir()/app_local_data_dir() resolve
+    // under $HOME (and under XDG_DATA_HOME/XDG_CONFIG_HOME when those are
+    // set), which embeds the OS account name. Without these, paths logged
+    // from config.rs's save_config_unlocked (portable/local config paths)
+    // leak the username on every successful config save.
+    ("HOME", "%HOME%"),
+    ("XDG_DATA_HOME", "%XDG_DATA_HOME%"),
+    ("XDG_CONFIG_HOME", "%XDG_CONFIG_HOME%"),
+];
+
+fn resolve_env_scrub_pairs() -> Vec<(String, &'static str)> {
+    ENV_SCRUB_KEYS
+        .iter()
+        .filter_map(|(env_key, placeholder)| {
+            std::env::var(env_key).ok().map(|path| (path, *placeholder))
+        })
+        .collect()
+}
+
+// These values are fixed for the process lifetime, so resolve them once
+// instead of paying 10 env lookups per sanitized field (4 fields per record).
+#[cfg(not(test))]
+fn resolved_env_scrub_pairs() -> Vec<(String, &'static str)> {
+    static ENV_SCRUB_CACHE: OnceLock<Vec<(String, &'static str)>> = OnceLock::new();
+    ENV_SCRUB_CACHE.get_or_init(resolve_env_scrub_pairs).clone()
+}
+
+// Tests mutate HOME / XDG_* at runtime, so they need a fresh read per call.
+#[cfg(test)]
+fn resolved_env_scrub_pairs() -> Vec<(String, &'static str)> {
+    resolve_env_scrub_pairs()
+}
+
 fn sanitize_log_text(value: &str) -> String {
     // Order matters: collapse emails first (they can contain digits/hex), then
     // BattleTags, then UUID/PUUID. We deliberately do NOT try to redact Steam
@@ -399,26 +482,8 @@ fn sanitize_log_text(value: &str) -> String {
     sanitized = redact_battletags(&sanitized);
     sanitized = redact_uuid_like_tokens(&sanitized);
 
-    for (env_key, placeholder) in [
-        ("USERPROFILE", "%USERPROFILE%"),
-        ("OneDrive", "%ONEDRIVE%"),
-        ("APPDATA", "%APPDATA%"),
-        ("LOCALAPPDATA", "%LOCALAPPDATA%"),
-        ("PROGRAMDATA", "%PROGRAMDATA%"),
-        ("TEMP", "%TEMP%"),
-        ("TMP", "%TEMP%"),
-        // Linux/macOS: AppContext::app_data_dir()/app_local_data_dir() resolve
-        // under $HOME (and under XDG_DATA_HOME/XDG_CONFIG_HOME when those are
-        // set), which embeds the OS account name. Without these, paths logged
-        // from config.rs's save_config_unlocked (portable/local config paths)
-        // leak the username on every successful config save.
-        ("HOME", "%HOME%"),
-        ("XDG_DATA_HOME", "%XDG_DATA_HOME%"),
-        ("XDG_CONFIG_HOME", "%XDG_CONFIG_HOME%"),
-    ] {
-        if let Ok(path) = std::env::var(env_key) {
-            sanitized = replace_case_insensitive(&sanitized, &path, placeholder);
-        }
+    for (path, placeholder) in resolved_env_scrub_pairs() {
+        sanitized = replace_case_insensitive(&sanitized, &path, placeholder);
     }
 
     sanitized

--- a/crates/accshift-core/src/os/common.rs
+++ b/crates/accshift-core/src/os/common.rs
@@ -130,6 +130,26 @@ pub fn any_process_running(process_names: &[&str]) -> bool {
     })
 }
 
+/// The subset of `process_names` that currently has a live process, resolved
+/// with a single process-table refresh for the whole batch. Callers that need
+/// the matching names (log details, diagnostics) should prefer this over one
+/// `is_process_running` call per name.
+pub fn running_process_names<'a>(process_names: &'a [&'a str]) -> Vec<&'a str> {
+    let matchers: Vec<NameMatcher> = process_names.iter().map(|n| NameMatcher::new(n)).collect();
+    with_refreshed_system(|system| {
+        matchers
+            .iter()
+            .filter(|matcher| {
+                system
+                    .processes()
+                    .values()
+                    .any(|p| is_live(p) && matcher.matches(p))
+            })
+            .map(|matcher| matcher.target)
+            .collect()
+    })
+}
+
 /// Executable names (lowercased, extension stripped) of streaming/recording
 /// software whose presence flips the UI into streamer mode. Windows reports
 /// e.g. "Streamlabs OBS.exe" and "XSplit.Core.exe", so the match lowercases and
@@ -150,6 +170,19 @@ const STREAMING_SOFTWARE: &[&str] = &[
 /// strips a trailing ".exe" so Windows ("OBS64.exe") and Unix ("obs") report
 /// the same way.
 fn is_streaming_process_name(name: &str) -> bool {
+    // Process names are ASCII in practice, and this runs for every entry in
+    // the process table on every streamer-mode poll. Compare in place instead
+    // of allocating a lowercased copy per process.
+    if name.is_ascii() {
+        let stem = if name.len() >= 4 && name[name.len() - 4..].eq_ignore_ascii_case(".exe") {
+            &name[..name.len() - 4]
+        } else {
+            name
+        };
+        return STREAMING_SOFTWARE
+            .iter()
+            .any(|s| s.eq_ignore_ascii_case(stem));
+    }
     let name = name.to_lowercase();
     let stem = name.strip_suffix(".exe").unwrap_or(name.as_str());
     STREAMING_SOFTWARE.contains(&stem)
@@ -237,10 +270,23 @@ pub fn kill_processes(process_names: &[&str]) {
 /// sleep `settle` so exit-time flushes (config files, leveldb, ...) land on
 /// disk. No-op when none of the processes is running.
 pub fn quit_processes_and_wait(process_names: &[&str], timeout_ms: u32, settle: Duration) {
-    if !any_process_running(process_names) {
+    let matchers: Vec<NameMatcher> = process_names.iter().map(|n| NameMatcher::new(n)).collect();
+    // One snapshot: kill every live matching process across all names.
+    let killed_any = with_refreshed_system(|system| {
+        let mut killed = false;
+        for p in system.processes().values() {
+            if is_live(p) && matchers.iter().any(|m| m.matches(p)) {
+                if !p.kill_with(Signal::Kill).unwrap_or(false) {
+                    let _ = p.kill();
+                }
+                killed = true;
+            }
+        }
+        killed
+    });
+    if !killed_any {
         return;
     }
-    kill_processes(process_names);
     for process_name in process_names {
         wait_for_process_exit(process_name, timeout_ms);
     }

--- a/crates/accshift-core/src/os/mod.rs
+++ b/crates/accshift-core/src/os/mod.rs
@@ -41,6 +41,12 @@ pub fn any_process_running(process_names: &[&str]) -> bool {
     common::any_process_running(process_names)
 }
 
+/// The subset of `process_names` currently running, using one process-table
+/// scan for the whole batch.
+pub fn running_process_names<'a>(process_names: &'a [&'a str]) -> Vec<&'a str> {
+    common::running_process_names(process_names)
+}
+
 /// Kill every process in `process_names`, best effort.
 pub fn kill_processes(process_names: &[&str]) {
     common::kill_processes(process_names)

--- a/crates/accshift-core/src/platforms/battle_net.rs
+++ b/crates/accshift-core/src/platforms/battle_net.rs
@@ -1,4 +1,4 @@
-use crate::config::{self, BattleNetAccountConfig};
+use crate::config::{self, AppConfig, BattleNetAccountConfig};
 use crate::error::PlatformError;
 use crate::platforms::{log_platform_error, log_platform_info, PlatformService, SetupStatus};
 use crate::{AppContext, AppCtx};
@@ -98,17 +98,13 @@ fn build_battle_net_switch_details(target_email: Option<&str>) -> String {
         .ok()
         .and_then(|accounts| accounts.into_iter().next())
         .unwrap_or_default();
-    let running_processes = BATTLE_NET_PROCESS_NAMES
-        .iter()
-        .copied()
-        .filter(|name| crate::os::is_process_running(name))
-        .collect::<Vec<_>>();
+    let running_processes = crate::os::running_process_names(BATTLE_NET_PROCESS_NAMES);
 
     use super::{redact_id, redact_opt};
     serde_json::json!({
         "targetEmail": redact_opt(target_email),
         "currentAccount": redact_id(&current_account),
-        "launcherRunning": is_battle_net_running(),
+        "launcherRunning": !running_processes.is_empty(),
         "runningProcesses": running_processes,
     })
     .to_string()
@@ -350,9 +346,10 @@ fn read_saved_accounts() -> Result<Vec<String>, String> {
     Ok(extract_saved_account_names(&value))
 }
 
-fn known_account_emails(app_handle: &dyn AppContext) -> Result<Vec<String>, String> {
-    let saved_accounts = read_saved_accounts()?;
-    let cfg = config::load_config(app_handle);
+/// Merge the launcher's saved account list with the ones we track in our own
+/// config, first occurrence wins. Takes both inputs so callers that already
+/// read them do not pay for a second disk read and config clone.
+fn known_account_emails_from(saved_accounts: Vec<String>, cfg: &AppConfig) -> Vec<String> {
     let mut accounts = Vec::new();
     let mut seen = HashSet::new();
 
@@ -364,7 +361,7 @@ fn known_account_emails(app_handle: &dyn AppContext) -> Result<Vec<String>, Stri
         accounts.push(email);
     }
 
-    for account in cfg.battle_net.accounts {
+    for account in &cfg.battle_net.accounts {
         let email = account.email.trim().to_string();
         let key = normalize_account_key(&email);
         if email.is_empty() || !seen.insert(key) {
@@ -373,16 +370,26 @@ fn known_account_emails(app_handle: &dyn AppContext) -> Result<Vec<String>, Stri
         accounts.push(email);
     }
 
-    Ok(accounts)
+    accounts
+}
+
+fn known_account_emails(app_handle: &dyn AppContext) -> Result<Vec<String>, String> {
+    let saved_accounts = read_saved_accounts()?;
+    let cfg = config::load_config(app_handle);
+    Ok(known_account_emails_from(saved_accounts, &cfg))
 }
 
 fn read_accounts(app_handle: &dyn AppContext) -> Result<Vec<BattleNetAccount>, String> {
-    if let Some(current_email) = read_saved_accounts()?.into_iter().next() {
-        let _ = remember_account_usage(app_handle, &current_email, true);
+    let saved_accounts = read_saved_accounts()?;
+    if let Some(current_email) = saved_accounts.first() {
+        let _ = remember_account_usage(app_handle, current_email, true);
     }
 
-    let account_emails = known_account_emails(app_handle)?;
+    // Load after `remember_account_usage`: it bumps last_used_at and may store
+    // a freshly fetched battle tag, so a config read before it would report
+    // stale metadata for the current account.
     let cfg = config::load_config(app_handle);
+    let account_emails = known_account_emails_from(saved_accounts, &cfg);
     let metadata_by_key = cfg
         .battle_net
         .accounts
@@ -398,16 +405,17 @@ fn read_accounts(app_handle: &dyn AppContext) -> Result<Vec<BattleNetAccount>, S
 
     Ok(account_emails
         .into_iter()
-        .map(|email| BattleNetAccount {
-            battle_tag: metadata_by_key
-                .get(&normalize_account_key(&email))
-                .map(|account| account.battle_tag.trim().to_string())
-                .filter(|battle_tag| !battle_tag.is_empty())
-                .unwrap_or_default(),
-            last_login_at: metadata_by_key
-                .get(&normalize_account_key(&email))
-                .and_then(|account| account.last_used_at),
-            email,
+        .map(|email| {
+            let key = normalize_account_key(&email);
+            let meta = metadata_by_key.get(&key);
+            BattleNetAccount {
+                battle_tag: meta
+                    .map(|account| account.battle_tag.trim().to_string())
+                    .filter(|battle_tag| !battle_tag.is_empty())
+                    .unwrap_or_default(),
+                last_login_at: meta.and_then(|account| account.last_used_at),
+                email,
+            }
         })
         .collect())
 }
@@ -432,27 +440,26 @@ fn remember_account_usage(
     // Only query battle tag from cache if we don't already have one stored.
     // After a switch, the log-based account_id_lo still points to the PREVIOUS
     // account, so current_battle_tag_from_cache() would return the wrong tag.
-    let existing_tag = config::load_config(app_handle)
-        .battle_net
-        .accounts
-        .iter()
-        .find(|a| normalize_account_key(&a.email) == key)
-        .map(|a| a.battle_tag.trim().to_string())
-        .filter(|t| !t.is_empty());
-
-    let battle_tag = if is_current_account && existing_tag.is_none() {
-        current_battle_tag_from_cache().ok().flatten()
-    } else {
-        None
-    };
-
+    // The check runs inside `update_config`, on the config it already loaded:
+    // a standalone `load_config` here would clone the whole config a second
+    // time on every account-list poll.
     config::update_config(app_handle, |cfg| {
-        if let Some(existing) = cfg
+        let index = cfg
             .battle_net
             .accounts
-            .iter_mut()
-            .find(|account| normalize_account_key(&account.email) == key)
-        {
+            .iter()
+            .position(|account| normalize_account_key(&account.email) == key);
+        let has_tag = index
+            .map(|i| !cfg.battle_net.accounts[i].battle_tag.trim().is_empty())
+            .unwrap_or(false);
+        let battle_tag = if is_current_account && !has_tag {
+            current_battle_tag_from_cache().ok().flatten()
+        } else {
+            None
+        };
+
+        if let Some(i) = index {
+            let existing = &mut cfg.battle_net.accounts[i];
             existing.email = email;
             if let Some(tag) = battle_tag {
                 existing.battle_tag = tag;

--- a/crates/accshift-core/src/platforms/discord.rs
+++ b/crates/accshift-core/src/platforms/discord.rs
@@ -39,6 +39,11 @@ const SETUP_MIN_LOGIN_MS: u64 = 4000;
 /// (the tail is read, where fresh appends live).
 const IDENTITY_SCAN_MAX_BYTES: u64 = 8 * 1024 * 1024;
 
+/// Budget for the tails cached across the two passes of a single identity scan
+/// (see `scan_identity_in_dir`). Past it, further tails are scanned and dropped
+/// so a directory full of `.ldb` files never pins its whole size in memory.
+const IDENTITY_SCAN_CACHE_MAX_BYTES: u64 = 32 * 1024 * 1024;
+
 /// Snapshot source directories under `%AppData%\discord` (all copied
 /// recursively) and the snapshot sub-directory each maps to.
 const SNAP_LEVELDB: &str = "local_storage_leveldb";
@@ -510,12 +515,32 @@ fn identity_scan_candidates(leveldb: &Path) -> Vec<PathBuf> {
 /// "logged out".
 fn scan_identity_in_dir(leveldb: &Path) -> Option<DiscordIdentity> {
     let files = identity_scan_candidates(leveldb);
-    let user_id = files.iter().find_map(|path| {
-        read_file_tail(path, IDENTITY_SCAN_MAX_BYTES).and_then(|bytes| extract_user_id(&bytes))
-    })?;
-    let username = files.iter().find_map(|path| {
-        read_file_tail(path, IDENTITY_SCAN_MAX_BYTES)
-            .and_then(|bytes| extract_username(&bytes, &user_id))
+    // The user id pass keeps the tails it read (up to a byte budget) so the
+    // username pass reuses them instead of re-reading the same files.
+    let mut cache: Vec<(usize, Vec<u8>)> = Vec::new();
+    let mut cached_bytes: u64 = 0;
+    let mut scanned_id = None;
+    for (index, path) in files.iter().enumerate() {
+        let Some(bytes) = read_file_tail(path, IDENTITY_SCAN_MAX_BYTES) else {
+            continue;
+        };
+        let hit = extract_user_id(&bytes);
+        if cached_bytes + bytes.len() as u64 <= IDENTITY_SCAN_CACHE_MAX_BYTES {
+            cached_bytes += bytes.len() as u64;
+            cache.push((index, bytes));
+        }
+        if hit.is_some() {
+            scanned_id = hit;
+            break;
+        }
+    }
+    let user_id = scanned_id?;
+    let username = files.iter().enumerate().find_map(|(index, path)| {
+        match cache.iter().find(|(i, _)| *i == index) {
+            Some((_, bytes)) => extract_username(bytes, &user_id),
+            None => read_file_tail(path, IDENTITY_SCAN_MAX_BYTES)
+                .and_then(|bytes| extract_username(&bytes, &user_id)),
+        }
     });
     Some(DiscordIdentity { user_id, username })
 }

--- a/crates/accshift-core/src/platforms/epic.rs
+++ b/crates/accshift-core/src/platforms/epic.rs
@@ -621,8 +621,10 @@ pub fn switch_account(app_handle: &dyn AppContext, account_id: &str) -> Result<(
     capture_current_account(app_handle)?;
 
     // Kill launcher
-    kill_epic();
-    std::thread::sleep(std::time::Duration::from_millis(POST_KILL_SETTLE_MS));
+    if is_epic_running() {
+        kill_epic();
+        std::thread::sleep(std::time::Duration::from_millis(POST_KILL_SETTLE_MS));
+    }
 
     // Restore target account's auth
     restore_auth_snapshot(app_handle, &account_id)?;
@@ -687,8 +689,10 @@ pub fn begin_account_setup(app_handle: &dyn AppContext) -> Result<SetupStatus, S
     )?;
 
     // Kill launcher, clear auth files to force login screen
-    kill_epic();
-    std::thread::sleep(std::time::Duration::from_millis(POST_KILL_SETTLE_MS));
+    if is_epic_running() {
+        kill_epic();
+        std::thread::sleep(std::time::Duration::from_millis(POST_KILL_SETTLE_MS));
+    }
     delete_auth_files()?;
     clear_eos_caches();
 

--- a/crates/accshift-core/src/platforms/riot.rs
+++ b/crates/accshift-core/src/platforms/riot.rs
@@ -173,11 +173,9 @@ fn is_any_process_running(process_names: &[&str]) -> bool {
 }
 
 fn running_process_names(process_names: &'static [&'static str]) -> Vec<&'static str> {
-    process_names
-        .iter()
-        .copied()
-        .filter(|process_name| os::is_process_running(process_name))
-        .collect()
+    // One process-table refresh for the whole batch instead of one per name.
+    // The order and uniqueness of the input list are preserved.
+    os::running_process_names(process_names)
 }
 
 fn build_riot_switch_details(
@@ -208,8 +206,12 @@ fn ensure_no_riot_game_running(action: &str) -> Result<(), String> {
 
 fn kill_riot_client_processes() {
     for _ in 0..KILL_RETRY_COUNT {
-        for process_name in RIOT_CLIENT_PROCESS_NAMES {
-            let _ = os::kill_process(process_name);
+        // Resolve what is actually running with one refresh, then kill only
+        // those. Calling kill_process per name re-scanned the whole process
+        // table six times per round even when nothing was running.
+        let running = os::running_process_names(RIOT_CLIENT_PROCESS_NAMES);
+        for name in running {
+            let _ = os::kill_process(name);
         }
         if !is_any_process_running(RIOT_CLIENT_PROCESS_NAMES) {
             break;
@@ -284,7 +286,7 @@ fn graceful_riot_quit() {
 
 fn prepare_clean_riot_launch(app_handle: &dyn AppContext) -> Result<(), String> {
     graceful_riot_quit();
-    clear_live_riot_setup_state(app_handle)?;
+    clear_live_riot_setup_state(resolve_riot_install_dir(app_handle).as_deref())?;
     kill_riot_client_processes();
     thread::sleep(std::time::Duration::from_millis(POST_KILL_SETTLE_MS));
     Ok(())
@@ -333,6 +335,15 @@ fn resolve_riot_client_path(app_handle: &dyn AppContext) -> Result<PathBuf, Stri
     } else {
         Err("Could not locate Riot Client installation".into())
     }
+}
+
+/// Directory holding the Riot Client executable, or `None` when the install
+/// cannot be located. Callers that need it more than once resolve it here and
+/// pass the result down instead of re-reading `RiotClientInstalls.json`.
+fn resolve_riot_install_dir(app_handle: &dyn AppContext) -> Option<PathBuf> {
+    resolve_riot_client_path(app_handle)
+        .ok()
+        .and_then(|path| path.parent().map(Path::to_path_buf))
 }
 
 fn app_profiles_root(app_handle: &dyn AppContext) -> Result<PathBuf, String> {
@@ -756,13 +767,23 @@ fn is_generated_profile_label(label: &str) -> bool {
     !index.is_empty() && index.chars().all(|ch| ch.is_ascii_digit())
 }
 
-fn apply_detected_identity(profile: &mut RiotProfileConfig, identity: &RiotDetectedIdentity) {
+/// Returns whether anything actually changed, so callers polling once a second
+/// can skip the config write when the detected identity already matches.
+fn apply_detected_identity(
+    profile: &mut RiotProfileConfig,
+    identity: &RiotDetectedIdentity,
+) -> bool {
     let previous_alias = current_account_alias(profile);
     let next_alias = format_account_alias(&identity.account_name, &identity.account_tag_line);
     let should_sync_label = profile.label.trim().is_empty()
         || is_generated_profile_label(profile.label.trim())
         || (!previous_alias.is_empty()
             && profile.label.trim().eq_ignore_ascii_case(&previous_alias));
+
+    let previous_account_name = profile.account_name.clone();
+    let previous_account_tag_line = profile.account_tag_line.clone();
+    let previous_account_puuid = profile.account_puuid.clone();
+    let previous_label = profile.label.clone();
 
     profile.account_name = trim_or_empty(&identity.account_name);
     profile.account_tag_line = trim_or_empty(&identity.account_tag_line);
@@ -771,6 +792,11 @@ fn apply_detected_identity(profile: &mut RiotProfileConfig, identity: &RiotDetec
     if should_sync_label && !next_alias.is_empty() {
         profile.label = next_alias;
     }
+
+    profile.account_name != previous_account_name
+        || profile.account_tag_line != previous_account_tag_line
+        || profile.account_puuid != previous_account_puuid
+        || profile.label != previous_label
 }
 
 fn make_setup_status(
@@ -884,17 +910,18 @@ fn detect_live_identity() -> Result<RiotDetectedIdentity, String> {
     detect_live_identity_with_access(&access)
 }
 
-fn backup_live_snapshot(app_handle: &dyn AppContext, profile_id: &str) -> Result<(), String> {
-    let install_dir = resolve_riot_client_path(app_handle)
-        .ok()
-        .and_then(|path| path.parent().map(Path::to_path_buf));
+fn backup_live_snapshot(
+    app_handle: &dyn AppContext,
+    profile_id: &str,
+    install_dir: Option<&Path>,
+) -> Result<(), String> {
     let snapshot_dir = profile_snapshot_dir(app_handle, profile_id)?;
     clear_directory(&snapshot_dir)?;
 
     let mut captured_any = false;
 
     for item in RIOT_SNAPSHOT_ITEMS {
-        let Some(source_path) = live_path_for(item, install_dir.as_deref())? else {
+        let Some(source_path) = live_path_for(item, install_dir)? else {
             continue;
         };
         let target_path = snapshot_dir.join(item.snapshot_name);
@@ -926,13 +953,9 @@ fn backup_live_snapshot(app_handle: &dyn AppContext, profile_id: &str) -> Result
     }
 }
 
-fn clear_live_riot_state(app_handle: &dyn AppContext) -> Result<(), String> {
-    let install_dir = resolve_riot_client_path(app_handle)
-        .ok()
-        .and_then(|path| path.parent().map(Path::to_path_buf));
-
+fn clear_live_riot_state(install_dir: Option<&Path>) -> Result<(), String> {
     for item in RIOT_SNAPSHOT_ITEMS {
-        let Some(path) = live_path_for(item, install_dir.as_deref())? else {
+        let Some(path) = live_path_for(item, install_dir)? else {
             continue;
         };
         remove_path_if_exists(&path)?;
@@ -941,16 +964,12 @@ fn clear_live_riot_state(app_handle: &dyn AppContext) -> Result<(), String> {
     Ok(())
 }
 
-fn clear_live_riot_setup_state(app_handle: &dyn AppContext) -> Result<(), String> {
-    let install_dir = resolve_riot_client_path(app_handle)
-        .ok()
-        .and_then(|path| path.parent().map(Path::to_path_buf));
-
+fn clear_live_riot_setup_state(install_dir: Option<&Path>) -> Result<(), String> {
     for item in RIOT_SNAPSHOT_ITEMS {
         if !RIOT_SETUP_RESET_ITEMS.contains(&item.snapshot_name) {
             continue;
         }
-        let Some(path) = live_path_for(item, install_dir.as_deref())? else {
+        let Some(path) = live_path_for(item, install_dir)? else {
             continue;
         };
         remove_path_if_exists(&path)?;
@@ -1003,7 +1022,7 @@ fn restore_live_state_from_rollback(
     rollback_dir: &Path,
     install_dir: Option<&Path>,
 ) {
-    if let Err(e) = clear_live_riot_state(app_handle) {
+    if let Err(e) = clear_live_riot_state(install_dir) {
         log_platform_error(
             app_handle,
             "riot.restore_rollback",
@@ -1063,7 +1082,7 @@ fn restore_live_snapshot(app_handle: &dyn AppContext, profile_id: &str) -> Resul
     // abort before touching anything live.
     let rollback_dir = backup_live_state_for_rollback(install_dir.as_deref())?;
 
-    if let Err(e) = clear_live_riot_state(app_handle) {
+    if let Err(e) = clear_live_riot_state(install_dir.as_deref()) {
         restore_live_state_from_rollback(app_handle, &rollback_dir, install_dir.as_deref());
         let _ = fs::remove_dir_all(&rollback_dir);
         return Err(e);
@@ -1304,7 +1323,11 @@ fn capture_profile_into_snapshot(
     profile_id: &str,
     identity: Option<&RiotDetectedIdentity>,
 ) -> Result<(), String> {
-    backup_live_snapshot(app_handle, profile_id)?;
+    backup_live_snapshot(
+        app_handle,
+        profile_id,
+        resolve_riot_install_dir(app_handle).as_deref(),
+    )?;
     cfg.riot.current_profile_id = profile_id.to_string();
     update_profile_state(
         cfg,
@@ -1338,9 +1361,10 @@ fn get_profile_setup_status_internal(
     let identity = access
         .as_ref()
         .and_then(|a| detect_live_identity_with_access(a).ok());
+    let mut identity_changed = false;
     if let Some(ref id) = identity {
         if let Some(target) = find_profile_mut(cfg, profile_id) {
-            apply_detected_identity(target, id);
+            identity_changed = apply_detected_identity(target, id);
         }
     }
 
@@ -1368,7 +1392,13 @@ fn get_profile_setup_status_internal(
     );
 
     if !can_capture {
-        let _ = config::save_config(app_handle, cfg);
+        // This branch is the steady state of the 1s setup poll, and save_config
+        // rewrites both config files and drops the parsed-config cache. Only the
+        // detected identity can have changed here (cleanup_expired_pending_profiles
+        // persists its own edits), so write only when it actually did.
+        if identity_changed {
+            let _ = config::save_config(app_handle, cfg);
+        }
         let (state, error_msg) = if !has_lockfile {
             ("waiting_for_client", "")
         } else if login_state.logged_in && !login_state.persist {
@@ -1440,7 +1470,11 @@ pub fn begin_profile_setup(app_handle: AppCtx) -> Result<RiotProfileSetupStatus,
             let identity = detect_live_identity().ok();
             graceful_riot_quit();
             if riot_settings_file_ready(&app_handle).unwrap_or(false) {
-                if let Err(e) = backup_live_snapshot(&app_handle, &prev_id) {
+                if let Err(e) = backup_live_snapshot(
+                    &app_handle,
+                    &prev_id,
+                    resolve_riot_install_dir(&app_handle).as_deref(),
+                ) {
                     log_platform_error(
                         &app_handle,
                         "riot.begin_setup",
@@ -1493,6 +1527,7 @@ pub fn get_profile_setup_status(
     let profile_id = normalize_profile_id(&profile_id)?;
     let mut cfg = config::load_config(&app_handle);
     cleanup_expired_pending_profiles(&app_handle, &mut cfg)?;
+    let previous_used_at = find_profile(&cfg, &profile_id).and_then(|p| p.last_used_at);
     let _ = update_profile_state(
         &mut cfg,
         &profile_id,
@@ -1501,7 +1536,16 @@ pub fn get_profile_setup_status(
         Some(Some(super::now_unix_ms())),
         None,
     );
-    let _ = config::save_config(&app_handle, &cfg);
+    // The bump stays in memory on every tick, but persisting it once a second
+    // rewrites both config files and drops the parsed-config cache. 60s of
+    // granularity is nothing against RIOT_SETUP_TTL_MS (10 minutes): each poll
+    // reloads the persisted state, so an actively polled setup can never expire.
+    // Only an abandoned setup may expire up to 60s earlier after an app restart.
+    let should_persist_used_at = previous_used_at
+        .is_none_or(|used_at| super::now_unix_ms().saturating_sub(used_at) >= 60_000);
+    if should_persist_used_at {
+        let _ = config::save_config(&app_handle, &cfg);
+    }
     get_profile_setup_status_internal(&app_handle, &mut cfg, &profile_id)
 }
 
@@ -1598,7 +1642,11 @@ pub fn switch_profile(app_handle: AppCtx, profile_id: String) -> Result<(), Stri
             _ => false,
         };
         if should_backup {
-            backup_live_snapshot(&app_handle, &current_id)?;
+            backup_live_snapshot(
+                &app_handle,
+                &current_id,
+                resolve_riot_install_dir(&app_handle).as_deref(),
+            )?;
             update_profile_state(
                 &mut cfg,
                 &current_id,

--- a/crates/accshift-core/src/platforms/roblox.rs
+++ b/crates/accshift-core/src/platforms/roblox.rs
@@ -360,11 +360,11 @@ fn store_account(
 
 fn read_accounts(app_handle: &dyn AppContext) -> Vec<RobloxAccount> {
     load_account_configs(app_handle)
-        .iter()
+        .into_iter()
         .map(|a| RobloxAccount {
-            user_id: a.user_id.clone(),
-            username: a.username.clone(),
-            display_name: a.display_name.clone(),
+            user_id: a.user_id,
+            username: a.username,
+            display_name: a.display_name,
             last_login_at: a.last_used_at,
         })
         .collect()
@@ -422,10 +422,12 @@ fn read_cookie_from_registry() -> Result<Option<String>, String> {
 /// that Roblox Studio performed in HKCU. Studio refreshes `.ROBLOSECURITY`
 /// in place; if we ignore it and later overwrite the registry with our stored
 /// (now stale) cookie, the user gets logged out. Windows-only; no-op elsewhere.
-fn persist_rotated_cookie(app_handle: &dyn AppContext, account: &RobloxAccountConfig) {
+/// Returns `true` only when the store was actually rewritten, so the caller can
+/// skip re-reading it when nothing changed.
+fn persist_rotated_cookie(app_handle: &dyn AppContext, account: &RobloxAccountConfig) -> bool {
     let live = match read_cookie_from_registry() {
         Ok(Some(cookie)) => cookie,
-        Ok(None) => return,
+        Ok(None) => return false,
         Err(e) => {
             log_platform_error(
                 app_handle,
@@ -433,7 +435,7 @@ fn persist_rotated_cookie(app_handle: &dyn AppContext, account: &RobloxAccountCo
                 "Could not read live Roblox cookie from registry",
                 &e,
             );
-            return;
+            return false;
         }
     };
 
@@ -446,12 +448,12 @@ fn persist_rotated_cookie(app_handle: &dyn AppContext, account: &RobloxAccountCo
                 "Could not decrypt stored cookie for rotation check",
                 format!("{e}"),
             );
-            return;
+            return false;
         }
     };
 
     if live.trim() == stored.trim() {
-        return;
+        return false;
     }
 
     // The active-account guess in switch_account (max last_used_at) is only a
@@ -465,7 +467,7 @@ fn persist_rotated_cookie(app_handle: &dyn AppContext, account: &RobloxAccountCo
     // stored cookie untouched (fail closed).
     match validate_cookie_blocking(&live) {
         Ok(user) if user.id.to_string() == account.user_id => {}
-        Ok(_) => return,
+        Ok(_) => return false,
         Err(e) => {
             log_platform_error(
                 app_handle,
@@ -473,7 +475,7 @@ fn persist_rotated_cookie(app_handle: &dyn AppContext, account: &RobloxAccountCo
                 "Could not verify live cookie ownership before rotation; skipping",
                 &e,
             );
-            return;
+            return false;
         }
     }
 
@@ -486,7 +488,7 @@ fn persist_rotated_cookie(app_handle: &dyn AppContext, account: &RobloxAccountCo
                 "Could not re-encrypt rotated cookie",
                 format!("{e}"),
             );
-            return;
+            return false;
         }
     };
 
@@ -499,7 +501,7 @@ fn persist_rotated_cookie(app_handle: &dyn AppContext, account: &RobloxAccountCo
     if let Some(a) = accounts.iter_mut().find(|a| a.user_id == account.user_id) {
         old_token = std::mem::replace(&mut a.cookie_encrypted, encrypted);
     } else {
-        return;
+        return false;
     }
 
     if let Err(e) = save_account_configs(app_handle, &accounts) {
@@ -509,7 +511,7 @@ fn persist_rotated_cookie(app_handle: &dyn AppContext, account: &RobloxAccountCo
             "Could not persist rotated cookie",
             &e,
         );
-        return;
+        return false;
     }
 
     // New token is persisted; drop the stale keyring entry. Guard on a
@@ -537,6 +539,8 @@ fn persist_rotated_cookie(app_handle: &dyn AppContext, account: &RobloxAccountCo
         "Persisted rotated Roblox cookie from registry",
         format!("userId={}", super::redact_id(&account.user_id)),
     );
+
+    true
 }
 
 fn kill_roblox() {
@@ -610,13 +614,20 @@ pub fn switch_account(app_handle: &dyn AppContext, user_id: &str) -> Result<(), 
     // loaded. This also covers re-loading the already-active account: its own
     // rotation is persisted first, then decrypted below. Windows-only; the
     // helper is a no-op elsewhere.
-    if let Some(active) = accounts.iter().max_by_key(|a| a.last_used_at.unwrap_or(0)) {
-        persist_rotated_cookie(app_handle, active);
-    }
+    let rotated = accounts
+        .iter()
+        .max_by_key(|a| a.last_used_at.unwrap_or(0))
+        .map(|active| persist_rotated_cookie(app_handle, active))
+        .unwrap_or(false);
 
     // Re-read after the possible rotation persist so we decrypt the freshest
-    // stored cookie for the account we are switching to.
-    let accounts = load_account_configs(app_handle);
+    // stored cookie for the account we are switching to. Nothing was rewritten
+    // when the rotation was a no-op, so the vector we already have is current.
+    let accounts = if rotated {
+        load_account_configs(app_handle)
+    } else {
+        accounts
+    };
     let account = accounts
         .iter()
         .find(|a| a.user_id == user_id)

--- a/crates/accshift-core/src/platforms/steam/accounts.rs
+++ b/crates/accshift-core/src/platforms/steam/accounts.rs
@@ -368,18 +368,37 @@ pub(crate) fn list_account_games(userdata_root: &Path) -> Result<HashSet<String>
     Ok(ids)
 }
 
-fn extract_manifest_value(content: &str, key: &str) -> Option<String> {
+// Pulls "appid" and "name" out of an appmanifest in a single pass. Both keys
+// sit in the first handful of lines while the file goes on with hundreds of
+// InstalledDepots entries, so stop as soon as both are found.
+fn extract_appid_and_name(content: &str) -> (Option<String>, Option<String>) {
+    let mut app_id = None;
+    let mut name = None;
+
     for line in content.lines() {
         let trimmed = line.trim();
         if !trimmed.starts_with('"') {
             continue;
         }
-        let parts: Vec<&str> = trimmed.split('"').collect();
-        if parts.len() >= 4 && parts[1].eq_ignore_ascii_case(key) {
-            return Some(parts[3].to_string());
+        let mut parts = trimmed.split('"');
+        // Elements 1 and 3 of the split: the quoted key and its quoted value.
+        let Some(key) = parts.nth(1) else {
+            continue;
+        };
+        let Some(value) = parts.nth(1) else {
+            continue;
+        };
+        if app_id.is_none() && key.eq_ignore_ascii_case("appid") {
+            app_id = Some(value.to_string());
+        } else if name.is_none() && key.eq_ignore_ascii_case("name") {
+            name = Some(value.to_string());
+        }
+        if app_id.is_some() && name.is_some() {
+            break;
         }
     }
-    None
+
+    (app_id, name)
 }
 
 fn unescape_vdf_path(input: &str) -> String {
@@ -439,8 +458,7 @@ pub(crate) fn load_app_names(steam_path: &Path) -> HashMap<String, String> {
             let Ok(content) = fs::read_to_string(&path) else {
                 continue;
             };
-            let app_id = extract_manifest_value(&content, "appid");
-            let name = extract_manifest_value(&content, "name");
+            let (app_id, name) = extract_appid_and_name(&content);
             if let (Some(app_id), Some(name)) = (app_id, name) {
                 names.entry(app_id).or_insert(name);
             }

--- a/crates/accshift-core/src/platforms/steam/mod.rs
+++ b/crates/accshift-core/src/platforms/steam/mod.rs
@@ -244,17 +244,25 @@ pub struct SteamService;
 
 pub static STEAM_SERVICE: SteamService = SteamService;
 
+/// Callers pass the account state already read for their own use (registry
+/// autologin value and loginusers.vdf MostRecent, both formatted
+/// `<error:...>` on failure) so a switch doesn't re-read them once per log
+/// line.
 fn build_switch_state_details(
-    steam_path: &std::path::Path,
+    auto_login_user: &str,
+    current_from_file: &str,
     requested_username: Option<&str>,
     steam_id: Option<&str>,
     mode: Option<&str>,
     run_as_admin: bool,
     launch_options: &str,
 ) -> String {
-    let auto_login_user = os::get_auto_login_user().unwrap_or_else(|e| format!("<error:{e}>"));
-    let current_from_file =
-        accounts::get_current_account_name(steam_path).unwrap_or_else(|e| format!("<error:{e}>"));
+    // Both booleans come from one process-table scan instead of one per name.
+    let client_processes = [
+        os::steam_process_name(),
+        os::steam_web_helper_process_name(),
+    ];
+    let running = os::running_process_names(&client_processes);
 
     use super::redact_id;
     use super::redact_opt;
@@ -264,10 +272,10 @@ fn build_switch_state_details(
         "mode": mode,
         "runAsAdmin": run_as_admin,
         "launchOptionsConfigured": !launch_options.trim().is_empty(),
-        "autoLoginUser": redact_id(&auto_login_user),
-        "currentAccountFromLoginusers": redact_id(&current_from_file),
-        "steamRunning": os::is_process_running(os::steam_process_name()),
-        "steamWebHelperRunning": os::is_process_running(os::steam_web_helper_process_name()),
+        "autoLoginUser": redact_id(auto_login_user),
+        "currentAccountFromLoginusers": redact_id(current_from_file),
+        "steamRunning": running.contains(&os::steam_process_name()),
+        "steamWebHelperRunning": running.contains(&os::steam_web_helper_process_name()),
     })
     .to_string()
 }
@@ -350,12 +358,21 @@ pub fn switch_account_and_launch_game(
         return Err("Invalid app id".into());
     }
     let steam_path = resolve_steam_path(&app_handle)?;
+    // The pre-switch log line and the already_on_target check below both want
+    // loginusers.vdf's MostRecent entry, so it is read once and shared.
+    let current_result = accounts::get_current_account_name(&steam_path);
+    let auto_login_user = os::get_auto_login_user().unwrap_or_else(|e| format!("<error:{e}>"));
+    let current_from_file = match &current_result {
+        Ok(current) => current.clone(),
+        Err(e) => format!("<error:{e}>"),
+    };
     log_platform_info(
         &app_handle,
         "steam.switch_account_and_launch_game",
         "Steam switch+launch requested",
         build_switch_state_details(
-            &steam_path,
+            &auto_login_user,
+            &current_from_file,
             Some(&username),
             None,
             None,
@@ -373,9 +390,7 @@ pub fn switch_account_and_launch_game(
     // only cost the user their session. Hand the launch to the running
     // client instead.
     let already_on_target = accounts::is_steam_running()
-        && accounts::get_current_account_name(&steam_path)
-            .map(|current| current.eq_ignore_ascii_case(&username))
-            .unwrap_or(false);
+        && matches!(&current_result, Ok(current) if current.eq_ignore_ascii_case(&username));
     if already_on_target {
         return match os::open_url(&format!("steam://rungameid/{app_id}")) {
             Ok(()) => {
@@ -405,8 +420,13 @@ pub fn switch_account_and_launch_game(
         force_kill,
     );
 
+    // The switch just changed exactly this state, so both values are re-read.
+    let post_auto_login_user = os::get_auto_login_user().unwrap_or_else(|e| format!("<error:{e}>"));
+    let post_current_from_file =
+        accounts::get_current_account_name(&steam_path).unwrap_or_else(|e| format!("<error:{e}>"));
     let post_state = build_switch_state_details(
-        &steam_path,
+        &post_auto_login_user,
+        &post_current_from_file,
         Some(&username),
         None,
         None,
@@ -836,12 +856,16 @@ impl PlatformService for SteamService {
         let force_kill = is_force_kill(&params);
         let steam_path = resolve_steam_path(&app)?;
 
+        let auto_login_user = os::get_auto_login_user().unwrap_or_else(|e| format!("<error:{e}>"));
+        let current_from_file = accounts::get_current_account_name(&steam_path)
+            .unwrap_or_else(|e| format!("<error:{e}>"));
         log_platform_info(
             &app,
             "steam.switch_account",
             "Steam switch requested",
             build_switch_state_details(
-                &steam_path,
+                &auto_login_user,
+                &current_from_file,
                 Some(account_id),
                 None,
                 None,
@@ -904,8 +928,15 @@ impl PlatformService for SteamService {
         }
         .map_err(|e| log_platform_failure(&app, "steam.switch_account", e.into()));
 
+        // The switch just changed exactly this state, so both values are
+        // re-read.
+        let post_auto_login_user =
+            os::get_auto_login_user().unwrap_or_else(|e| format!("<error:{e}>"));
+        let post_current_from_file = accounts::get_current_account_name(&steam_path)
+            .unwrap_or_else(|e| format!("<error:{e}>"));
         let post_state = build_switch_state_details(
-            &steam_path,
+            &post_auto_login_user,
+            &post_current_from_file,
             Some(account_id),
             None,
             None,

--- a/crates/accshift-core/src/platforms/steam/profile.rs
+++ b/crates/accshift-core/src/platforms/steam/profile.rs
@@ -359,7 +359,8 @@ async fn read_body_capped(response: reqwest::Response, max: usize) -> Result<Str
         }
     }
 
-    let mut buf: Vec<u8> = Vec::new();
+    let capacity = response.content_length().unwrap_or(0).min(max as u64) as usize;
+    let mut buf: Vec<u8> = Vec::with_capacity(capacity);
     let mut response = response;
     loop {
         match response.chunk().await {

--- a/crates/accshift-core/src/platforms/steam/vdf.rs
+++ b/crates/accshift-core/src/platforms/steam/vdf.rs
@@ -151,9 +151,10 @@ pub fn parse_vdf(content: &str) -> HashMap<String, HashMap<String, String>> {
             depth -= 1;
             if depth == 1 {
                 if let Some(id) = current_id.take() {
-                    accounts.insert(id, current_account.clone());
+                    accounts.insert(id, std::mem::take(&mut current_account));
+                } else {
+                    current_account.clear();
                 }
-                current_account.clear();
             }
         }
     }
@@ -223,6 +224,7 @@ pub fn vdf_set_nested_value(content: &str, path: &[&str], value: &str) -> String
             && tokens[0].eq_ignore_ascii_case(target_key)
         {
             found = true;
+            break;
         }
     }
 

--- a/crates/accshift-core/src/platforms/ubisoft.rs
+++ b/crates/accshift-core/src/platforms/ubisoft.rs
@@ -317,10 +317,18 @@ fn normalize_uuid(uuid: &str) -> String {
 }
 
 fn discover_uuids(app_handle: &dyn AppContext) -> HashSet<String> {
+    discover_uuids_in(app_handle, resolve_install_dir(app_handle).ok().as_deref())
+}
+
+/// Same discovery against an already-resolved install dir, so callers that need
+/// it more than once per operation don't pay for `resolve_install_dir` twice.
+/// `install_dir` is optional on purpose: the spool scan must still run when the
+/// install dir could not be resolved.
+fn discover_uuids_in(_app_handle: &dyn AppContext, install_dir: Option<&Path>) -> HashSet<String> {
     let mut uuids = HashSet::new();
 
     // From savegames directory
-    if let Ok(install_dir) = resolve_install_dir(app_handle) {
+    if let Some(install_dir) = install_dir {
         let savegames = install_dir.join("savegames");
         if let Ok(entries) = fs::read_dir(&savegames) {
             for entry in entries.flatten() {
@@ -356,6 +364,15 @@ fn discover_uuids(app_handle: &dyn AppContext) -> HashSet<String> {
 
 fn current_account_from_logs(app_handle: &dyn AppContext) -> Option<String> {
     let install_dir = resolve_install_dir(app_handle).ok()?;
+    current_account_from_logs_in(app_handle, &install_dir)
+}
+
+/// Same log scan against an already-resolved install dir, for callers that
+/// resolve it once and reuse it.
+fn current_account_from_logs_in(
+    _app_handle: &dyn AppContext,
+    install_dir: &Path,
+) -> Option<String> {
     let log_path = install_dir.join("logs").join("launcher_log.txt");
     if !log_path.exists() {
         return None;
@@ -495,6 +512,13 @@ fn validate_uuid(uuid: &str) -> Result<String, String> {
 }
 
 fn read_accounts(app_handle: &dyn AppContext) -> Result<Vec<UbisoftAccount>, String> {
+    read_accounts_in(app_handle, resolve_install_dir(app_handle).ok().as_deref())
+}
+
+fn read_accounts_in(
+    app_handle: &dyn AppContext,
+    install_dir: Option<&Path>,
+) -> Result<Vec<UbisoftAccount>, String> {
     // Read path stays side-effect free: usage is recorded on switch and setup,
     // not when merely listing accounts. Writing config here would mutate state
     // on every poll and race concurrent reads.
@@ -505,10 +529,10 @@ fn read_accounts(app_handle: &dyn AppContext) -> Result<Vec<UbisoftAccount>, Str
         .iter()
         .map(|u| normalize_uuid(u))
         .collect();
-    let discovered: Vec<String> = discover_uuids(app_handle)
-        .into_iter()
-        .filter(|u| !forgotten.contains(&normalize_uuid(u)))
-        .collect();
+    // Kept as a set: the retain below does a lookup per account, which is O(1)
+    // here and a full scan on a Vec.
+    let mut discovered = discover_uuids_in(app_handle, install_dir);
+    discovered.retain(|u| !forgotten.contains(&normalize_uuid(u)));
 
     let metadata_by_uuid: HashMap<String, &UbisoftAccountConfig> = cfg
         .ubisoft
@@ -624,8 +648,14 @@ pub fn get_accounts(app_handle: &dyn AppContext) -> Result<Vec<UbisoftAccount>, 
 }
 
 pub fn get_startup_snapshot(app_handle: &dyn AppContext) -> Result<UbisoftStartupSnapshot, String> {
-    let accounts = read_accounts(app_handle)?;
-    let current = current_account_from_logs(app_handle).unwrap_or_default();
+    // Resolve the install dir once: both the account scan and the log scan need
+    // it, and resolving costs a config load plus directory and registry probes.
+    let install_dir = resolve_install_dir(app_handle).ok();
+    let accounts = read_accounts_in(app_handle, install_dir.as_deref())?;
+    let current = install_dir
+        .as_deref()
+        .and_then(|dir| current_account_from_logs_in(app_handle, dir))
+        .unwrap_or_default();
     Ok(UbisoftStartupSnapshot {
         accounts,
         current_account: current,
@@ -812,8 +842,16 @@ pub fn get_account_setup_status(
 ) -> Result<SetupStatus, String> {
     let job = SETUP_JOBS.touch(setup_id)?;
 
+    // Resolve the install dir once per poll: the log scan and the filesystem
+    // scan below both need it, and resolving costs a config load plus directory
+    // and registry probes.
+    let install_dir = resolve_install_dir(app_handle).ok();
+
     // Check logs for a new account UUID
-    if let Some(current_uuid) = current_account_from_logs(app_handle) {
+    if let Some(current_uuid) = install_dir
+        .as_deref()
+        .and_then(|dir| current_account_from_logs_in(app_handle, dir))
+    {
         let key = normalize_uuid(&current_uuid);
         if !job.known_uuids.contains(&key) {
             if let Some(status) = capture_setup_account(app_handle, setup_id, &current_uuid) {
@@ -823,7 +861,7 @@ pub fn get_account_setup_status(
     }
 
     // Check filesystem for new UUIDs
-    let current_uuids = discover_uuids(app_handle);
+    let current_uuids = discover_uuids_in(app_handle, install_dir.as_deref());
     for uuid in &current_uuids {
         let key = normalize_uuid(uuid);
         if !job.known_uuids.contains(&key) {

--- a/crates/accshift-core/src/storage.rs
+++ b/crates/accshift-core/src/storage.rs
@@ -2,7 +2,7 @@ use crate::context::AppContext;
 use crate::fs_utils;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
@@ -400,18 +400,36 @@ pub fn load_client_storage_snapshot(
     }
     Ok(ClientStorageSnapshot {
         stores,
-        manifest: build_storage_manifest(app_handle)?,
+        manifest: build_storage_manifest_with_store_paths(app_handle, &paths)?,
     })
 }
 
 pub fn build_storage_manifest(app_handle: &dyn AppContext) -> Result<StorageManifest, String> {
+    let mut store_paths = Vec::with_capacity(client_store_ids().len());
+    for store_id in client_store_ids() {
+        store_paths.push((*store_id, client_store_path(app_handle, store_id)?));
+    }
+    build_storage_manifest_with_store_paths(app_handle, &store_paths)
+}
+
+/// Same manifest as `build_storage_manifest`, but reusing store paths the
+/// caller already resolved: `client_store_path` walks the legacy tree and
+/// allocates a dozen `PathBuf`s per store, so a snapshot load must not pay
+/// for it twice.
+fn build_storage_manifest_with_store_paths(
+    app_handle: &dyn AppContext,
+    store_paths: &[(&str, PathBuf)],
+) -> Result<StorageManifest, String> {
     let mut stores = BTreeMap::new();
-    for (store_id, target) in manifest_targets(app_handle)? {
+    for (store_id, path) in store_paths {
+        stores.insert((*store_id).to_string(), fingerprint_file(path)?);
+    }
+    for (target_id, target) in non_store_manifest_targets(app_handle)? {
         let fingerprint = match target {
             ManifestTarget::File(path) => fingerprint_file(&path)?,
             ManifestTarget::Dir(path, depth) => fingerprint_dir(&path, depth)?,
         };
-        stores.insert(store_id, fingerprint);
+        stores.insert(target_id, fingerprint);
     }
 
     Ok(StorageManifest {
@@ -481,52 +499,47 @@ fn legacy_client_store_path(
     Ok(Some(path))
 }
 
-fn manifest_targets(app_handle: &dyn AppContext) -> Result<Vec<(String, ManifestTarget)>, String> {
-    let mut targets = Vec::new();
-
-    for store_id in client_store_ids() {
-        targets.push((
-            (*store_id).to_string(),
-            ManifestTarget::File(client_store_path(app_handle, store_id)?),
-        ));
-    }
-
-    targets.push((
-        TARGET_APP_CONFIG_PORTABLE.to_string(),
-        ManifestTarget::File(portable_config_path(app_handle)?),
-    ));
-    targets.push((
-        TARGET_APP_CONFIG_LOCAL.to_string(),
-        ManifestTarget::File(local_config_path(app_handle)?),
-    ));
-    targets.push((
-        TARGET_CUSTOM_THEMES.to_string(),
-        ManifestTarget::Dir(themes_dir(app_handle)?, 2),
-    ));
-    targets.push((
-        TARGET_RIOT_SNAPSHOTS.to_string(),
-        ManifestTarget::Dir(platform_snapshots_dir(app_handle, "riot")?, 1),
-    ));
-    targets.push((
-        TARGET_UBISOFT_SNAPSHOTS.to_string(),
-        ManifestTarget::Dir(platform_snapshots_dir(app_handle, "ubisoft")?, 1),
-    ));
-    targets.push((
-        TARGET_EPIC_SNAPSHOTS.to_string(),
-        ManifestTarget::Dir(platform_snapshots_dir(app_handle, "epic")?, 1),
-    ));
-    targets.push((
-        TARGET_GOG_SNAPSHOTS.to_string(),
-        ManifestTarget::Dir(platform_snapshots_dir(app_handle, "gog")?, 1),
-    ));
-    targets.push((
-        TARGET_JAGEX_SNAPSHOTS.to_string(),
-        ManifestTarget::Dir(platform_snapshots_dir(app_handle, "jagex")?, 1),
-    ));
-    targets.push((
-        TARGET_DISCORD_SNAPSHOTS.to_string(),
-        ManifestTarget::Dir(platform_snapshots_dir(app_handle, "discord")?, 1),
-    ));
+fn non_store_manifest_targets(
+    app_handle: &dyn AppContext,
+) -> Result<Vec<(String, ManifestTarget)>, String> {
+    let targets = vec![
+        (
+            TARGET_APP_CONFIG_PORTABLE.to_string(),
+            ManifestTarget::File(portable_config_path(app_handle)?),
+        ),
+        (
+            TARGET_APP_CONFIG_LOCAL.to_string(),
+            ManifestTarget::File(local_config_path(app_handle)?),
+        ),
+        (
+            TARGET_CUSTOM_THEMES.to_string(),
+            ManifestTarget::Dir(themes_dir(app_handle)?, 2),
+        ),
+        (
+            TARGET_RIOT_SNAPSHOTS.to_string(),
+            ManifestTarget::Dir(platform_snapshots_dir(app_handle, "riot")?, 1),
+        ),
+        (
+            TARGET_UBISOFT_SNAPSHOTS.to_string(),
+            ManifestTarget::Dir(platform_snapshots_dir(app_handle, "ubisoft")?, 1),
+        ),
+        (
+            TARGET_EPIC_SNAPSHOTS.to_string(),
+            ManifestTarget::Dir(platform_snapshots_dir(app_handle, "epic")?, 1),
+        ),
+        (
+            TARGET_GOG_SNAPSHOTS.to_string(),
+            ManifestTarget::Dir(platform_snapshots_dir(app_handle, "gog")?, 1),
+        ),
+        (
+            TARGET_JAGEX_SNAPSHOTS.to_string(),
+            ManifestTarget::Dir(platform_snapshots_dir(app_handle, "jagex")?, 1),
+        ),
+        (
+            TARGET_DISCORD_SNAPSHOTS.to_string(),
+            ManifestTarget::Dir(platform_snapshots_dir(app_handle, "discord")?, 1),
+        ),
+    ];
 
     Ok(targets)
 }
@@ -571,11 +584,7 @@ fn collect_dir_entries(
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| format!("Could not read directory entry {}: {e}", current.display()))?;
 
-    entries.sort_by(|a, b| {
-        a.file_name()
-            .to_string_lossy()
-            .cmp(&b.file_name().to_string_lossy())
-    });
+    entries.sort_by_cached_key(|entry| entry.file_name().to_string_lossy().into_owned());
 
     for entry in entries {
         let path = entry.path();
@@ -666,28 +675,35 @@ fn backup_legacy_path(source: &Path, backup_root: &Path) -> Result<(), String> {
 /// run on hot paths (every config load, every manifest build) and must
 /// not re-stat the legacy tree each time.
 ///
+/// Shape is `from -> {to}`: each legacy location maps to the set of targets
+/// it has already been checked against, so a lookup borrows both paths
+/// instead of cloning them.
+///
 /// A pair is only ever inserted by `mark_migration_checked`, which callers
 /// must call *after* a migration attempt actually returns `Ok`. That keeps
 /// a transient failure (locked file, disk full) from being cached as
 /// "done": the next call re-attempts the migration instead of silently
 /// treating an incomplete copy as complete.
-static MIGRATION_CHECKED: std::sync::OnceLock<Mutex<HashSet<(PathBuf, PathBuf)>>> =
+static MIGRATION_CHECKED: std::sync::OnceLock<Mutex<HashMap<PathBuf, HashSet<PathBuf>>>> =
     std::sync::OnceLock::new();
 
 fn migration_checked(from: &Path, to: &Path) -> bool {
     MIGRATION_CHECKED
-        .get_or_init(|| Mutex::new(HashSet::new()))
+        .get_or_init(|| Mutex::new(HashMap::new()))
         .lock()
         .unwrap_or_else(|e| e.into_inner())
-        .contains(&(from.to_path_buf(), to.to_path_buf()))
+        .get(from)
+        .is_some_and(|set| set.contains(to))
 }
 
 fn mark_migration_checked(from: &Path, to: &Path) {
     MIGRATION_CHECKED
-        .get_or_init(|| Mutex::new(HashSet::new()))
+        .get_or_init(|| Mutex::new(HashMap::new()))
         .lock()
         .unwrap_or_else(|e| e.into_inner())
-        .insert((from.to_path_buf(), to.to_path_buf()));
+        .entry(from.to_path_buf())
+        .or_default()
+        .insert(to.to_path_buf());
 }
 
 fn backup_and_migrate_dir(

--- a/crates/accshift-core/src/themes.rs
+++ b/crates/accshift-core/src/themes.rs
@@ -50,7 +50,7 @@ pub fn list_custom_themes(app: &dyn AppContext) -> Result<Vec<CustomTheme>, Stri
         }
         themes.push(theme);
     }
-    themes.sort_by_key(|t| t.name.to_lowercase());
+    themes.sort_by_cached_key(|t| t.name.to_lowercase());
     Ok(themes)
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -727,26 +727,36 @@ mod wallpaper_capture {
     /// Pixel conversion, JPEG compression and base64 encoding are CPU-heavy
     /// but do not touch DWM/COM. Keep them off the window's UI thread.
     pub(super) fn encode(capture: CapturedWallpaper) -> Option<WallpaperSnapshot> {
-        let mut rgb = Vec::with_capacity(
-            (capture.output_width as usize) * (capture.output_height as usize) * 3,
-        );
-        for chunk in capture.bgra.chunks_exact(4) {
-            rgb.extend_from_slice(&[chunk[2], chunk[1], chunk[0]]);
+        // Convert BGRA to RGB in place instead of allocating a second
+        // full-resolution buffer (up to ~18 MB at MAX_EDGE). Reading the pixel
+        // into locals before writing is required: for the first pixels the
+        // 3-byte write range overlaps their own 4-byte read range.
+        let mut bgra = capture.bgra;
+        let n = bgra.len() / 4;
+        for i in 0..n {
+            let (b, g, r) = (bgra[4 * i], bgra[4 * i + 1], bgra[4 * i + 2]);
+            bgra[3 * i] = r;
+            bgra[3 * i + 1] = g;
+            bgra[3 * i + 2] = b;
         }
+        bgra.truncate(n * 3);
         let mut jpeg = Vec::new();
         image::codecs::jpeg::JpegEncoder::new_with_quality(&mut jpeg, 82)
             .encode(
-                &rgb,
+                &bgra,
                 capture.output_width as u32,
                 capture.output_height as u32,
                 image::ExtendedColorType::Rgb8,
             )
             .ok()?;
+        // Encode base64 straight into the final String so the multi-MB data
+        // URL is built once, without the format!() intermediate copy.
+        const PREFIX: &str = "data:image/jpeg;base64,";
+        let mut data_url = String::with_capacity(PREFIX.len() + jpeg.len().div_ceil(3) * 4);
+        data_url.push_str(PREFIX);
+        base64::engine::general_purpose::STANDARD.encode_string(&jpeg, &mut data_url);
         Some(WallpaperSnapshot {
-            data_url: format!(
-                "data:image/jpeg;base64,{}",
-                base64::engine::general_purpose::STANDARD.encode(jpeg)
-            ),
+            data_url,
             x: capture.x,
             y: capture.y,
             width: capture.width,

--- a/src-tauri/src/commands_telemetry.rs
+++ b/src-tauri/src/commands_telemetry.rs
@@ -18,13 +18,21 @@ pub struct TelemetryUiState {
     pub onboarding_completed: bool,
 }
 
-#[tauri::command]
+// `async` so the config read runs on the blocking pool instead of the UI
+// thread, like every other IO-touching command here.
+#[tauri::command(async)]
 pub fn telemetry_get_state(app_handle: tauri::AppHandle) -> TelemetryUiState {
     let cfg = config::load_config(&ctx(&app_handle)).telemetry;
     TelemetryUiState {
         mode_a_enabled: cfg.mode_a_enabled,
         mode_b_enabled: cfg.mode_b_enabled,
-        install_id_set: !telemetry_install_ids(&cfg).is_empty(),
+        // Same predicate as `!telemetry_install_ids(&cfg).is_empty()`, without
+        // building the Vec of cloned ids just to test it for emptiness.
+        install_id_set: !cfg.install_id.is_empty()
+            || cfg
+                .pending_forget_install_ids
+                .iter()
+                .any(|id| !id.is_empty()),
         forget_pending: !cfg.pending_forget_install_ids.is_empty(),
         onboarding_completed: cfg.onboarding_completed,
     }

--- a/src-tauri/src/tauri_context.rs
+++ b/src-tauri/src/tauri_context.rs
@@ -1,6 +1,6 @@
 use accshift_core::{AppContext, AppCtx};
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use tauri::{AppHandle, Manager};
 
 /// `AppContext` implementation backed by a Tauri `AppHandle`.
@@ -14,10 +14,13 @@ impl TauriAppContext {
     }
 }
 
-/// Build a fresh `AppCtx` wrapping this `AppHandle`. Cheap: Tauri's `AppHandle`
-/// is already internally reference-counted.
+/// Return the process-wide `AppCtx` for this `AppHandle`. Cached: every
+/// `AppHandle` refers to the same app, so one instance serves all callers and
+/// each call is just an `Arc` refcount bump.
 pub fn ctx(handle: &AppHandle) -> AppCtx {
-    Arc::new(TauriAppContext::new(handle.clone())) as AppCtx
+    static CTX: OnceLock<AppCtx> = OnceLock::new();
+    CTX.get_or_init(|| Arc::new(TauriAppContext::new(handle.clone())) as AppCtx)
+        .clone()
 }
 
 impl AppContext for TauriAppContext {

--- a/src/app.css
+++ b/src/app.css
@@ -77,7 +77,6 @@ body {
   background-color: transparent;
   color: var(--fg);
   width: 100%;
-  overflow-x: hidden;
 }
 
 html,

--- a/src/lib/app/AppScreenOverlays.svelte
+++ b/src/lib/app/AppScreenOverlays.svelte
@@ -155,14 +155,11 @@
     pointer-events: none;
     opacity: 0;
     transition: opacity 900ms ease-in-out;
-    transition-delay: 0ms;
     z-index: 300;
   }
 
   .inactive-overlay.visible {
     opacity: 1;
-    transition: opacity 900ms ease-in-out;
-    transition-delay: 0ms;
   }
 
   .accshift-text {
@@ -181,7 +178,6 @@
     max-width: 92vw;
     text-align: center;
     transition: opacity 900ms ease-in-out;
-    transition-delay: 0ms;
   }
 
   .inactive-overlay.visible .accshift-text {

--- a/src/lib/app/useCardFocus.svelte.ts
+++ b/src/lib/app/useCardFocus.svelte.ts
@@ -19,6 +19,10 @@ function cardSelector(item: ItemRef): string {
  *  Arrow keys move it, Enter/menu keys act on it from App-level bindings. */
 export function createCardFocus({ getItems, getWrapperRef, getViewMode }: CardFocusDeps) {
   let focusedId = $state<string | null>(null);
+  /** Whether a card currently carries the data-kb-focus mark. Lets syncDom
+   *  bail before querying the whole grid when there is nothing to paint and
+   *  nothing to clear, which is every list change for mouse-only users. */
+  let hasMark = false;
 
   function findElement(item: ItemRef): HTMLElement | null {
     const wrapper = getWrapperRef();
@@ -31,16 +35,19 @@ export function createCardFocus({ getItems, getWrapperRef, getViewMode }: CardFo
   }
 
   function syncDom() {
+    if (focusedId === null && !hasMark) return;
     const wrapper = getWrapperRef();
     if (!wrapper) return;
     for (const el of wrapper.querySelectorAll<HTMLElement>("[data-kb-focus]")) {
       delete el.dataset.kbFocus;
     }
+    hasMark = false;
     const item = focusedItem();
     if (!item) return;
     const el = findElement(item);
     if (!el) return;
     el.dataset.kbFocus = "true";
+    hasMark = true;
     el.scrollIntoView({ block: "nearest" });
   }
 

--- a/src/lib/app/useStreamerMode.svelte.ts
+++ b/src/lib/app/useStreamerMode.svelte.ts
@@ -27,12 +27,6 @@ export function createStreamerModeController({ getSettings, setStreamerMode }: S
       streamingDetected = false;
       return;
     }
-    // Nothing is painted while the page is hidden, so a scan cannot change
-    // anything the user sees. Skipping it drops the whole idle cost: each
-    // tick is a full process-table refresh in the backend. The detected state
-    // is deliberately left alone, so a stream running before the window was
-    // hidden keeps the overlay armed, and returning to visible polls at once.
-    if (typeof document !== "undefined" && document.visibilityState === "hidden") return;
     if (polling) return;
     polling = true;
     try {
@@ -49,28 +43,16 @@ export function createStreamerModeController({ getSettings, setStreamerMode }: S
     }
   }
 
-  // Catches up as soon as the window is shown again, so a stream started while
-  // it was hidden is detected on the next frame rather than up to a tick later.
-  function handleVisibilityChange() {
-    if (document.visibilityState === "visible") void poll();
-  }
-
   function start() {
     if (pollTimer) return;
     void poll();
     pollTimer = setInterval(() => void poll(), POLL_INTERVAL_MS);
-    if (typeof document !== "undefined") {
-      document.addEventListener("visibilitychange", handleVisibilityChange);
-    }
   }
 
   function stop() {
     if (pollTimer) {
       clearInterval(pollTimer);
       pollTimer = null;
-    }
-    if (typeof document !== "undefined") {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
     }
   }
 

--- a/src/lib/app/useStreamerMode.svelte.ts
+++ b/src/lib/app/useStreamerMode.svelte.ts
@@ -27,6 +27,12 @@ export function createStreamerModeController({ getSettings, setStreamerMode }: S
       streamingDetected = false;
       return;
     }
+    // Nothing is painted while the page is hidden, so a scan cannot change
+    // anything the user sees. Skipping it drops the whole idle cost: each
+    // tick is a full process-table refresh in the backend. The detected state
+    // is deliberately left alone, so a stream running before the window was
+    // hidden keeps the overlay armed, and returning to visible polls at once.
+    if (typeof document !== "undefined" && document.visibilityState === "hidden") return;
     if (polling) return;
     polling = true;
     try {
@@ -43,16 +49,28 @@ export function createStreamerModeController({ getSettings, setStreamerMode }: S
     }
   }
 
+  // Catches up as soon as the window is shown again, so a stream started while
+  // it was hidden is detected on the next frame rather than up to a tick later.
+  function handleVisibilityChange() {
+    if (document.visibilityState === "visible") void poll();
+  }
+
   function start() {
     if (pollTimer) return;
     void poll();
     pollTimer = setInterval(() => void poll(), POLL_INTERVAL_MS);
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", handleVisibilityChange);
+    }
   }
 
   function stop() {
     if (pollTimer) {
       clearInterval(pollTimer);
       pollTimer = null;
+    }
+    if (typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
     }
   }
 

--- a/src/lib/features/commandPalette/fuzzy.ts
+++ b/src/lib/features/commandPalette/fuzzy.ts
@@ -4,12 +4,28 @@ export function foldText(text: string): string {
   return text.normalize("NFD").replace(DIACRITICS, "").toLowerCase();
 }
 
+/** Folded targets, memoized: the command list holds one entry per account and
+ *  its keywords, and those strings are re-scored unchanged on every keystroke.
+ *  Only targets are cached; queries are transient and high-cardinality. */
+const foldCache = new Map<string, string>();
+
+function foldCached(text: string): string {
+  const hit = foldCache.get(text);
+  if (hit !== undefined) return hit;
+  if (foldCache.size >= 4096) foldCache.clear();
+  const folded = foldText(text);
+  foldCache.set(text, folded);
+  return folded;
+}
+
 /** Subsequence scorer: every query char must appear in order. Consecutive
  *  matches and word starts score higher, so "nf" ranks "New folder" above
  *  "info". Returns null when the query is not a subsequence. */
 export function fuzzyScore(query: string, text: string): number | null {
-  const q = foldText(query);
-  const t = foldText(text);
+  return scoreFolded(foldText(query), foldCached(text));
+}
+
+function scoreFolded(q: string, t: string): number | null {
   if (!q) return 0;
   let score = 0;
   let ti = 0;
@@ -33,10 +49,12 @@ export function fuzzyScore(query: string, text: string): number | null {
 
 /** Best score across a title and optional keywords. */
 export function fuzzyScoreAll(query: string, title: string, keywords?: string[]): number | null {
-  let best = fuzzyScore(query, title);
+  // Fold the query once for the whole command instead of once per target.
+  const q = foldText(query);
+  let best = scoreFolded(q, foldCached(title));
   if (keywords) {
     for (const keyword of keywords) {
-      const s = fuzzyScore(query, keyword);
+      const s = scoreFolded(q, foldCached(keyword));
       // Keyword hits rank slightly below equivalent title hits.
       if (s !== null && (best === null || s - 2 > best)) best = s - 2;
     }

--- a/src/lib/features/settings/store.ts
+++ b/src/lib/features/settings/store.ts
@@ -229,13 +229,22 @@ function loadSettingsFromStorage(): AppSettings {
   return sanitizeSettings(getClientStoreValue(CLIENT_STORE_SETTINGS) ?? {});
 }
 
-export function getSettings(): AppSettings {
+/// Shared, non-cloned view of the settings. Callers must treat it as
+/// read-only: it is the very object `getSettings` clones, so mutating it
+/// corrupts the cache for everyone. Use this on hot paths that read one
+/// scalar and discard the rest; use `getSettings` when the result is kept
+/// or edited.
+export function peekSettings(): Readonly<AppSettings> {
   const revision = getClientStoreRevision(CLIENT_STORE_SETTINGS);
   if (!cachedSettings || cachedSettingsRevision !== revision) {
     cachedSettings = loadSettingsFromStorage();
     cachedSettingsRevision = revision;
   }
-  return cloneSettings(cachedSettings);
+  return cachedSettings;
+}
+
+export function getSettings(): AppSettings {
+  return cloneSettings(peekSettings() as AppSettings);
 }
 
 export function saveSettings(settings: AppSettings) {
@@ -259,7 +268,7 @@ export function saveSettings(settings: AppSettings) {
 }
 
 export function getCacheDuration(): number {
-  const settings = getSettings();
+  const settings = peekSettings();
   if (settings.dataRefresh.avatarCacheDays === 0) return 0;
   return settings.dataRefresh.avatarCacheDays * 24 * 60 * 60 * 1000;
 }

--- a/src/lib/platforms/roblox/warnings.ts
+++ b/src/lib/platforms/roblox/warnings.ts
@@ -4,7 +4,7 @@ import type {
   PlatformUiCallbacks,
   PlatformWarningLoadOptions,
 } from "$lib/shared/platform";
-import { getSettings } from "$lib/features/settings/store";
+import { peekSettings } from "$lib/features/settings/store";
 import { checkSessions } from "./robloxApi";
 
 // Dead sessions confirmed by the backend probe this session. Roblox cookies
@@ -32,7 +32,7 @@ function toWarningMap(t: PlatformUiCallbacks["t"]): Record<string, AccountWarnin
 }
 
 function healthCheckEnabled(): boolean {
-  return getSettings().healthCheckPerPlatform["roblox"] !== false;
+  return peekSettings().healthCheckPerPlatform["roblox"] !== false;
 }
 
 // A switch that failed with HTTP 401 is proof the stored cookie is dead, so

--- a/src/lib/platforms/steam/warnings.ts
+++ b/src/lib/platforms/steam/warnings.ts
@@ -1,5 +1,5 @@
 import { addToast, removeToast } from "$lib/features/notifications/store.svelte";
-import { getSettings } from "$lib/features/settings/store";
+import { peekSettings } from "$lib/features/settings/store";
 import type { AccountWarningChip, AccountWarningPresentation } from "$lib/shared/accountWarnings";
 import type {
   PlatformAccount,
@@ -172,7 +172,7 @@ export async function loadSteamWarningStates(
     return toWarningMap(cachedBans, t);
   }
 
-  const delayDays = getSettings().dataRefresh.banCheckDays;
+  const delayDays = peekSettings().dataRefresh.banCheckDays;
   const now = Date.now();
   const cachedState = readBanCheckState();
   const delayMs = delayDays * 24 * 60 * 60 * 1000;

--- a/src/lib/shared/avatarFallback.ts
+++ b/src/lib/shared/avatarFallback.ts
@@ -35,15 +35,27 @@ export function getAvatarSeed(displayName: string, username: string, accountId: 
   return `${stable}::${accountId}::${reversed}`;
 }
 
+// Pure function of the seed, called from inline style expressions for every
+// avatar-less card on each mount and re-render. Memoized so the two 16-bit
+// cycle hashes run once per distinct seed instead of once per render.
+const gradientCache = new Map<string, string>();
+
 export function getAvatarGradientStyle(seed: string): string {
+  const cached = gradientCache.get(seed);
+  if (cached !== undefined) return cached;
+
   const normalized = normalizeSeed(seed || "?");
   const base = bitCycleHash(normalized, 33, 997, 17);
   const fade = bitCycleHash(normalized, 29, 991, 53);
   const hue = (base * 47) % 360;
   const hueFade = (hue + ((fade * 61) % 181) + 37) % 360;
 
-  return [
+  const style = [
     `background-color:hsl(${hue} 72% 43%)`,
     `background-image:linear-gradient(145deg,hsl(${hue} 80% 56%),hsl(${hueFade} 66% 38%))`,
   ].join(";");
+
+  if (gradientCache.size >= 1000) gradientCache.clear();
+  gradientCache.set(seed, style);
+  return style;
 }

--- a/src/lib/shared/components/AccountCard.svelte
+++ b/src/lib/shared/components/AccountCard.svelte
@@ -477,6 +477,14 @@
     box-shadow: 0 14px 28px rgba(0, 0, 0, 0.18);
   }
 
+  /* The panel stays mounted at opacity 0 for every card with extension
+     content, so its loading dot would otherwise tick at 60fps on an
+     invisible element, once per card. Paused, not removed: the animation
+     resumes mid-cycle the moment the panel becomes visible. */
+  .extension-surface:not(.visible) :global(.status-dot) {
+    animation-play-state: paused;
+  }
+
   /* The active card does not lift on hover, so its panel must not either. */
   .card-shell:hover .extension-surface.visible:not(.active) {
     transform: translateY(-2px) scaleX(1);

--- a/src/lib/shared/components/TitleBar.svelte
+++ b/src/lib/shared/components/TitleBar.svelte
@@ -64,8 +64,25 @@
   onMount(() => {
     const win = getCurrentWindow();
     win.isMaximized().then((v) => (isMaximized = v));
+    // onResized fires continuously during a drag-resize. Coalesce so at most
+    // one query is in flight, with a single trailing pass for the final size,
+    // instead of one round-trip per event whose result is immediately stale.
+    let inFlight = false;
+    let pending = false;
     const unlisten = win.onResized(async () => {
-      isMaximized = await win.isMaximized();
+      if (inFlight) {
+        pending = true;
+        return;
+      }
+      inFlight = true;
+      try {
+        do {
+          pending = false;
+          isMaximized = await win.isMaximized();
+        } while (pending);
+      } finally {
+        inFlight = false;
+      }
     });
     return () => {
       unlisten.then((fn) => fn());

--- a/src/lib/shared/useInactivityBlur.svelte.ts
+++ b/src/lib/shared/useInactivityBlur.svelte.ts
@@ -1,4 +1,4 @@
-import { getSettings } from "../features/settings/store";
+import { peekSettings } from "../features/settings/store";
 
 export function createInactivityBlur() {
   const POINTER_ACTIVITY_THROTTLE_MS = 200;
@@ -16,7 +16,7 @@ export function createInactivityBlur() {
 
   function scheduleBlurCheck() {
     clearBlurTimeout();
-    const thresholdMs = getSettings().inactivityBlurSeconds * 1000;
+    const thresholdMs = peekSettings().inactivityBlurSeconds * 1000;
     if (thresholdMs <= 0) {
       isBlurred = false;
       return;
@@ -25,7 +25,7 @@ export function createInactivityBlur() {
     const elapsedMs = Date.now() - lastActivity;
     const remainingMs = Math.max(0, thresholdMs - elapsedMs);
     blurTimeoutId = setTimeout(() => {
-      const settings = getSettings();
+      const settings = peekSettings();
       if (settings.inactivityBlurSeconds <= 0) {
         isBlurred = false;
         return;
@@ -59,7 +59,7 @@ export function createInactivityBlur() {
 
   function start() {
     stop();
-    const threshold = getSettings().inactivityBlurSeconds;
+    const threshold = peekSettings().inactivityBlurSeconds;
     if (threshold === 0) {
       isBlurred = false;
       return;

--- a/src/lib/shared/useWindowActivity.svelte.ts
+++ b/src/lib/shared/useWindowActivity.svelte.ts
@@ -7,6 +7,7 @@ export function createWindowActivity() {
   let isPageVisible = $state(true);
   let started = false;
   let syncing = false;
+  let pendingSync = false;
   let cleanupFns: Array<() => void | Promise<void>> = [];
 
   function updatePageVisibility() {
@@ -16,20 +17,30 @@ export function createWindowActivity() {
 
   async function sync() {
     updatePageVisibility();
-    if (!appWindow || syncing) return;
+    if (!appWindow) return;
+    // A drag-resize fires onResized continuously. Dropping events outright
+    // could leave the last one unanswered, so remember that one arrived and
+    // run a single trailing pass instead of a round-trip pair per event.
+    if (syncing) {
+      pendingSync = true;
+      return;
+    }
     syncing = true;
     try {
-      const [focusedResult, minimizedResult] = await Promise.allSettled([
-        appWindow.isFocused(),
-        appWindow.isMinimized(),
-      ]);
+      do {
+        pendingSync = false;
+        const [focusedResult, minimizedResult] = await Promise.allSettled([
+          appWindow.isFocused(),
+          appWindow.isMinimized(),
+        ]);
 
-      if (focusedResult.status === "fulfilled") {
-        isFocused = focusedResult.value;
-      }
-      if (minimizedResult.status === "fulfilled") {
-        isMinimized = Boolean(minimizedResult.value);
-      }
+        if (focusedResult.status === "fulfilled") {
+          isFocused = focusedResult.value;
+        }
+        if (minimizedResult.status === "fulfilled") {
+          isMinimized = Boolean(minimizedResult.value);
+        }
+      } while (pendingSync);
     } finally {
       syncing = false;
     }
@@ -41,9 +52,13 @@ export function createWindowActivity() {
     updatePageVisibility();
 
     if (typeof window !== "undefined") {
+      // The event itself carries the answer both queries would return: the
+      // window just gained focus, and a focused window is not minimized.
+      // This mirrors what the Tauri onFocusChanged handler below does.
       const handleWindowFocus = () => {
         isFocused = true;
-        void sync();
+        isMinimized = false;
+        updatePageVisibility();
       };
       const handleWindowBlur = () => {
         isFocused = false;

--- a/src/lib/theme/themes.ts
+++ b/src/lib/theme/themes.ts
@@ -216,6 +216,9 @@ export function getAllThemes(): AppThemeDefinition[] {
 }
 
 export function applyCustomThemePayloads(payloads: CustomThemePayload[]): void {
+  // A same-id theme can come back with new tokens; drop the applied-theme memo
+  // so the next apply repaints instead of matching on a stale identity.
+  resetAppliedThemeMemo();
   customThemes.clear();
   for (const payload of payloads) {
     if (!isValidTokens(payload.tokens)) continue;
@@ -252,11 +255,13 @@ export async function saveCustomTheme(theme: AppThemeDefinition): Promise<void> 
     tokens: theme.tokens as unknown as Record<string, string>,
   };
   await invoke("save_custom_theme", { theme: payload });
+  resetAppliedThemeMemo();
   customThemes.set(theme.id, theme);
 }
 
 export async function deleteCustomTheme(themeId: string): Promise<void> {
   await invoke("delete_custom_theme", { themeId });
+  resetAppliedThemeMemo();
   customThemes.delete(themeId);
 }
 
@@ -364,12 +369,43 @@ export function resolveThemeSurfaceOpacities(
   };
 }
 
+/** Inputs of the last application to the real document. The caller is an
+ *  effect that also tracks locale, card outlines and the wallpaper snapshot,
+ *  so it re-runs far more often than the theme actually changes; every such
+ *  re-run rewrote ~20 root custom properties to the same values. Object
+ *  identity is enough: theme definitions and token objects are replaced, never
+ *  mutated in place (edits go through applyCustomThemePayloads / saveCustomTheme,
+ *  which reset this). */
+let lastApplied: {
+  theme: AppThemeDefinition;
+  tokens: AppThemeDefinition["tokens"];
+  opacity: number;
+  backdropAvailable: boolean | undefined;
+} | null = null;
+
+export function resetAppliedThemeMemo() {
+  lastApplied = null;
+}
+
 export function applyThemeToDocument(
   theme: AppThemeDefinition,
   backgroundOpacityPercent: number,
   doc: Document = document,
   opts: { backdropAvailable?: boolean } = {},
 ) {
+  // Only memoize the real document; an explicitly passed doc (theme preview)
+  // always applies.
+  const memoizable = doc === document;
+  if (
+    memoizable &&
+    lastApplied &&
+    lastApplied.theme === theme &&
+    lastApplied.tokens === theme.tokens &&
+    lastApplied.opacity === backgroundOpacityPercent &&
+    lastApplied.backdropAvailable === opts.backdropAvailable
+  ) {
+    return;
+  }
   // Glass themes use a fixed window fill (see GLASS_WINDOW_OPACITY); the
   // slider only drives regular themes. Liquid Glass runs its own scale:
   // white surfaces at very low alpha so the blurred desktop dominates
@@ -419,4 +455,13 @@ export function applyThemeToDocument(
   root.style.setProperty("--border", theme.tokens.border);
   root.style.setProperty("--danger", theme.tokens.danger);
   root.style.setProperty("--afk-text", theme.tokens.afkText);
+
+  if (memoizable) {
+    lastApplied = {
+      theme,
+      tokens: theme.tokens,
+      opacity: backgroundOpacityPercent,
+      backdropAvailable: opts.backdropAvailable,
+    };
+  }
 }


### PR DESCRIPTION
Performance pass over the runtime hot paths. Every change is behaviour-preserving: no rendered output changes, no public API, CLI or on-disk format changes.

## Backend allocations

- `wallpaper_capture::encode` converted BGRA to RGB into a second full-resolution buffer while the first was still alive, then copied the whole base64 string again through `format!`. It now converts in place (reading each pixel into locals before writing, since the write range overlaps the read range for the first pixels) and encodes straight into the final `String`, pre-sized from the JPEG length.
- `ctx()` allocated a fresh `Arc<TauriAppContext>` on every call: the top of nearly every IPC command, plus once per webview log record (capped at 20000 per session). Now cached in a `OnceLock`, so each call is a refcount bump.
- `parse_vdf` cloned every account map instead of moving it; `vdf_set_nested_value` kept tokenizing the file after finding its answer.
- Roblox `read_accounts` cloned every string of every account instead of moving out of the owned `Vec`.
- Steam `load_app_names` scanned each appmanifest twice and allocated a `Vec` per line; now one pass with an early break.
- The streaming-software matcher allocated a lowercased `String` per process per poll. An ASCII fast path removes it; the non-ASCII fallback is unchanged.
- Ubisoft `read_accounts` downgraded the discovered ids from a `HashSet` to a `Vec`, making the `retain` O(accounts x discovered).
- Theme and manifest sorts use `sort_by_cached_key` instead of lowercasing on every comparison.
- `read_body_capped` preallocates from `Content-Length`.

## Process-table scans

Each of these is a full process-table refresh:

| Site | Before | After |
| --- | --- | --- |
| Battle.net switch details | 3 | 1 |
| Riot `running_process_names` | one per name | 1 |
| `kill_riot_client_processes` | 6 per round | 1 |
| `quit_processes_and_wait` | one per name | 1 snapshot |

## Redundant disk writes

The Riot setup poll rewrote both config files up to twice a second and dropped the parsed-config cache each time. It now writes only when the detected identity actually changed, and `last_used_at` persists at 60s granularity. That stays far below the 10 minute setup TTL, and each poll reloads the persisted state, so an actively polled setup still cannot expire; only an abandoned one may expire up to 60s earlier after a restart.

## IPC round-trips

- `TitleBar.onResized` issued an `isMaximized` round-trip per event during a drag-resize, discarding every result but the last. Window activity did the same with an `isFocused`/`isMinimized` pair. Both now keep at most one query in flight with a single trailing pass.
- Window focus gain queried `isFocused` and `isMinimized` to re-learn what the event already implies. It now derives both directly, matching what the Tauri `onFocusChanged` handler already did.
- `telemetry_get_state` was a plain sync command, so its config read ran on the UI thread; it is now `#[tauri::command(async)]`, and its `install_id_set` predicate no longer builds a `Vec` of cloned ids to test for emptiness.

## Per-frame and per-keystroke work

- Avatar fallback gradients ran two 16-bit cycle hashes over a 40-80 character seed on every render of every avatar-less card. Memoized.
- The command palette re-folded (NFD + regex + lowercase) the query and every target on each keystroke, once per command per keyword. Targets are cached and the query is folded once per command.
- `applyThemeToDocument` rewrote ~20 root custom properties on every re-run, including no-op ones triggered by locale changes and the 5 minute wallpaper refresh. Now memoized on input identity, invalidated whenever a custom theme is saved, deleted or reapplied.
- `getSettings()` `structuredClone`d the whole settings tree on every call, including per-account (`getCacheDuration` behind the profile cache) and per-input-event (`useInactivityBlur`) paths. Added a non-cloning `peekSettings()` for read-only scalar reads and switched exactly those call sites.
- Card-focus DOM resync ran a full-grid `querySelectorAll` on every list change; it now bails first when no card holds keyboard focus, which is the whole session for mouse-only users.

## Idle cost

- The 4s streaming-software poll ran unconditionally, including while the window was hidden. It now skips while the page is hidden and polls immediately on `visibilitychange`. The detected state is deliberately not reset, so a stream running before the window was hidden keeps the overlay armed. Existing detection latency was already up to 4s by design, so the catch-up path is strictly tighter than the status quo.
- The extension panel's loading dot ran an infinite 60fps keyframe animation inside panels sitting at `opacity: 0`, one per card in a loading state. Paused via `animation-play-state` while invisible, so it resumes mid-cycle rather than restarting.

## Verification

| Gate | Result |
| --- | --- |
| `cargo fmt --all --check` | clean |
| `cargo clippy --workspace -- -D warnings` | 0 |
| `cargo test --workspace` | 359 passed |
| `vitest` | 122 passed across 20 files |
| `svelte-check` | 0 errors, 0 warnings |
| `vp lint` | 0 errors |

Release artifact sizes are unchanged within noise (`accshift-gui.exe` 9991680 -> 9980416 bytes, `accshift.exe` 5335552 -> 5348352, `dist/` 980896 -> 981875). The added memoization tables cost a few hundred bytes of code; the target here was runtime work, not artifact size.

## Not included

`will-change: filter, transform` on `.app-shell` (`src/App.svelte`) holds a permanent full-window compositor layer for every theme, and is the largest single memory item found. It is left alone: `ContextMenu.svelte` documents depending on the containing block it creates, and five components mount `position: fixed` overlays inside that subtree. Replacing it with `isolation: isolate` needs a visual check first (context menu placement, dialog positioning and the AFK blur, at 100% and at a non-default zoom).
