### PR TITLE
feat(steam): ask the CS2 bridge only for the local accounts

### DIFF
--- a/crates/accshift-core/src/platforms/steam/cs2_bridge.rs
+++ b/crates/accshift-core/src/platforms/steam/cs2_bridge.rs
@@ -1,9 +1,14 @@
 //! Bridge vers un gestionnaire de comptes CS2 externe qui expose, par
 //! SteamID64, le niveau, l'XP dans le niveau (0..5000) et l'etat de la caisse
 //! hebdomadaire. L'utilisateur configure l'URL complete de l'endpoint (lien
-//! magique read-only ou endpoint maison) ; accshift la GET telle quelle, avec
-//! un Bearer optionnel pour les implementations qui en veulent un. Le contrat
-//! JSON est documente dans le wiki, n'importe quel serveur peut le servir.
+//! magique read-only ou endpoint maison), avec un Bearer optionnel pour les
+//! implementations qui en veulent un. Le contrat JSON est documente dans le
+//! wiki, n'importe quel serveur peut le servir.
+//!
+//! accshift n'interroge jamais la base entiere : il envoie les SteamID64 de
+//! SES comptes locaux et ne recoit que ces lignes-la (POST {url}/accounts, ou
+//! GET {url}?ids=... pour les serveurs sans POST). Les comptes inconnus de la
+//! source sont simplement absents de la reponse.
 
 use crate::config;
 use crate::os;
@@ -13,6 +18,8 @@ use serde::{Deserialize, Serialize};
 
 /// Reponse plafond : la source gere ~500 comptes, 1 MB est deja tres large.
 const MAX_RESPONSE_BYTES: usize = 1024 * 1024;
+/// Le serveur de reference borne une demande a 100 ids ; au-dela on decoupe.
+const MAX_IDS_PER_REQUEST: usize = 100;
 /// Le serveur de reference attend jusqu'a 20 s qu'un check GC se termine.
 /// Cette limite par requete remplace le timeout global de 10 s du client.
 const CHECK_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
@@ -69,6 +76,13 @@ struct BridgeResponse {
 #[serde(rename_all = "camelCase")]
 struct CheckRequest<'a> {
     steam_id: &'a str,
+}
+
+/// Corps du POST /accounts : les SteamID64 dont on veut l'etat.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AccountsRequest<'a> {
+    steam_ids: &'a [String],
 }
 
 /// Reponse du POST /check : la ligne fraiche du compte demande.
@@ -134,6 +148,18 @@ fn normalize_url(raw: &str) -> Result<String, String> {
     Ok(trimmed.to_string())
 }
 
+/// SteamID64 des comptes presents sur cette machine. Steam introuvable ou
+/// `loginusers.vdf` illisible : liste vide, le bridge ne demande alors rien
+/// (et le bouton "tester" se contente de joindre le serveur).
+fn local_steam_ids(app_handle: &dyn AppContext) -> Vec<String> {
+    let Ok(steam_path) = super::resolve_steam_path(app_handle) else {
+        return vec![];
+    };
+    super::accounts::get_accounts(&steam_path)
+        .map(|accounts| accounts.into_iter().map(|a| a.steam_id).collect())
+        .unwrap_or_default()
+}
+
 pub async fn fetch_accounts(
     app_handle: &dyn AppContext,
     client: &reqwest::Client,
@@ -142,7 +168,12 @@ pub async fn fetch_accounts(
     if !cfg.enabled {
         return Ok(vec![]);
     }
-    fetch_from(client, &cfg.url, &cfg.token_encrypted).await
+    let steam_ids = local_steam_ids(app_handle);
+    if steam_ids.is_empty() {
+        // Aucun compte local a afficher : rien a demander au bridge.
+        return Ok(vec![]);
+    }
+    fetch_from(client, &cfg.url, &cfg.token_encrypted, &steam_ids).await
 }
 
 /// Fetch sans condition d'activation : le bouton "tester" des settings doit
@@ -152,8 +183,9 @@ pub async fn test_connection(
     client: &reqwest::Client,
 ) -> Cs2BridgeTestResult {
     let cfg = config::load_config(app_handle).steam.cs2_bridge;
+    let steam_ids = local_steam_ids(app_handle);
     let started = std::time::Instant::now();
-    let outcome = fetch_from(client, &cfg.url, &cfg.token_encrypted).await;
+    let outcome = fetch_from(client, &cfg.url, &cfg.token_encrypted, &steam_ids).await;
     let latency_ms = started.elapsed().as_millis() as u64;
     match outcome {
         Ok(accounts) => Cs2BridgeTestResult {
@@ -171,10 +203,13 @@ pub async fn test_connection(
     }
 }
 
+/// Demande l'etat des comptes fournis, par lots de `MAX_IDS_PER_REQUEST`. Une
+/// liste vide fait quand meme un aller-retour : c'est le test de connexion.
 async fn fetch_from(
     client: &reqwest::Client,
     raw_url: &str,
     token_encrypted: &str,
+    steam_ids: &[String],
 ) -> Result<Vec<Cs2BridgeAccount>, String> {
     let url = normalize_url(raw_url)?;
     if url.is_empty() {
@@ -182,7 +217,35 @@ async fn fetch_from(
     }
     let token = decrypt_token(token_encrypted)?;
 
-    let mut request = client.get(url);
+    let wanted: std::collections::HashSet<&str> = steam_ids.iter().map(String::as_str).collect();
+    let mut accounts = Vec::new();
+    let chunks: Vec<&[String]> = if steam_ids.is_empty() {
+        vec![&[]]
+    } else {
+        steam_ids.chunks(MAX_IDS_PER_REQUEST).collect()
+    };
+    for chunk in chunks {
+        for account in fetch_chunk(client, raw_url, &token, chunk).await? {
+            // Un serveur qui ignorerait le filtre renverrait des comptes qui ne
+            // nous appartiennent pas : on ne garde que ce qu'on a demande.
+            if wanted.is_empty() || wanted.contains(account.steam_id.as_str()) {
+                accounts.push(account);
+            }
+        }
+    }
+    Ok(accounts)
+}
+
+/// POST {url}/accounts avec les ids ; repli sur GET {url}?ids=... quand le
+/// serveur ne connait pas la route (implementations tierces plus anciennes).
+async fn fetch_chunk(
+    client: &reqwest::Client,
+    raw_url: &str,
+    token: &str,
+    steam_ids: &[String],
+) -> Result<Vec<Cs2BridgeAccount>, String> {
+    let endpoint = sub_endpoint(raw_url, "accounts")?;
+    let mut request = client.post(endpoint).json(&AccountsRequest { steam_ids });
     if !token.is_empty() {
         request = request.bearer_auth(token);
     }
@@ -191,6 +254,43 @@ async fn fetch_from(
         .await
         .map_err(|e| format!("Bridge request failed: {}", e))?;
 
+    let status = response.status();
+    if matches!(
+        status,
+        reqwest::StatusCode::NOT_FOUND
+            | reqwest::StatusCode::METHOD_NOT_ALLOWED
+            | reqwest::StatusCode::NOT_IMPLEMENTED
+    ) {
+        if steam_ids.is_empty() {
+            // Rien a demander et pas de route POST : le serveur repond, c'est
+            // tout ce que le test avait besoin de savoir.
+            return Ok(vec![]);
+        }
+        return fetch_filtered_get(client, raw_url, token, steam_ids).await;
+    }
+    if !status.is_success() {
+        return Err(format!("Bridge returned {}", status));
+    }
+    let parsed: BridgeResponse =
+        read_limited_json(response, "Failed to parse bridge response").await?;
+    Ok(parsed.accounts)
+}
+
+async fn fetch_filtered_get(
+    client: &reqwest::Client,
+    raw_url: &str,
+    token: &str,
+    steam_ids: &[String],
+) -> Result<Vec<Cs2BridgeAccount>, String> {
+    let endpoint = ids_endpoint(raw_url, &steam_ids.join(","))?;
+    let mut request = client.get(endpoint);
+    if !token.is_empty() {
+        request = request.bearer_auth(token);
+    }
+    let response = request
+        .send()
+        .await
+        .map_err(|e| format!("Bridge request failed: {}", e))?;
     let status = response.status();
     if !status.is_success() {
         return Err(format!("Bridge returned {}", status));
@@ -229,7 +329,10 @@ async fn read_limited_json<T: DeserializeOwned>(
     serde_json::from_slice(&body).map_err(|e| format!("{parse_context}: {e}"))
 }
 
-fn check_endpoint(raw_url: &str) -> Result<reqwest::Url, String> {
+/// Ajoute un segment de chemin a l'URL configuree en gardant sa query : le
+/// lien magique porte la cle dans le chemin, `{url}/accounts` et `{url}/check`
+/// restent donc sous la meme cle.
+fn sub_endpoint(raw_url: &str, segment: &str) -> Result<reqwest::Url, String> {
     let normalized = normalize_url(raw_url)?;
     if normalized.is_empty() {
         return Err("Bridge URL is not configured".to_string());
@@ -241,12 +344,12 @@ fn check_endpoint(raw_url: &str) -> Result<reqwest::Url, String> {
             .path_segments_mut()
             .map_err(|_| "Bridge URL cannot be used as a base URL".to_string())?;
         segments.pop_if_empty();
-        segments.push("check");
+        segments.push(segment);
     }
     Ok(endpoint)
 }
 
-fn account_fallback_endpoint(raw_url: &str, steam_id: &str) -> Result<reqwest::Url, String> {
+fn ids_endpoint(raw_url: &str, ids: &str) -> Result<reqwest::Url, String> {
     let normalized = normalize_url(raw_url)?;
     if normalized.is_empty() {
         return Err("Bridge URL is not configured".to_string());
@@ -262,33 +365,22 @@ fn account_fallback_endpoint(raw_url: &str, steam_id: &str) -> Result<reqwest::U
     endpoint
         .query_pairs_mut()
         .extend_pairs(existing)
-        .append_pair("ids", steam_id);
+        .append_pair("ids", ids);
     Ok(endpoint)
 }
 
+/// Repli du check quand le serveur n'a pas de route /check : on relit juste ce
+/// compte-la par la commande de lecture.
 async fn fetch_fallback_account(
     client: &reqwest::Client,
     raw_url: &str,
     token: &str,
     steam_id: &str,
 ) -> Result<Cs2BridgeAccount, String> {
-    let endpoint = account_fallback_endpoint(raw_url, steam_id)?;
-    let mut request = client.get(endpoint);
-    if !token.is_empty() {
-        request = request.bearer_auth(token);
-    }
-    let response = request
-        .send()
+    let ids = [steam_id.to_string()];
+    fetch_chunk(client, raw_url, token, &ids)
         .await
-        .map_err(|e| format!("Bridge fallback request failed: {e}"))?;
-    let status = response.status();
-    if !status.is_success() {
-        return Err(format!("Bridge fallback returned {status}"));
-    }
-    let parsed: BridgeResponse =
-        read_limited_json(response, "Failed to parse bridge fallback response").await?;
-    parsed
-        .accounts
+        .map_err(|e| format!("Bridge fallback failed: {e}"))?
         .into_iter()
         .find(|account| account.steam_id == steam_id)
         .ok_or_else(|| "Bridge fallback did not return the requested account".to_string())
@@ -319,7 +411,7 @@ async fn check_from(
     token_encrypted: &str,
     steam_id: &str,
 ) -> Result<Cs2BridgeAccount, String> {
-    let endpoint = check_endpoint(raw_url)?;
+    let endpoint = sub_endpoint(raw_url, "check")?;
     let token = decrypt_token(token_encrypted)?;
 
     let mut request = client
@@ -357,9 +449,7 @@ async fn check_from(
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        account_fallback_endpoint, check_endpoint, check_from, fetch_from, MAX_RESPONSE_BYTES,
-    };
+    use super::{check_from, fetch_from, ids_endpoint, sub_endpoint, MAX_RESPONSE_BYTES};
     use std::io::{Read, Write};
     use std::net::{TcpListener, TcpStream};
     use std::sync::mpsc;
@@ -447,14 +537,21 @@ mod tests {
 
     #[test]
     fn appends_check_path_without_losing_query_parameters() {
-        let endpoint = check_endpoint("https://example.test/api/bridge/key/?secret=a%20b").unwrap();
+        let endpoint =
+            sub_endpoint("https://example.test/api/bridge/key/?secret=a%20b", "check").unwrap();
         assert_eq!(endpoint.path(), "/api/bridge/key/check");
         assert_eq!(endpoint.query(), Some("secret=a%20b"));
     }
 
     #[test]
+    fn appends_accounts_path_under_the_configured_link() {
+        let endpoint = sub_endpoint("https://example.test/api/bridge/key", "accounts").unwrap();
+        assert_eq!(endpoint.path(), "/api/bridge/key/accounts");
+    }
+
+    #[test]
     fn fallback_endpoint_replaces_an_existing_ids_filter() {
-        let endpoint = account_fallback_endpoint(
+        let endpoint = ids_endpoint(
             "https://example.test/api/bridge?secret=x&ids=old",
             "76561198000000001",
         )
@@ -470,7 +567,7 @@ mod tests {
     }
 
     #[test]
-    fn falls_back_to_filtered_get_when_check_route_is_missing() {
+    fn falls_back_to_the_read_command_when_check_route_is_missing() {
         let steam_id = "76561198000000001";
         let fallback_body =
             format!(r#"{{"accounts":[{{"steamId":"{steam_id}","level":12,"xp":345}}]}}"#);
@@ -483,12 +580,84 @@ mod tests {
         let account = crate::runtime::block_on(check_from(&client(), &url, "", steam_id)).unwrap();
         assert_eq!(account.steam_id, steam_id);
 
+        let check = requests.recv_timeout(Duration::from_secs(2)).unwrap();
+        let read = requests.recv_timeout(Duration::from_secs(2)).unwrap();
+        server.join().unwrap();
+        assert!(check.starts_with("POST /api/bridge/key/check?secret=value HTTP/1.1"));
+        assert!(check.contains(&format!(r#""steamId":"{steam_id}""#)));
+        assert!(read.starts_with("POST /api/bridge/key/accounts?secret=value HTTP/1.1"));
+        assert!(read.contains(&format!(r#""steamIds":["{steam_id}"]"#)));
+    }
+
+    #[test]
+    fn asks_only_for_the_local_accounts_and_drops_anything_else() {
+        let mine = "76561198000000001".to_string();
+        let body = format!(
+            r#"{{"accounts":[{{"steamId":"{mine}","level":7,"xp":10}},{{"steamId":"76561198000000009","level":40,"xp":20}}]}}"#
+        );
+        let (base, requests, server) = serve_responses(vec![response("200 OK", &body)]);
+
+        let accounts = crate::runtime::block_on(fetch_from(
+            &client(),
+            &format!("{base}/api/bridge/key"),
+            "",
+            std::slice::from_ref(&mine),
+        ))
+        .unwrap();
+
+        let request = requests.recv_timeout(Duration::from_secs(2)).unwrap();
+        server.join().unwrap();
+        assert!(request.starts_with("POST /api/bridge/key/accounts HTTP/1.1"));
+        assert!(request.contains(&format!(r#""steamIds":["{mine}"]"#)));
+        // Le compte d'un tiers renvoye en trop ne doit jamais entrer en cache.
+        assert_eq!(accounts.len(), 1);
+        assert_eq!(accounts[0].steam_id, mine);
+    }
+
+    #[test]
+    fn splits_the_request_when_there_are_more_ids_than_the_server_accepts() {
+        let ids: Vec<String> = (0..super::MAX_IDS_PER_REQUEST + 5)
+            .map(|i| format!("7656119800000{i:04}"))
+            .collect();
+        let (base, requests, server) = serve_responses(vec![
+            response("200 OK", r#"{"accounts":[]}"#),
+            response("200 OK", r#"{"accounts":[]}"#),
+        ]);
+
+        crate::runtime::block_on(fetch_from(&client(), &format!("{base}/bridge"), "", &ids))
+            .unwrap();
+
+        let first = requests.recv_timeout(Duration::from_secs(2)).unwrap();
+        let second = requests.recv_timeout(Duration::from_secs(2)).unwrap();
+        server.join().unwrap();
+        assert!(first.contains(&ids[super::MAX_IDS_PER_REQUEST - 1]));
+        assert!(!first.contains(&ids[super::MAX_IDS_PER_REQUEST]));
+        assert!(second.contains(&ids[super::MAX_IDS_PER_REQUEST]));
+    }
+
+    #[test]
+    fn falls_back_to_a_filtered_get_when_the_accounts_route_is_missing() {
+        let steam_id = "76561198000000001".to_string();
+        let body = format!(r#"{{"accounts":[{{"steamId":"{steam_id}","level":3,"xp":9}}]}}"#);
+        let (base, requests, server) = serve_responses(vec![
+            response("404 Not Found", r#"{"error":"Not found"}"#),
+            response("200 OK", &body),
+        ]);
+
+        let accounts = crate::runtime::block_on(fetch_from(
+            &client(),
+            &format!("{base}/api/bridge/key"),
+            "",
+            std::slice::from_ref(&steam_id),
+        ))
+        .unwrap();
+        assert_eq!(accounts.len(), 1);
+
         let post = requests.recv_timeout(Duration::from_secs(2)).unwrap();
         let get = requests.recv_timeout(Duration::from_secs(2)).unwrap();
         server.join().unwrap();
-        assert!(post.starts_with("POST /api/bridge/key/check?secret=value HTTP/1.1"));
-        assert!(post.contains(&format!(r#""steamId":"{steam_id}""#)));
-        assert!(get.starts_with("GET /api/bridge/key?secret=value&ids=76561198000000001 HTTP/1.1"));
+        assert!(post.starts_with("POST /api/bridge/key/accounts HTTP/1.1"));
+        assert!(get.starts_with(&format!("GET /api/bridge/key?ids={steam_id} HTTP/1.1")));
     }
 
     #[test]
@@ -509,7 +678,7 @@ mod tests {
     #[test]
     fn rejects_an_oversized_chunked_fetch_response() {
         let (base, _, server) = serve_responses(vec![oversized_chunked_response()]);
-        let error = crate::runtime::block_on(fetch_from(&client(), &base, "")).unwrap_err();
+        let error = crate::runtime::block_on(fetch_from(&client(), &base, "", &[])).unwrap_err();
         server.join().unwrap();
         assert_eq!(error, "Bridge response too large");
     }

--- a/crates/accshift-core/src/platforms/steam/cs2_bridge.rs
+++ b/crates/accshift-core/src/platforms/steam/cs2_bridge.rs
@@ -18,8 +18,8 @@ use serde::{Deserialize, Serialize};
 
 /// Reponse plafond : la source gere ~500 comptes, 1 MB est deja tres large.
 const MAX_RESPONSE_BYTES: usize = 1024 * 1024;
-/// Le serveur de reference borne une demande a 100 ids ; au-dela on decoupe.
-const MAX_IDS_PER_REQUEST: usize = 100;
+/// Le serveur de reference borne une demande a 300 ids ; au-dela on decoupe.
+const MAX_IDS_PER_REQUEST: usize = 300;
 /// Le serveur de reference attend jusqu'a 20 s qu'un check GC se termine.
 /// Cette limite par requete remplace le timeout global de 10 s du client.
 const CHECK_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);


### PR DESCRIPTION
The CS2 bridge used to `GET` the configured URL bare, so a server holding
several people's accounts answered with all of them. accshift now sends the
SteamID64 it actually displays and keeps only the rows it asked for.

- `POST {url}/accounts` carries the ids in the body, in chunks of 300, and
  falls back to `GET {url}?ids=...` when a server answers 404, 405 or 501.
- The single-account check falls back to that same read command instead of its
  own filtered `GET`.
- Rows for accounts that were not requested are dropped on arrival.

The ids are read from `loginusers.vdf` in the core crate, so the Tauri command
signatures, the front-end store and the configured link are unchanged. No local
Steam account means no request at all; the settings Test button still reaches
the server with an empty list.

Wiki draft updated with the new contract. Servers that only implement the old
bare `GET` keep working through the fallback.
