### PR TITLE
fix(telemetry): count Steam accounts in accounts_snapshot

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -51,7 +51,7 @@ Nine events, and that is the complete list.
 | `streamer_mode_activated` | Streamer mode auto-enabled       | none                                       |
 | `deep_link_used`          | An `accshift://` link was opened | none                                       |
 | `session_ended`           | You closed the window            | `duration_ms`                              |
-| `accounts_snapshot`       | Daily, enhanced mode only        | `platform`, how many accounts on it        |
+| `accounts_snapshot`       | Each app start, enhanced only    | `platform`, how many accounts on it        |
 
 Every event also carries three common fields: the app version, the OS version,
 and your locale (for example `fr_FR`). The server adds one more, the country
@@ -63,6 +63,11 @@ you typed.
 `accounts_snapshot` is the only event that counts anything about your library,
 and it counts only how many accounts exist per platform. It is sent in enhanced
 mode only: the app drops it before upload in anonymous mode.
+
+Every release up to and including 1.0.2 skipped Steam in this event, because the
+list it was built from only covered platforms whose accounts live in the config
+file. Snapshots recorded by those releases say nothing about Steam, in either
+direction.
 
 This table is checked against the code on every release. Where this page and the
 code disagree, the code is right and the page is a bug worth reporting.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -187,10 +187,27 @@ pub fn finish_boot(
 /// v1.0 used `battle_net` (config field name); dashboards reading
 /// `accounts_snapshot` must alias `battle_net` → `battle-net` across that
 /// boundary. All other ids are unchanged.
+///
+/// Second continuity note: `steam` was absent from this list in every release
+/// up to and including 1.0.2. The eight other platforms keep their accounts in
+/// the config, so counting them is a field access; Steam keeps its own in
+/// `loginusers.vdf` and was skipped when the list was built from config fields.
+/// Every `accounts_snapshot` emitted by those releases therefore says nothing
+/// about Steam, and no dashboard can reconstruct it.
 fn emit_accounts_snapshots(app_handle: &tauri::AppHandle, tstate: &TelemetryState) {
     use crate::platforms::ids;
-    let cfg = crate::config::load_config(&ctx(app_handle));
-    let counts: [(&str, u64); 8] = [
+    let c = ctx(app_handle);
+    let cfg = crate::config::load_config(&c);
+    // Steam is the one platform whose accounts need a disk read rather than a
+    // config lookup, and the read fails on a machine with no Steam installed
+    // (ClientNotInstalled). That is not worth distinguishing from an empty
+    // library here: both mean zero, and zero is skipped below like any other
+    // empty platform.
+    let steam_count = crate::platforms::steam::get_accounts(c.clone())
+        .map(|accounts| accounts.len() as u64)
+        .unwrap_or(0);
+    let counts: [(&str, u64); 9] = [
+        (ids::STEAM, steam_count),
         (ids::RIOT, cfg.riot.profiles.len() as u64),
         (ids::BATTLE_NET, cfg.battle_net.accounts.len() as u64),
         (ids::UBISOFT, cfg.ubisoft.accounts.len() as u64),


### PR DESCRIPTION
`accounts_snapshot` never included Steam. The platform list in
`emit_accounts_snapshots` was built by walking config fields, and Steam is the
one platform that keeps its accounts in `loginusers.vdf` instead, so it fell out
of the list. The event was blind to the largest part of a typical library.

The count now comes from `steam::get_accounts`. A machine with no Steam install
returns `ClientNotInstalled`, folded to zero, and the loop already skips zero, so
no event is emitted where none was emitted before.

`docs/analytics.md`: the `accounts_snapshot` row said the event fires daily; it
fires once per app start, `finish_boot` being its only caller. Added a note that
releases up to and including 1.0.2 recorded nothing about Steam, so that gap in
existing data is not read as a genuine zero.

`cargo check -p accshift-gui` and `cargo fmt --check` pass. No test added:
`commands.rs` has no test module and the function needs a live `AppHandle`.
