### PR TITLE
ci: submit winget manifests automatically on release

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,46 @@
+name: Publish to winget
+
+# Submits a pull request to microsoft/winget-pkgs whenever a release is
+# published. Drafts do not trigger it: the `released` event fires when the
+# draft created by release.yml is published.
+#
+# Requires the WINGET_TOKEN secret: a token with write access to the
+# klNuno/winget-pkgs fork, which is where the manifest branch is pushed from
+# before the pull request is opened upstream. The package must already exist
+# in winget-pkgs; the action fails on purpose if it does not.
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to publish, for example v1.0.2
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate the winget token secret
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          if [ -z "$WINGET_TOKEN" ]; then
+            echo "Missing GitHub secret WINGET_TOKEN. The manifest cannot be submitted." >&2
+            exit 1
+          fi
+
+      - name: Submit the manifest
+        uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
+        with:
+          identifier: klNuno.Accshift
+          release-tag: ${{ github.event.release.tag_name || inputs.tag }}
+          # The release attaches Linux, macOS and CLI artifacts too; only the
+          # Windows NSIS installer belongs in the manifest.
+          installers-regex: '^Accshift_[0-9.]+_x64-setup\.exe$'
+          max-versions-to-keep: 3
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Adds `.github/workflows/winget.yml`, which submits the winget manifest to microsoft/winget-pkgs when a release is published.

The workflow listens on `release: released`, so drafts do not trigger it and the current flow is unchanged: `release.yml` still creates a draft, and publishing that draft submits the manifest. A `workflow_dispatch` input allows re-running it against a given tag.

`installers-regex` matches only `Accshift_<version>_x64-setup.exe`, checked against the v1.0.2 assets: the Linux, macOS and CLI artifacts are excluded. `max-versions-to-keep` is 3, so older versions are removed from winget-pkgs as new ones land.

The action is pinned by commit SHA, as the other workflows are.

Requires a repository secret `WINGET_TOKEN` with write access to the `klNuno/winget-pkgs` fork. The first step fails with an explicit message when the secret is absent. The action also requires the package to already exist in winget-pkgs; the initial submission is microsoft/winget-pkgs#411672.
