### PR TITLE
feat(telemetry): close the coverage and pipeline gaps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tauri-build = "2.5.6"
 winreg = "0.56"
 windows-sys = { version = "0.61", features = [
   "Win32_Foundation",
+  "Win32_Globalization",
   "Win32_Security_Cryptography",
   "Win32_UI_Shell",
   "Win32_UI_WindowsAndMessaging",

--- a/crates/accshift-cli/src/main.rs
+++ b/crates/accshift-cli/src/main.rs
@@ -3,6 +3,7 @@ mod folders;
 mod output;
 mod pin;
 mod settings;
+mod telemetry;
 
 use accshift_core::error::PlatformErrorKind;
 use accshift_core::lock::{acquire_exclusive, LockError};
@@ -93,9 +94,29 @@ enum Command {
     },
 }
 
+impl Command {
+    /// Subcommand name for telemetry. Never its arguments: an account id or a
+    /// folder name is exactly what must stay on the machine.
+    fn name(&self) -> &'static str {
+        match self {
+            Command::List { .. } => "list",
+            Command::Platforms => "platforms",
+            Command::Switch { .. } => "switch",
+        }
+    }
+}
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
     let format = Format::resolve(cli.json);
+
+    // Started before the command so a run that ends in an error still gets
+    // reported, and dropped silently when consent is absent.
+    let reporter = CliAppContext::new()
+        .ok()
+        .map(|c| Arc::new(c) as accshift_core::AppCtx)
+        .and_then(|ctx| telemetry::CliTelemetry::start(&ctx));
+    let command_name = cli.command.name();
 
     let exit = match cli.command {
         Command::List { platform, folder } => cmd_list(format, &platform, folder.as_deref()),
@@ -125,6 +146,10 @@ fn main() -> ExitCode {
             },
         ),
     };
+
+    if let Some(reporter) = reporter {
+        reporter.finish(command_name, telemetry::error_code_for_exit(exit));
+    }
 
     ExitCode::from(exit)
 }

--- a/crates/accshift-cli/src/telemetry.rs
+++ b/crates/accshift-cli/src/telemetry.rs
@@ -1,0 +1,116 @@
+//! Telemetry for the CLI.
+//!
+//! The CLI reports under the same consent as the app, reads the same config,
+//! and sends to the same Worker. Without this, every `accshift switch` was
+//! invisible: the switch counts, the platform mix and the failure rates all
+//! described app users only, and a CLI-first user looked like someone who had
+//! stopped using the tool.
+//!
+//! Two differences from the app's queue:
+//! - No `ping`. A short-lived process would emit one per invocation and turn
+//!   a single user typing five commands into five daily actives.
+//! - A bounded flush at the end of the command instead of a periodic one. The
+//!   process is about to exit, so there is no later.
+
+use accshift_core::telemetry::{self, ConsentState, Event, QueueParams, Worker};
+use std::time::Duration;
+
+/// How long the process lingers to flush its single event.
+///
+/// The command's output has already been printed when this runs, so the cost
+/// is a process that exits slightly later, never a delayed result. Still kept
+/// tight: a POST to the edge lands in well under this on a working link, and
+/// a machine with no network pays the full deadline on every single command.
+/// A CLI that normally answers in 50 ms cannot afford half a second of that.
+const FLUSH_DEADLINE: Duration = Duration::from_millis(400);
+
+/// A CLI run's telemetry, or nothing at all when consent is absent.
+pub struct CliTelemetry {
+    worker: Worker,
+}
+
+impl CliTelemetry {
+    /// Builds a queue when telemetry is enabled for this installation.
+    ///
+    /// Returns None when both modes are off, in which case nothing is spawned
+    /// at all: a user who opted out does not pay for a thread.
+    pub fn start(ctx: &accshift_core::AppCtx) -> Option<Self> {
+        let cfg = accshift_core::config::load_config(&**ctx);
+        let consent: ConsentState = telemetry::consent_from_config(&cfg.telemetry);
+        if !consent.mode_a && !consent.mode_b {
+            return None;
+        }
+        let tctx = telemetry::context_for(env!("CARGO_PKG_VERSION"), "cli");
+        let params = QueueParams {
+            emit_ping: false,
+            ..Default::default()
+        };
+        Some(Self {
+            worker: Worker::spawn(tctx, consent, params),
+        })
+    }
+
+    /// Records the command outcome and flushes, bounded.
+    pub fn finish(self, command: &str, error_code: Option<&str>) {
+        self.worker.handle().track(Event::CliCommand {
+            command: command.to_string(),
+            success: error_code.is_none(),
+            error_code: error_code.map(str::to_string),
+        });
+        self.worker.shutdown(FLUSH_DEADLINE);
+    }
+}
+
+/// Maps a CLI exit code onto the error vocabulary shared with the app.
+///
+/// Returns None for a success. The CLI's own `unknown_account` wording maps
+/// onto `account_not_found` so one query answers "how often does a switch
+/// fail because the account is gone", whichever surface it came from.
+pub fn error_code_for_exit(exit: u8) -> Option<&'static str> {
+    use crate::exit;
+    match exit {
+        exit::OK => None,
+        exit::PLATFORM_UNAVAILABLE => Some("platform_unavailable"),
+        exit::UNKNOWN_ACCOUNT => Some("account_not_found"),
+        exit::LOCK_CONTENDED => Some("lock_contended"),
+        exit::IO => Some("io"),
+        exit::PIN_DENIED => Some("pin_denied"),
+        exit::CLI_DISABLED => Some("cli_disabled"),
+        _ => Some("other"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::exit;
+
+    #[test]
+    fn success_has_no_error_code() {
+        assert_eq!(error_code_for_exit(exit::OK), None);
+    }
+
+    #[test]
+    fn every_exit_code_maps_to_the_shared_vocabulary() {
+        for code in [
+            exit::GENERIC,
+            exit::PLATFORM_UNAVAILABLE,
+            exit::UNKNOWN_ACCOUNT,
+            exit::LOCK_CONTENDED,
+            exit::IO,
+            exit::PIN_DENIED,
+            exit::CLI_DISABLED,
+        ] {
+            let mapped = error_code_for_exit(code).expect("a failure must carry a code");
+            assert!(
+                accshift_core::telemetry::ERROR_CODES.contains(&mapped),
+                "{mapped} is emitted but not declared in ERROR_CODES"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unmapped_exit_code_degrades_instead_of_leaking() {
+        assert_eq!(error_code_for_exit(u8::MAX), Some("other"));
+    }
+}

--- a/crates/accshift-core/src/config.rs
+++ b/crates/accshift-core/src/config.rs
@@ -218,6 +218,14 @@ pub struct TelemetryConfig {
     pub anonymous_id: String,
     #[serde(default)]
     pub onboarding_completed: bool,
+    /// Whether the one-shot `first_run` event has already been emitted.
+    ///
+    /// Existing installations default to false and will report a `first_run`
+    /// on their next launch, so the event means "first launch that knew how
+    /// to report one". Dashboards must read it against the release that
+    /// introduced it, not as an install date for the whole population.
+    #[serde(default)]
+    pub first_run_reported: bool,
 }
 
 impl Default for TelemetryConfig {
@@ -229,6 +237,7 @@ impl Default for TelemetryConfig {
             pending_forget_install_ids: Vec::new(),
             anonymous_id: String::new(),
             onboarding_completed: false,
+            first_run_reported: false,
         }
     }
 }

--- a/crates/accshift-core/src/telemetry/client.rs
+++ b/crates/accshift-core/src/telemetry/client.rs
@@ -1,7 +1,11 @@
-use super::events::{Event, TelemetryContext};
+use super::events::{
+    code_from, platform_code, Event, TelemetryContext, CLI_COMMANDS, ERROR_CODES, OPERATIONS,
+    UI_LANGUAGES,
+};
+use super::time::to_rfc3339_utc;
 use serde::Serialize;
 use serde_json::{json, Map, Value};
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 /// Inert placeholder used when `ACCSHIFT_TELEMETRY_URL` is not set at compile
 /// time. Not a live endpoint on purpose: it only marks builds that forgot to
@@ -38,17 +42,54 @@ impl Mode {
     }
 }
 
+/// Maximum length of a version string sent as a property.
+const MAX_VERSION_LEN: usize = 32;
+
+/// Reduces a version string to digits, letters, dots and dashes.
+///
+/// The updater hands us whatever the release manifest declared, which is
+/// remote input. It has never been anything but a semver string, and this is
+/// what keeps it that way.
+fn sanitize_version(raw: &str) -> Option<String> {
+    let cleaned: String = raw
+        .trim()
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '.' || *c == '-' || *c == '+')
+        .take(MAX_VERSION_LEN)
+        .collect();
+    if cleaned.is_empty() {
+        None
+    } else {
+        Some(cleaned)
+    }
+}
+
 /// Serializes an event to flat JSON for the `/track` endpoint.
-pub fn event_to_json(event: &Event, ctx: &TelemetryContext) -> Value {
+///
+/// `client_ts` is the instant the event happened, not the instant the batch
+/// leaves: a batch covers up to a full flush interval, so a single
+/// server-side stamp would flatten it.
+pub fn event_to_json(event: &Event, ctx: &TelemetryContext, client_ts: SystemTime) -> Value {
     let mut m = Map::new();
     m.insert("name".into(), Value::from(event.name()));
     m.insert("app_version".into(), Value::from(ctx.app_version.clone()));
+    m.insert("os".into(), Value::from(ctx.os.clone()));
+    m.insert("arch".into(), Value::from(ctx.arch.clone()));
     m.insert("os_version".into(), Value::from(ctx.os_version.clone()));
+    m.insert("surface".into(), Value::from(ctx.surface.clone()));
+    m.insert("client_ts".into(), Value::from(to_rfc3339_utc(client_ts)));
     if let Some(locale) = &ctx.locale {
         m.insert("locale".into(), Value::from(locale.clone()));
     }
     match event {
-        Event::Ping => {}
+        Event::Ping { dropped_events } => {
+            // Only sent when non-zero: a queue that never overflowed must not
+            // add a property to every single ping just to say so.
+            if *dropped_events > 0 {
+                m.insert("dropped_events".into(), Value::from(*dropped_events));
+            }
+        }
+        Event::FirstRun => {}
         Event::AppLaunched { duration_ms } => {
             m.insert("duration_ms".into(), Value::from(*duration_ms));
         }
@@ -56,20 +97,83 @@ pub fn event_to_json(event: &Event, ctx: &TelemetryContext) -> Value {
             platform,
             duration_ms,
             success,
+            error_code,
         } => {
-            m.insert("platform".into(), Value::from(platform.clone()));
+            m.insert("platform".into(), Value::from(platform_code(platform)));
             m.insert("duration_ms".into(), Value::from(*duration_ms));
+            m.insert("success".into(), Value::from(*success));
+            // `count` carried the success flag before `success` existed, and
+            // every dashboard built against it still reads it. Kept as-is.
             m.insert("count".into(), Value::from(u64::from(*success)));
+            if let Some(code) = error_code {
+                m.insert(
+                    "error_code".into(),
+                    Value::from(code_from(code, ERROR_CODES)),
+                );
+            }
         }
         Event::PersonaSwitch {
             platforms,
             succeeded,
         } => {
             m.insert("platforms".into(), Value::from(*platforms));
+            m.insert("succeeded".into(), Value::from(*succeeded));
+            // Same continuity reason as platform_switch above.
             m.insert("count".into(), Value::from(*succeeded));
         }
-        Event::AccountAdded { platform } => {
-            m.insert("platform".into(), Value::from(platform.clone()));
+        Event::AccountAddStarted { platform }
+        | Event::AccountAddCancelled { platform }
+        | Event::AccountAdded { platform } => {
+            m.insert("platform".into(), Value::from(platform_code(platform)));
+        }
+        Event::OperationFailed {
+            operation,
+            platform,
+            error_code,
+        } => {
+            m.insert(
+                "operation".into(),
+                Value::from(code_from(operation, OPERATIONS)),
+            );
+            m.insert(
+                "error_code".into(),
+                Value::from(code_from(error_code, ERROR_CODES)),
+            );
+            if let Some(platform) = platform {
+                m.insert("platform".into(), Value::from(platform_code(platform)));
+            }
+        }
+        Event::Update {
+            target_version,
+            error_code,
+            ..
+        } => {
+            if let Some(version) = target_version.as_deref().and_then(sanitize_version) {
+                m.insert("target_version".into(), Value::from(version));
+            }
+            if let Some(code) = error_code {
+                m.insert(
+                    "error_code".into(),
+                    Value::from(code_from(code, ERROR_CODES)),
+                );
+            }
+        }
+        Event::CliCommand {
+            command,
+            success,
+            error_code,
+        } => {
+            m.insert(
+                "command".into(),
+                Value::from(code_from(command, CLI_COMMANDS)),
+            );
+            m.insert("success".into(), Value::from(*success));
+            if let Some(code) = error_code {
+                m.insert(
+                    "error_code".into(),
+                    Value::from(code_from(code, ERROR_CODES)),
+                );
+            }
         }
         Event::StreamerModeActivated => {}
         Event::DeepLinkUsed => {}
@@ -77,8 +181,43 @@ pub fn event_to_json(event: &Event, ctx: &TelemetryContext) -> Value {
             m.insert("duration_ms".into(), Value::from(*duration_ms));
         }
         Event::AccountsSnapshot { platform, count } => {
-            m.insert("platform".into(), Value::from(platform.clone()));
+            m.insert("platform".into(), Value::from(platform_code(platform)));
             m.insert("count".into(), Value::from(*count));
+        }
+        Event::SettingsSnapshot {
+            ui_language,
+            enabled_platforms,
+            personas_enabled,
+            pin_enabled,
+            cli_enabled,
+            deep_links_enabled,
+            streamer_mode,
+            animations,
+        } => {
+            m.insert(
+                "ui_language".into(),
+                Value::from(code_from(ui_language, UI_LANGUAGES)),
+            );
+            let platforms: Vec<Value> = enabled_platforms
+                .iter()
+                .map(|id| Value::from(platform_code(id)))
+                .collect();
+            m.insert("enabled_platforms".into(), Value::Array(platforms));
+            m.insert("personas_enabled".into(), Value::from(*personas_enabled));
+            m.insert("pin_enabled".into(), Value::from(*pin_enabled));
+            m.insert("cli_enabled".into(), Value::from(*cli_enabled));
+            m.insert(
+                "deep_links_enabled".into(),
+                Value::from(*deep_links_enabled),
+            );
+            m.insert(
+                "streamer_mode".into(),
+                Value::from(code_from(streamer_mode, &["auto", "off"])),
+            );
+            m.insert(
+                "animations".into(),
+                Value::from(code_from(animations, &["system", "on", "off"])),
+            );
         }
     }
     Value::Object(m)
@@ -228,55 +367,136 @@ pub fn export(
 mod tests {
     use super::*;
 
-    #[test]
-    fn event_to_json_ping_has_only_invariants() {
-        let ctx = TelemetryContext {
+    use super::super::events::UpdateStage;
+    use std::time::UNIX_EPOCH;
+
+    fn ctx_with_locale(locale: Option<&str>) -> TelemetryContext {
+        TelemetryContext {
             app_version: "0.9.0".into(),
+            os: "windows".into(),
+            arch: "x86_64".into(),
             os_version: "Windows 11 22631".into(),
-            locale: Some("fr-FR".into()),
-        };
-        let v = event_to_json(&Event::Ping, &ctx);
-        assert_eq!(v["name"], "ping");
-        assert_eq!(v["app_version"], "0.9.0");
-        assert_eq!(v["os_version"], "Windows 11 22631");
-        assert_eq!(v["locale"], "fr-FR");
-        assert!(v.get("duration_ms").is_none());
-        assert!(v.get("platform").is_none());
+            locale: locale.map(str::to_string),
+            surface: "gui".into(),
+        }
+    }
+
+    fn at(secs: u64) -> SystemTime {
+        UNIX_EPOCH + Duration::from_secs(secs)
     }
 
     #[test]
-    fn event_to_json_platform_switch_encodes_success_as_count() {
-        let ctx = TelemetryContext {
-            app_version: "0.9.0".into(),
-            os_version: "Windows 11 22631".into(),
-            locale: None,
-        };
+    fn event_to_json_ping_has_only_invariants() {
+        let ctx = ctx_with_locale(Some("fr-FR"));
+        let v = event_to_json(&Event::Ping { dropped_events: 0 }, &ctx, at(1_785_846_896));
+        assert_eq!(v["name"], "ping");
+        assert_eq!(v["app_version"], "0.9.0");
+        assert_eq!(v["os"], "windows");
+        assert_eq!(v["arch"], "x86_64");
+        assert_eq!(v["os_version"], "Windows 11 22631");
+        assert_eq!(v["surface"], "gui");
+        assert_eq!(v["locale"], "fr-FR");
+        assert_eq!(v["client_ts"], "2026-08-04T12:34:56Z");
+        assert!(v.get("duration_ms").is_none());
+        assert!(v.get("platform").is_none());
+        // A queue that never overflowed says nothing rather than zero.
+        assert!(v.get("dropped_events").is_none());
+    }
+
+    #[test]
+    fn event_to_json_ping_reports_dropped_events_when_any() {
+        let ctx = ctx_with_locale(None);
+        let v = event_to_json(&Event::Ping { dropped_events: 12 }, &ctx, at(0));
+        assert_eq!(v["dropped_events"], 12);
+    }
+
+    #[test]
+    fn event_to_json_platform_switch_keeps_count_and_adds_success() {
+        let ctx = ctx_with_locale(None);
         let ev = Event::PlatformSwitch {
             platform: "steam".into(),
             duration_ms: 180,
             success: true,
+            error_code: None,
         };
-        let v = event_to_json(&ev, &ctx);
+        let v = event_to_json(&ev, &ctx, at(0));
         assert_eq!(v["name"], "platform_switch");
         assert_eq!(v["platform"], "steam");
         assert_eq!(v["duration_ms"], 180);
+        assert_eq!(v["success"], true);
+        // Continuity: dashboards built before `success` existed read `count`.
         assert_eq!(v["count"], 1);
+        assert!(v.get("error_code").is_none());
+    }
+
+    #[test]
+    fn event_to_json_platform_switch_classifies_a_failure() {
+        let ctx = ctx_with_locale(None);
+        let ev = Event::PlatformSwitch {
+            platform: "riot".into(),
+            duration_ms: 40,
+            success: false,
+            error_code: Some("client_running".into()),
+        };
+        let v = event_to_json(&ev, &ctx, at(0));
+        assert_eq!(v["success"], false);
+        assert_eq!(v["count"], 0);
+        assert_eq!(v["error_code"], "client_running");
+    }
+
+    #[test]
+    fn event_to_json_never_lets_a_message_through_a_code_field() {
+        let ctx = ctx_with_locale(None);
+        let ev = Event::OperationFailed {
+            operation: "profile_capture".into(),
+            platform: Some("riot".into()),
+            error_code: r"C:\Users\alice\riot missing".to_string(),
+        };
+        let v = event_to_json(&ev, &ctx, at(0));
+        assert_eq!(v["operation"], "profile_capture");
+        assert_eq!(v["platform"], "riot");
+        // A raw message is not normalized into a code, it is discarded.
+        assert_eq!(v["error_code"], "other");
+    }
+
+    #[test]
+    fn event_to_json_rejects_an_unknown_platform_id() {
+        let ctx = ctx_with_locale(None);
+        let v = event_to_json(
+            &Event::AccountAdded {
+                platform: "MyPrivateLauncher".into(),
+            },
+            &ctx,
+            at(0),
+        );
+        assert_eq!(v["platform"], "other");
+    }
+
+    #[test]
+    fn event_to_json_keeps_the_battle_net_id_verbatim() {
+        // Renaming it on the wire would break the dashboards a second time.
+        let ctx = ctx_with_locale(None);
+        let v = event_to_json(
+            &Event::AccountAdded {
+                platform: "battle-net".into(),
+            },
+            &ctx,
+            at(0),
+        );
+        assert_eq!(v["platform"], "battle-net");
     }
 
     #[test]
     fn event_to_json_persona_switch_carries_counts_only() {
-        let ctx = TelemetryContext {
-            app_version: "0.9.0".into(),
-            os_version: "Windows 11 22631".into(),
-            locale: None,
-        };
+        let ctx = ctx_with_locale(None);
         let ev = Event::PersonaSwitch {
             platforms: 3,
             succeeded: 2,
         };
-        let v = event_to_json(&ev, &ctx);
+        let v = event_to_json(&ev, &ctx, at(0));
         assert_eq!(v["name"], "persona_switch");
         assert_eq!(v["platforms"], 3);
+        assert_eq!(v["succeeded"], 2);
         assert_eq!(v["count"], 2);
         // Non-PII by construction: no persona name, no platform id, no account.
         assert!(v.get("platform").is_none());
@@ -284,27 +504,24 @@ mod tests {
 
     #[test]
     fn event_to_json_feature_events_carry_no_pii() {
-        let ctx = TelemetryContext {
-            app_version: "0.9.0".into(),
-            os_version: "Windows 11 22631".into(),
-            locale: None,
-        };
+        let ctx = ctx_with_locale(None);
         let v = event_to_json(
             &Event::AccountAdded {
                 platform: "discord".into(),
             },
             &ctx,
+            at(0),
         );
         assert_eq!(v["name"], "account_added");
         // Platform id only: no account name, id, or display name.
         assert_eq!(v["platform"], "discord");
         assert!(v.get("account").is_none());
 
-        let v = event_to_json(&Event::StreamerModeActivated, &ctx);
+        let v = event_to_json(&Event::StreamerModeActivated, &ctx, at(0));
         assert_eq!(v["name"], "streamer_mode_activated");
         assert!(v.get("platform").is_none());
 
-        let v = event_to_json(&Event::DeepLinkUsed, &ctx);
+        let v = event_to_json(&Event::DeepLinkUsed, &ctx, at(0));
         assert_eq!(v["name"], "deep_link_used");
         // No URL contents: a deep link carries account ids in its path.
         assert!(v.get("url").is_none());
@@ -312,13 +529,92 @@ mod tests {
     }
 
     #[test]
-    fn event_to_json_omits_locale_when_none() {
+    fn event_to_json_update_sanitizes_the_remote_version() {
+        let ctx = ctx_with_locale(None);
+        let v = event_to_json(
+            &Event::Update {
+                stage: UpdateStage::Available,
+                target_version: Some("1.4.2".into()),
+                error_code: None,
+            },
+            &ctx,
+            at(0),
+        );
+        assert_eq!(v["name"], "update_available");
+        assert_eq!(v["target_version"], "1.4.2");
+
+        // The manifest is remote input; it never reaches PostHog verbatim.
+        let v = event_to_json(
+            &Event::Update {
+                stage: UpdateStage::Failed,
+                target_version: Some("1.4.2 <script>alert(1)</script>".into()),
+                error_code: Some("download failed".into()),
+            },
+            &ctx,
+            at(0),
+        );
+        assert_eq!(v["name"], "update_failed");
+        assert_eq!(v["target_version"], "1.4.2scriptalert1script");
+        assert_eq!(v["error_code"], "download_failed");
+    }
+
+    #[test]
+    fn event_to_json_settings_snapshot_is_all_low_cardinality_codes() {
+        let ctx = ctx_with_locale(None);
+        let v = event_to_json(
+            &Event::SettingsSnapshot {
+                ui_language: "pt-BR".into(),
+                enabled_platforms: vec!["steam".into(), "battle-net".into()],
+                personas_enabled: true,
+                pin_enabled: false,
+                cli_enabled: true,
+                deep_links_enabled: true,
+                streamer_mode: "auto".into(),
+                animations: "system".into(),
+            },
+            &ctx,
+            at(0),
+        );
+        assert_eq!(v["name"], "settings_snapshot");
+        assert_eq!(v["ui_language"], "pt_br");
+        assert_eq!(v["enabled_platforms"], json!(["steam", "battle-net"]));
+        assert_eq!(v["personas_enabled"], true);
+        assert_eq!(v["pin_enabled"], false);
+        // A user-named custom theme has no field to travel in.
+        assert!(v.get("theme").is_none());
+    }
+
+    #[test]
+    fn event_to_json_cli_command_carries_no_arguments() {
         let ctx = TelemetryContext {
-            app_version: "0.9.0".into(),
-            os_version: "Windows 11 22631".into(),
-            locale: None,
+            surface: "cli".into(),
+            ..ctx_with_locale(None)
         };
-        let v = event_to_json(&Event::Ping, &ctx);
+        let v = event_to_json(
+            &Event::CliCommand {
+                command: "switch".into(),
+                success: false,
+                error_code: Some("account_not_found".into()),
+            },
+            &ctx,
+            at(0),
+        );
+        assert_eq!(v["name"], "cli_command");
+        assert_eq!(v["surface"], "cli");
+        assert_eq!(v["command"], "switch");
+        assert_eq!(v["success"], false);
+        // The CLI's own `unknown_account` exit code maps onto the one error
+        // vocabulary shared with the app, so both surfaces stay comparable.
+        assert_eq!(v["error_code"], "account_not_found");
+        // The account id and every other argument stay on the machine.
+        assert!(v.get("account_id").is_none());
+        assert!(v.get("args").is_none());
+    }
+
+    #[test]
+    fn event_to_json_omits_locale_when_none() {
+        let ctx = ctx_with_locale(None);
+        let v = event_to_json(&Event::Ping { dropped_events: 0 }, &ctx, at(0));
         assert!(v.get("locale").is_none());
     }
 

--- a/crates/accshift-core/src/telemetry/events.rs
+++ b/crates/accshift-core/src/telemetry/events.rs
@@ -1,25 +1,59 @@
+use crate::error::PlatformErrorKind;
+
 /// Telemetry events emitted by the app.
 ///
 /// An `Event` only carries the variable fields specific to that event. Stable
-/// per-session fields (app_version, os_version, locale) live in
-/// `TelemetryContext` and are merged at serialization time.
+/// per-session fields (app_version, os, arch, os_version, locale, surface)
+/// live in `TelemetryContext` and are merged at serialization time.
 #[derive(Debug, Clone)]
 pub enum Event {
     /// Daily ping for DAU / MAU measurement.
-    Ping,
+    ///
+    /// Emitted by the queue itself, not by a caller: it has to fire once a day
+    /// for as long as the process lives, and it carries the number of events
+    /// the queue had to drop since the previous ping, which only the queue
+    /// knows.
+    Ping { dropped_events: u64 },
+    /// First launch of this installation, emitted once ever.
+    FirstRun,
     /// App launch time (between `main()` and the first frame).
     AppLaunched { duration_ms: u64 },
-    /// Account switch on a given platform.
+    /// Account switch on a given platform. `error_code` classifies a failure
+    /// into a fixed vocabulary; it is never a message.
     PlatformSwitch {
         platform: String,
         duration_ms: u64,
         success: bool,
+        error_code: Option<String>,
     },
     /// A persona activation: how many platforms it targeted and how many
     /// switched successfully. No persona name, no account data.
     PersonaSwitch { platforms: u64, succeeded: u64 },
+    /// An add-account flow was opened for a platform.
+    AccountAddStarted { platform: String },
+    /// An add-account flow was abandoned before it produced an account.
+    AccountAddCancelled { platform: String },
     /// A new account finished its add flow on a platform. Platform id only.
     AccountAdded { platform: String },
+    /// A named operation failed. `operation` and `error_code` both come from
+    /// fixed vocabularies, so no user data can reach this event.
+    OperationFailed {
+        operation: String,
+        platform: Option<String>,
+        error_code: String,
+    },
+    /// A stage of the in-app update flow.
+    Update {
+        stage: UpdateStage,
+        target_version: Option<String>,
+        error_code: Option<String>,
+    },
+    /// A CLI invocation. Subcommand name only, never its arguments.
+    CliCommand {
+        command: String,
+        success: bool,
+        error_code: Option<String>,
+    },
     /// The streamer-mode overlay auto-activated (streaming software detected).
     StreamerModeActivated,
     /// An accshift:// deep link triggered an action. No URL contents.
@@ -29,21 +63,194 @@ pub enum Event {
     /// Snapshot of the number of accounts configured for a platform.
     /// Mode B only (requires a stable install_id).
     AccountsSnapshot { platform: String, count: u64 },
+    /// Snapshot of the non-identifying app settings, once per launch.
+    ///
+    /// Mode B only. Each field is low-entropy on its own, but nine of them
+    /// together are a weak fingerprint, and Mode A exists precisely so that
+    /// two events cannot be tied to the same installation across days.
+    ///
+    /// No theme id: built-in ids would be safe, but a custom theme is named by
+    /// the user and there is no way for this crate to tell the two apart.
+    SettingsSnapshot {
+        ui_language: String,
+        enabled_platforms: Vec<String>,
+        personas_enabled: bool,
+        pin_enabled: bool,
+        cli_enabled: bool,
+        deep_links_enabled: bool,
+        streamer_mode: String,
+        animations: String,
+    },
+}
+
+/// Stage of the updater flow. Each maps to its own PostHog event name so a
+/// funnel can be built without unpacking a property.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateStage {
+    Available,
+    Downloaded,
+    Applied,
+    Failed,
 }
 
 impl Event {
     pub fn name(&self) -> &'static str {
         match self {
-            Event::Ping => "ping",
+            Event::Ping { .. } => "ping",
+            Event::FirstRun => "first_run",
             Event::AppLaunched { .. } => "app_launched",
             Event::PlatformSwitch { .. } => "platform_switch",
             Event::PersonaSwitch { .. } => "persona_switch",
+            Event::AccountAddStarted { .. } => "account_add_started",
+            Event::AccountAddCancelled { .. } => "account_add_cancelled",
             Event::AccountAdded { .. } => "account_added",
+            Event::OperationFailed { .. } => "operation_failed",
+            Event::Update { stage, .. } => match stage {
+                UpdateStage::Available => "update_available",
+                UpdateStage::Downloaded => "update_downloaded",
+                UpdateStage::Applied => "update_applied",
+                UpdateStage::Failed => "update_failed",
+            },
+            Event::CliCommand { .. } => "cli_command",
             Event::StreamerModeActivated => "streamer_mode_activated",
             Event::DeepLinkUsed => "deep_link_used",
             Event::SessionEnded { .. } => "session_ended",
             Event::AccountsSnapshot { .. } => "accounts_snapshot",
+            Event::SettingsSnapshot { .. } => "settings_snapshot",
         }
+    }
+
+    /// True for events that require a stable install_id to mean anything, and
+    /// that the queue drops before a Mode A upload.
+    pub fn is_mode_b_only(&self) -> bool {
+        matches!(
+            self,
+            Event::AccountsSnapshot { .. } | Event::SettingsSnapshot { .. }
+        )
+    }
+}
+
+/// The value every unrecognised code collapses to.
+pub const UNKNOWN_CODE: &str = "other";
+
+/// Every error code that may reach the network.
+///
+/// A closed vocabulary rather than a sanitizer. Normalising an arbitrary
+/// string is not enough: `C:\Users\alice\...` survives character filtering
+/// with the account name intact, and an error message is exactly the kind of
+/// string that carries paths and usernames. Anything not listed here becomes
+/// `other`, so a caller that passes a raw message leaks a category at worst.
+pub const ERROR_CODES: &[&str] = &[
+    // PlatformErrorKind, one for one.
+    "client_not_installed",
+    "client_running",
+    "account_not_found",
+    "setup_expired",
+    "lock_contended",
+    "io",
+    "crypto",
+    // Updater flow.
+    "check_failed",
+    "download_failed",
+    "install_failed",
+    "relaunch_failed",
+    // CLI-only outcomes.
+    "cli_disabled",
+    "platform_unavailable",
+    "pin_denied",
+    "unknown_folder",
+    "folder_store_error",
+    UNKNOWN_CODE,
+];
+
+/// Every operation name that may reach the network.
+pub const OPERATIONS: &[&str] = &[
+    "platform_switch",
+    "account_add",
+    "account_forget",
+    "profile_capture",
+    "session_check",
+    "bulk_edit",
+    "game_settings_copy",
+    "cs2_bridge_fetch",
+    "avatar_refresh",
+    "ban_check",
+    UNKNOWN_CODE,
+];
+
+/// Every CLI subcommand name that may reach the network.
+pub const CLI_COMMANDS: &[&str] = &["list", "switch", "platforms", UNKNOWN_CODE];
+
+/// UI languages the app ships. An unlisted value becomes `other` rather than
+/// travelling as typed.
+pub const UI_LANGUAGES: &[&str] = &["en", "fr", "es", "pt", "pt_br", "ru", "zh", UNKNOWN_CODE];
+
+/// Maximum length of a normalized identifier-like value.
+const MAX_CODE_LEN: usize = 40;
+
+/// Normalizes a string to lowercase `[a-z0-9_]`.
+///
+/// Shape only. On its own this is NOT a privacy boundary, which is why every
+/// caller pairs it with [`code_from`] and a closed vocabulary.
+pub fn sanitize_code(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len().min(MAX_CODE_LEN));
+    for ch in raw.trim().chars() {
+        if out.len() == MAX_CODE_LEN {
+            break;
+        }
+        let lowered = ch.to_ascii_lowercase();
+        if lowered.is_ascii_alphanumeric() || lowered == '_' {
+            out.push(lowered);
+        } else if !out.ends_with('_') && !out.is_empty() {
+            out.push('_');
+        }
+    }
+    let trimmed = out.trim_matches('_');
+    if trimmed.is_empty() {
+        UNKNOWN_CODE.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Maps a value onto a closed vocabulary, or onto `other`.
+///
+/// The single gate that makes it impossible for a message, a path or an
+/// account name to reach the network through a code field, whatever a caller
+/// passes.
+pub fn code_from(raw: &str, allowed: &[&'static str]) -> &'static str {
+    let normalized = sanitize_code(raw);
+    allowed
+        .iter()
+        .copied()
+        .find(|candidate| *candidate == normalized)
+        .unwrap_or(UNKNOWN_CODE)
+}
+
+/// Maps a platform id onto the canonical registry, or onto `other`.
+///
+/// Matched verbatim, not normalized: `battle-net` has to stay `battle-net` on
+/// the wire. It was `battle_net` before v1.0 and dashboards already alias the
+/// two across that boundary; a second spelling change would break them again.
+pub fn platform_code(raw: &str) -> &'static str {
+    crate::platforms::ids::ALL
+        .iter()
+        .copied()
+        .find(|id| *id == raw)
+        .unwrap_or(UNKNOWN_CODE)
+}
+
+/// Fixed error code for a typed platform failure.
+pub fn error_code_for_kind(kind: PlatformErrorKind) -> &'static str {
+    match kind {
+        PlatformErrorKind::ClientNotInstalled => "client_not_installed",
+        PlatformErrorKind::ClientRunning => "client_running",
+        PlatformErrorKind::AccountNotFound => "account_not_found",
+        PlatformErrorKind::SetupExpired => "setup_expired",
+        PlatformErrorKind::LockContended => "lock_contended",
+        PlatformErrorKind::Io => "io",
+        PlatformErrorKind::Crypto => "crypto",
+        PlatformErrorKind::Other => UNKNOWN_CODE,
     }
 }
 
@@ -51,6 +258,116 @@ impl Event {
 #[derive(Debug, Clone)]
 pub struct TelemetryContext {
     pub app_version: String,
+    /// Fixed identifier: `windows`, `macos`, `linux`.
+    pub os: String,
+    /// Target architecture: `x86_64`, `aarch64`.
+    pub arch: String,
+    /// Human-readable OS version, for support decisions.
     pub os_version: String,
     pub locale: Option<String>,
+    /// `gui` or `cli`. Without it, a CLI switch is indistinguishable from an
+    /// app switch and every per-user average is wrong.
+    pub surface: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_normalizes_shape() {
+        assert_eq!(sanitize_code("Account Not Found"), "account_not_found");
+        assert_eq!(sanitize_code("io"), "io");
+        assert_eq!(sanitize_code("  spaced  "), "spaced");
+    }
+
+    #[test]
+    fn sanitize_never_returns_empty() {
+        assert_eq!(sanitize_code(""), UNKNOWN_CODE);
+        assert_eq!(sanitize_code("   "), UNKNOWN_CODE);
+        assert_eq!(sanitize_code("!!!"), UNKNOWN_CODE);
+    }
+
+    #[test]
+    fn sanitize_truncates_long_input() {
+        let long = "a".repeat(200);
+        assert_eq!(sanitize_code(&long).len(), MAX_CODE_LEN);
+    }
+
+    #[test]
+    fn a_raw_message_cannot_leak_through_a_code_field() {
+        // Character filtering alone leaves "alice" intact, which is the whole
+        // reason codes go through a closed vocabulary.
+        let code = code_from(r"C:\Users\alice\Steam\loginusers.vdf missing", ERROR_CODES);
+        assert_eq!(code, UNKNOWN_CODE);
+    }
+
+    #[test]
+    fn known_codes_survive_the_vocabulary() {
+        assert_eq!(code_from("client_running", ERROR_CODES), "client_running");
+        assert_eq!(code_from("Client Running", ERROR_CODES), "client_running");
+        assert_eq!(code_from("switch", CLI_COMMANDS), "switch");
+        assert_eq!(code_from("pt-BR", UI_LANGUAGES), "pt_br");
+        assert_eq!(code_from("klingon", UI_LANGUAGES), UNKNOWN_CODE);
+    }
+
+    #[test]
+    fn every_platform_error_kind_maps_into_the_vocabulary() {
+        for kind in [
+            PlatformErrorKind::ClientNotInstalled,
+            PlatformErrorKind::ClientRunning,
+            PlatformErrorKind::AccountNotFound,
+            PlatformErrorKind::SetupExpired,
+            PlatformErrorKind::LockContended,
+            PlatformErrorKind::Io,
+            PlatformErrorKind::Crypto,
+            PlatformErrorKind::Other,
+        ] {
+            let code = error_code_for_kind(kind);
+            assert!(
+                ERROR_CODES.contains(&code),
+                "{code} is emitted but not declared in ERROR_CODES"
+            );
+        }
+    }
+
+    #[test]
+    fn snapshot_events_are_the_only_mode_b_only_ones() {
+        assert!(Event::AccountsSnapshot {
+            platform: "steam".into(),
+            count: 3
+        }
+        .is_mode_b_only());
+        assert!(!Event::Ping { dropped_events: 0 }.is_mode_b_only());
+        assert!(!Event::DeepLinkUsed.is_mode_b_only());
+    }
+
+    #[test]
+    fn update_stages_have_distinct_event_names() {
+        let names: Vec<&str> = [
+            UpdateStage::Available,
+            UpdateStage::Downloaded,
+            UpdateStage::Applied,
+            UpdateStage::Failed,
+        ]
+        .into_iter()
+        .map(|stage| {
+            Event::Update {
+                stage,
+                target_version: None,
+                error_code: None,
+            }
+            .name()
+        })
+        .collect();
+        assert_eq!(
+            names,
+            [
+                "update_available",
+                "update_downloaded",
+                "update_applied",
+                "update_failed"
+            ]
+        );
+    }
 }

--- a/crates/accshift-core/src/telemetry/mod.rs
+++ b/crates/accshift-core/src/telemetry/mod.rs
@@ -14,12 +14,18 @@
 mod client;
 mod events;
 pub mod install_id;
+mod platform_info;
 mod queue;
+mod time;
 
 pub use client::{
     export, forget, record_consent_choice, user_agent, ConsentChoice, Mode, TELEMETRY_URL,
 };
-pub use events::{Event, TelemetryContext};
+pub use events::{
+    code_from, error_code_for_kind, platform_code, sanitize_code, Event, TelemetryContext,
+    UpdateStage, CLI_COMMANDS, ERROR_CODES, OPERATIONS, UI_LANGUAGES, UNKNOWN_CODE,
+};
+pub use platform_info::{detect_arch, detect_locale, detect_os, detect_os_version};
 pub use queue::{ConsentState, Handle, QueueParams, Worker};
 
 use crate::config::TelemetryConfig;
@@ -42,16 +48,19 @@ pub fn consent_from_config(cfg: &TelemetryConfig) -> ConsentState {
     }
 }
 
-/// Best-effort detection of the current OS locale.
-/// Returns None if it cannot be determined; the `/track` API tolerates absence.
-pub fn detect_locale() -> Option<String> {
-    // `LANG` and `LC_ALL` on Linux/macOS, POSIX-style fallback on Windows
-    // via env. Tauri exposes a similar API but we avoid that dep here.
-    std::env::var("LC_ALL")
-        .or_else(|_| std::env::var("LANG"))
-        .ok()
-        .map(|v| v.split('.').next().unwrap_or(&v).to_string())
-        .filter(|s| !s.is_empty() && s != "C")
+/// Builds the invariant context every event is merged with.
+///
+/// `surface` distinguishes the app from the CLI. Both report the same OS
+/// fields, which is why detection lives in the core crate.
+pub fn context_for(app_version: impl Into<String>, surface: &str) -> TelemetryContext {
+    TelemetryContext {
+        app_version: app_version.into(),
+        os: detect_os().to_string(),
+        arch: detect_arch().to_string(),
+        os_version: detect_os_version(),
+        locale: detect_locale(),
+        surface: surface.to_string(),
+    }
 }
 
 #[cfg(test)]
@@ -67,6 +76,7 @@ mod tests {
             pending_forget_install_ids: Vec::new(),
             anonymous_id: String::new(),
             onboarding_completed: true,
+            first_run_reported: true,
         };
         let state = consent_from_config(&cfg);
         assert!(state.mode_a);
@@ -83,6 +93,7 @@ mod tests {
             pending_forget_install_ids: Vec::new(),
             anonymous_id: "797f20fe-94de-4e89-98a2-ae3a3273ad1e".into(),
             onboarding_completed: true,
+            first_run_reported: true,
         };
         let state = consent_from_config(&cfg);
         assert!(state.mode_b);

--- a/crates/accshift-core/src/telemetry/platform_info.rs
+++ b/crates/accshift-core/src/telemetry/platform_info.rs
@@ -1,0 +1,276 @@
+//! OS identification for the telemetry context.
+//!
+//! Three separate values rather than one string:
+//! - `os` is a fixed identifier (`windows`, `macos`, `linux`) so a dashboard
+//!   can group by platform without parsing prose.
+//! - `arch` is the target architecture, which `os_version` used to carry on
+//!   some platforms and not others.
+//! - `os_version` stays the human-readable string, used for release-support
+//!   decisions ("how many people are still on Windows 10").
+//!
+//! Lives in the core crate rather than in the GUI: the CLI reports the same
+//! context, and duplicating the detection would let the two drift.
+
+/// Fixed OS identifier: `windows`, `macos`, `linux`, or the Rust target name.
+pub fn detect_os() -> &'static str {
+    std::env::consts::OS
+}
+
+/// Target architecture (`x86_64`, `aarch64`, ...).
+pub fn detect_arch() -> &'static str {
+    std::env::consts::ARCH
+}
+
+#[cfg(windows)]
+pub fn detect_os_version() -> String {
+    use winreg::enums::HKEY_LOCAL_MACHINE;
+    use winreg::RegKey;
+    let Ok(key) = RegKey::predef(HKEY_LOCAL_MACHINE)
+        .open_subkey("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion")
+    else {
+        return "Windows".to_string();
+    };
+    let product: String = key
+        .get_value::<String, _>("ProductName")
+        .unwrap_or_else(|_| "Windows".into());
+    let build: String = key
+        .get_value::<String, _>("CurrentBuildNumber")
+        .unwrap_or_default();
+    format_windows_version(&product, &build)
+}
+
+/// Combines the registry `ProductName` and `CurrentBuildNumber` into a display
+/// string. Pure so it can be unit-tested without the registry.
+///
+/// ProductName stays "Windows 10" on Win11; the build number is the only
+/// reliable discriminator. Builds >= 22000 are Windows 11, so a leading
+/// "Windows 10" is rewritten to "Windows 11" while keeping the edition suffix
+/// (e.g. "Windows 10 Pro" -> "Windows 11 Pro"). The build number is kept.
+#[cfg(windows)]
+fn format_windows_version(product: &str, build: &str) -> String {
+    let mut product = product.to_string();
+    if build.parse::<u32>().is_ok_and(|n| n >= 22000) {
+        if let Some(suffix) = product.strip_prefix("Windows 10") {
+            product = format!("Windows 11{suffix}");
+        }
+    }
+    if build.is_empty() {
+        product
+    } else {
+        format!("{product} {build}")
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn detect_os_version() -> String {
+    // Prefer /etc/os-release PRETTY_NAME (e.g. "CachyOS Linux", "Ubuntu 24.04").
+    if let Ok(content) = std::fs::read_to_string("/etc/os-release") {
+        if let Some(name) = parse_os_release_pretty_name(&content) {
+            return name;
+        }
+    }
+    "Linux".to_string()
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn parse_os_release_pretty_name(content: &str) -> Option<String> {
+    for line in content.lines() {
+        let (key, value) = line.split_once('=')?;
+        if key.trim() != "PRETTY_NAME" {
+            continue;
+        }
+        let trimmed = value.trim().trim_matches('"').trim_matches('\'');
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+    None
+}
+
+/// macOS product version, read from the system plist.
+///
+/// Every release before this one reported `macos <arch>` and no version at
+/// all, which made "what is the oldest macOS still in use" unanswerable. The
+/// plist is a fixed-format file owned by the OS, so a targeted scan beats
+/// spawning `sw_vers` at every startup.
+#[cfg(target_os = "macos")]
+pub fn detect_os_version() -> String {
+    const PLIST: &str = "/System/Library/CoreServices/SystemVersion.plist";
+    match std::fs::read_to_string(PLIST) {
+        Ok(content) => match parse_plist_string_value(&content, "ProductVersion") {
+            Some(version) => format!("macOS {version}"),
+            None => "macOS".to_string(),
+        },
+        Err(_) => "macOS".to_string(),
+    }
+}
+
+/// Reads `<key>NAME</key><string>VALUE</string>` out of an XML plist.
+///
+/// Deliberately not a plist parser: this file has one shape, has had it for
+/// twenty years, and a failed read falls back to an unversioned label.
+#[cfg(any(target_os = "macos", test))]
+fn parse_plist_string_value(content: &str, key: &str) -> Option<String> {
+    let key_tag = format!("<key>{key}</key>");
+    let after_key = content.split_once(&key_tag)?.1;
+    let after_open = after_key.split_once("<string>")?.1;
+    let (value, _) = after_open.split_once("</string>")?;
+    let value = value.trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
+pub fn detect_os_version() -> String {
+    std::env::consts::OS.to_string()
+}
+
+/// Best-effort detection of the current OS locale, as a BCP 47 or POSIX tag.
+///
+/// Windows has no `LANG` in a normal user session, so the POSIX-only lookup
+/// this used to do reported nothing for almost the entire Windows install
+/// base. The platform API is the only reliable source there.
+#[cfg(windows)]
+pub fn detect_locale() -> Option<String> {
+    use windows_sys::Win32::Globalization::GetUserDefaultLocaleName;
+
+    // LOCALE_NAME_MAX_LENGTH from winnls.h. windows-sys does not re-export it,
+    // and the value is part of the Win32 ABI, so it cannot move.
+    const LOCALE_NAME_MAX_LENGTH: usize = 85;
+
+    let mut buffer = [0u16; LOCALE_NAME_MAX_LENGTH];
+    // Returns the number of characters written, terminating null included.
+    let written = unsafe { GetUserDefaultLocaleName(buffer.as_mut_ptr(), buffer.len() as i32) };
+    if written <= 1 {
+        return posix_locale_from_env();
+    }
+    let name = String::from_utf16_lossy(&buffer[..(written as usize - 1)]);
+    let name = name.trim();
+    if name.is_empty() {
+        posix_locale_from_env()
+    } else {
+        Some(name.to_string())
+    }
+}
+
+#[cfg(not(windows))]
+pub fn detect_locale() -> Option<String> {
+    posix_locale_from_env()
+}
+
+/// `LC_ALL` then `LANG`, stripped of the encoding suffix (`fr_FR.UTF-8`).
+/// The `C` locale means "unset" for our purposes and is reported as absent.
+fn posix_locale_from_env() -> Option<String> {
+    std::env::var("LC_ALL")
+        .or_else(|_| std::env::var("LANG"))
+        .ok()
+        .map(|v| v.split('.').next().unwrap_or(&v).to_string())
+        .filter(|s| !s.is_empty() && s != "C" && s != "POSIX")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn os_and_arch_are_never_empty() {
+        assert!(!detect_os().is_empty());
+        assert!(!detect_arch().is_empty());
+        assert!(!detect_os_version().is_empty());
+    }
+
+    #[test]
+    fn plist_product_version_is_extracted() {
+        let plist = r#"<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>ProductName</key>
+	<string>macOS</string>
+	<key>ProductVersion</key>
+	<string>15.3.1</string>
+</dict>
+</plist>"#;
+        assert_eq!(
+            parse_plist_string_value(plist, "ProductVersion").as_deref(),
+            Some("15.3.1")
+        );
+    }
+
+    #[test]
+    fn plist_without_the_key_yields_nothing() {
+        let plist = "<dict><key>ProductName</key><string>macOS</string></dict>";
+        assert!(parse_plist_string_value(plist, "ProductVersion").is_none());
+    }
+
+    #[test]
+    fn os_release_pretty_name_is_unquoted() {
+        let content = "NAME=\"Ubuntu\"\nPRETTY_NAME=\"Ubuntu 24.04.1 LTS\"\nID=ubuntu\n";
+        assert_eq!(
+            parse_os_release_pretty_name(content).as_deref(),
+            Some("Ubuntu 24.04.1 LTS")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn win11_build_upgrades_product_and_keeps_edition() {
+        // ProductName lies ("Windows 10") on Win11; build >= 22000 fixes it.
+        assert_eq!(
+            format_windows_version("Windows 10 Pro", "22631"),
+            "Windows 11 Pro 22631"
+        );
+        assert_eq!(
+            format_windows_version("Windows 10 Home", "22000"),
+            "Windows 11 Home 22000"
+        );
+        assert_eq!(
+            format_windows_version("Windows 10", "26100"),
+            "Windows 11 26100"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn win10_build_stays_windows_10() {
+        // 22000 is the threshold; anything below stays Windows 10.
+        assert_eq!(
+            format_windows_version("Windows 10 Pro", "19045"),
+            "Windows 10 Pro 19045"
+        );
+        assert_eq!(
+            format_windows_version("Windows 10 Pro", "21999"),
+            "Windows 10 Pro 21999"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn non_windows_10_product_is_left_alone() {
+        // Don't rewrite a product that doesn't start with "Windows 10".
+        assert_eq!(
+            format_windows_version("Windows Server 2022 Datacenter", "20348"),
+            "Windows Server 2022 Datacenter 20348"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn missing_build_falls_back_to_product_only() {
+        assert_eq!(
+            format_windows_version("Windows 10 Pro", ""),
+            "Windows 10 Pro"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn non_numeric_build_is_not_treated_as_win11() {
+        assert_eq!(
+            format_windows_version("Windows 10 Pro", "not-a-number"),
+            "Windows 10 Pro not-a-number"
+        );
+    }
+}

--- a/crates/accshift-core/src/telemetry/queue.rs
+++ b/crates/accshift-core/src/telemetry/queue.rs
@@ -1,10 +1,11 @@
 use super::client::{self, Mode};
 use super::events::{Event, TelemetryContext};
 use serde_json::Value;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 /// Consent state read at every flush to decide which mode to use.
 #[derive(Debug, Clone, Default)]
@@ -40,38 +41,68 @@ fn resolve_mode(state: &ConsentState) -> Option<(Mode, Option<String>)> {
 
 /// Internal messages consumed by the worker thread.
 enum Message {
-    Event(Event),
+    Event(Event, SystemTime),
     Shutdown,
 }
 
 /// Tuning parameters for the queue.
 pub struct QueueParams {
+    /// Delay before the first flush of the process.
+    ///
+    /// Short on purpose. Everything a launch produces (first_run,
+    /// app_launched, the snapshots) is emitted in the first second, and a
+    /// session shorter than the steady-state interval used to depend entirely
+    /// on the bounded flush at window close. Those are exactly the sessions of
+    /// someone who hit a bug and quit.
+    pub first_flush_interval: Duration,
+    /// Delay between flushes once the first one has happened.
     pub flush_interval: Duration,
+    /// Upper bound on the retry backoff after repeated failures.
+    pub max_backoff: Duration,
     pub max_batch_size: usize,
     pub endpoint: String,
+    /// Whether this queue emits the daily `ping`.
+    ///
+    /// False for the CLI: a short-lived process would emit one ping per
+    /// invocation and inflate the daily active count with what is really a
+    /// single user typing a command five times.
+    pub emit_ping: bool,
 }
 
 impl Default for QueueParams {
     fn default() -> Self {
         Self {
+            first_flush_interval: Duration::from_secs(20),
             flush_interval: Duration::from_secs(300), // 5 min
+            max_backoff: Duration::from_secs(3600),   // 1 h
             max_batch_size: 50,
             endpoint: client::TELEMETRY_URL.to_string(),
+            emit_ping: true,
         }
     }
 }
+
+/// Interval between two `ping` events while the process keeps running.
+const PING_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 
 /// Upper bound on queued messages. A slow flush (network timeout) must not
 /// let the channel grow without limit; overflow events are dropped.
 const QUEUE_CAPACITY: usize = 512;
 
+/// Upper bound on events held for retry.
+///
+/// The buffer now survives a failed flush, so it needs a ceiling of its own:
+/// a machine that is offline for a day would otherwise accumulate every event
+/// it ever produced. Oldest first, because a stale event is the least useful.
+const MAX_BUFFERED_EVENTS: usize = 200;
+
 /// Lightweight cloneable handle, usable from any thread or command.
 /// Used to push events or change consent.
-
 #[derive(Clone)]
 pub struct Handle {
     tx: SyncSender<Message>,
     consent: Arc<Mutex<ConsentState>>,
+    dropped: Arc<AtomicU64>,
 }
 
 impl Handle {
@@ -84,7 +115,16 @@ impl Handle {
                 return;
             }
         }
-        let _ = self.tx.try_send(Message::Event(event));
+        if self
+            .tx
+            .try_send(Message::Event(event, SystemTime::now()))
+            .is_err()
+        {
+            // A full channel means the worker is stuck on a slow flush. The
+            // event is lost, which is by design, but the loss is counted so
+            // the next ping can report it instead of silently skewing totals.
+            self.dropped.fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     /// Updates the consent state (called after a UI toggle or after the
@@ -107,14 +147,20 @@ impl Worker {
         let (tx, rx) = mpsc::sync_channel(QUEUE_CAPACITY);
         let consent = Arc::new(Mutex::new(consent));
         let consent_clone = consent.clone();
+        let dropped = Arc::new(AtomicU64::new(0));
+        let dropped_clone = dropped.clone();
 
         let join = thread::Builder::new()
             .name("accshift-telemetry".into())
-            .spawn(move || run(rx, ctx, consent_clone, params))
+            .spawn(move || run(rx, ctx, consent_clone, params, dropped_clone))
             .expect("telemetry thread spawn failed");
 
         Self {
-            handle: Handle { tx, consent },
+            handle: Handle {
+                tx,
+                consent,
+                dropped,
+            },
             join: Some(join),
         }
     }
@@ -144,11 +190,21 @@ impl Worker {
     }
 }
 
+/// Everything the worker loop carries between iterations.
+struct WorkerState {
+    buffer: Vec<(Event, SystemTime)>,
+    /// Consecutive failed flushes, used to space out retries.
+    consecutive_failures: u32,
+    /// None until the first ping of the process has been queued.
+    last_ping: Option<Instant>,
+}
+
 fn run(
     rx: Receiver<Message>,
     ctx: TelemetryContext,
     consent: Arc<Mutex<ConsentState>>,
     params: QueueParams,
+    dropped: Arc<AtomicU64>,
 ) {
     let http = match reqwest::blocking::Client::builder()
         .user_agent(client::user_agent(&ctx.app_version))
@@ -169,93 +225,203 @@ fn run(
     };
 
     let ua = client::user_agent(&ctx.app_version);
-    let mut buffer: Vec<Event> = Vec::new();
+    let mut state = WorkerState {
+        buffer: Vec::new(),
+        consecutive_failures: 0,
+        last_ping: None,
+    };
     let mut last_flush = Instant::now();
+    let mut next_interval = params.first_flush_interval;
 
     loop {
-        let remaining = params
-            .flush_interval
+        let remaining = next_interval
             .checked_sub(last_flush.elapsed())
             .unwrap_or(Duration::ZERO);
 
         match rx.recv_timeout(remaining) {
-            Ok(Message::Event(ev)) => {
-                buffer.push(ev);
-                if buffer.len() >= params.max_batch_size {
-                    flush(&http, &params.endpoint, &ua, &ctx, &consent, &mut buffer);
+            Ok(Message::Event(ev, at)) => {
+                push_bounded(&mut state.buffer, (ev, at), &dropped);
+                if state.buffer.len() >= params.max_batch_size {
+                    flush(&http, &params, &ua, &ctx, &consent, &mut state, &dropped);
                     last_flush = Instant::now();
+                    next_interval = retry_interval(&params, state.consecutive_failures);
                 }
             }
             Ok(Message::Shutdown) => {
-                flush(&http, &params.endpoint, &ua, &ctx, &consent, &mut buffer);
+                flush(&http, &params, &ua, &ctx, &consent, &mut state, &dropped);
                 return;
             }
             Err(RecvTimeoutError::Timeout) => {
-                flush(&http, &params.endpoint, &ua, &ctx, &consent, &mut buffer);
+                flush(&http, &params, &ua, &ctx, &consent, &mut state, &dropped);
                 last_flush = Instant::now();
+                next_interval = retry_interval(&params, state.consecutive_failures);
             }
             Err(RecvTimeoutError::Disconnected) => {
                 // All Senders have dropped; exit the loop.
-                flush(&http, &params.endpoint, &ua, &ctx, &consent, &mut buffer);
+                flush(&http, &params, &ua, &ctx, &consent, &mut state, &dropped);
                 return;
             }
         }
+    }
+}
+
+/// Appends an event, dropping the oldest one when the buffer is full.
+fn push_bounded(
+    buffer: &mut Vec<(Event, SystemTime)>,
+    entry: (Event, SystemTime),
+    dropped: &Arc<AtomicU64>,
+) {
+    if buffer.len() >= MAX_BUFFERED_EVENTS {
+        buffer.remove(0);
+        dropped.fetch_add(1, Ordering::Relaxed);
+    }
+    buffer.push(entry);
+}
+
+/// Delay before the next flush attempt.
+///
+/// Doubles per consecutive failure so a machine that has been offline for an
+/// hour stops retrying every five minutes, and is capped so it always comes
+/// back on its own once the network returns.
+fn retry_interval(params: &QueueParams, consecutive_failures: u32) -> Duration {
+    if consecutive_failures == 0 {
+        return params.flush_interval;
+    }
+    let factor = 1u32 << consecutive_failures.min(8);
+    params
+        .flush_interval
+        .saturating_mul(factor)
+        .min(params.max_backoff)
+}
+
+/// True when a `ping` is due: once at the first flush that has consent, then
+/// once a day for as long as the process lives.
+fn ping_is_due(last_ping: Option<Instant>) -> bool {
+    match last_ping {
+        None => true,
+        Some(at) => at.elapsed() >= PING_INTERVAL,
     }
 }
 
 fn flush(
     http: &reqwest::blocking::Client,
-    endpoint: &str,
+    params: &QueueParams,
     ua: &str,
     ctx: &TelemetryContext,
     consent: &Arc<Mutex<ConsentState>>,
-    buffer: &mut Vec<Event>,
+    state: &mut WorkerState,
+    dropped: &Arc<AtomicU64>,
 ) {
-    if buffer.is_empty() {
-        return;
-    }
     let snapshot = {
         let guard = consent.lock().unwrap_or_else(|e| e.into_inner());
         guard.clone()
     };
     let Some((mode, install_id)) = resolve_mode(&snapshot) else {
-        // Consent was revoked while events were queued; drop them.
-        buffer.clear();
+        // Consent was revoked (or never given) while events were queued; drop
+        // them. Checked before the ping below so an installation that has not
+        // completed onboarding never emits one.
+        state.buffer.clear();
         return;
     };
 
-    // AccountsSnapshot is documented (events.rs) as Mode B only: it must
+    // The ping is minted here rather than at startup: consent can arrive after
+    // the process does (onboarding), and a ping pushed before that would be
+    // dropped by `track` and leave the day uncounted.
+    if params.emit_ping && ping_is_due(state.last_ping) {
+        let dropped_events = dropped.swap(0, Ordering::Relaxed);
+        push_bounded(
+            &mut state.buffer,
+            (Event::Ping { dropped_events }, SystemTime::now()),
+            dropped,
+        );
+        state.last_ping = Some(Instant::now());
+    }
+
+    if state.buffer.is_empty() {
+        return;
+    }
+
+    // Snapshot events are documented (events.rs) as Mode B only: they must
     // never leave the process under Mode A, even though Mode A is otherwise
     // enabled. Drop just those events here rather than gating at track()
     // time, since the applicable mode is only known for certain at flush.
     if mode == Mode::A {
-        buffer.retain(|ev| !matches!(ev, Event::AccountsSnapshot { .. }));
-        if buffer.is_empty() {
+        state.buffer.retain(|(ev, _)| !ev.is_mode_b_only());
+        if state.buffer.is_empty() {
             return;
         }
     }
 
-    let events_json: Vec<Value> = buffer
+    let events_json: Vec<Value> = state
+        .buffer
         .iter()
-        .map(|ev| client::event_to_json(ev, ctx))
+        .map(|(ev, at)| client::event_to_json(ev, ctx, *at))
         .collect();
 
-    match client::send_batch(http, endpoint, ua, mode, install_id.as_deref(), events_json) {
+    match client::send_batch(
+        http,
+        &params.endpoint,
+        ua,
+        mode,
+        install_id.as_deref(),
+        events_json,
+    ) {
         Ok(()) => {
-            buffer.clear();
+            state.buffer.clear();
+            state.consecutive_failures = 0;
         }
         Err(_e) => {
-            // Mode A: drop on error (RAM-only by design, no on-disk persistence).
-            // Mode B: same, kept symmetric. Important events (ping,
-            // accounts_snapshot) will be re-emitted next cycle.
-            buffer.clear();
+            // Kept for the next attempt. Telemetry is still RAM-only: nothing
+            // is written to disk, and an app that closes before the network
+            // comes back forgets these events entirely. What changed is that a
+            // transient failure no longer costs a whole batch, which used to
+            // silently under-count every user with an unreliable connection.
+            state.consecutive_failures = state.consecutive_failures.saturating_add(1);
+            trim_to_capacity(&mut state.buffer, dropped);
         }
     }
+}
+
+/// Enforces the retry ceiling after a failure, oldest events first.
+fn trim_to_capacity(buffer: &mut Vec<(Event, SystemTime)>, dropped: &Arc<AtomicU64>) {
+    if buffer.len() <= MAX_BUFFERED_EVENTS {
+        return;
+    }
+    let excess = buffer.len() - MAX_BUFFERED_EVENTS;
+    buffer.drain(..excess);
+    dropped.fetch_add(excess as u64, Ordering::Relaxed);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_ctx() -> TelemetryContext {
+        TelemetryContext {
+            app_version: "0.0.0".into(),
+            os: "test".into(),
+            arch: "x86_64".into(),
+            os_version: "test".into(),
+            locale: None,
+            surface: "gui".into(),
+        }
+    }
+
+    /// Endpoint that refuses instantly, so a flush fails without a timeout.
+    fn unreachable_params() -> QueueParams {
+        QueueParams {
+            endpoint: "http://127.0.0.1:1/track".into(),
+            ..Default::default()
+        }
+    }
+
+    fn new_state(buffer: Vec<(Event, SystemTime)>) -> WorkerState {
+        WorkerState {
+            buffer,
+            consecutive_failures: 0,
+            last_ping: Some(Instant::now()),
+        }
+    }
 
     #[test]
     fn resolve_mode_picks_b_when_install_id_valid() {
@@ -324,38 +490,156 @@ mod tests {
     }
 
     #[test]
-    fn flush_drops_accounts_snapshot_under_mode_a() {
-        // AccountsSnapshot is documented as Mode B only (events.rs). Under
-        // Mode A it must be dropped rather than sent, even though Mode A
+    fn flush_drops_mode_b_only_events_under_mode_a() {
+        // Snapshot events are documented as Mode B only (events.rs). Under
+        // Mode A they must be dropped rather than sent, even though Mode A
         // itself is enabled and would otherwise flush fine.
         let http = reqwest::blocking::Client::new();
-        let ctx = TelemetryContext {
-            app_version: "0.0.0".into(),
-            os_version: "test".into(),
-            locale: None,
-        };
+        let ctx = test_ctx();
         let consent = Arc::new(Mutex::new(ConsentState {
             mode_a: true,
             mode_b: false,
             install_id: None,
             anonymous_id: None,
         }));
-        let mut buffer = vec![Event::AccountsSnapshot {
-            platform: "steam".into(),
-            count: 3,
-        }];
+        let dropped = Arc::new(AtomicU64::new(0));
+        let mut state = new_state(vec![
+            (
+                Event::AccountsSnapshot {
+                    platform: "steam".into(),
+                    count: 3,
+                },
+                SystemTime::now(),
+            ),
+            (
+                Event::SettingsSnapshot {
+                    ui_language: "fr".into(),
+                    enabled_platforms: vec!["steam".into()],
+                    personas_enabled: true,
+                    pin_enabled: false,
+                    cli_enabled: true,
+                    deep_links_enabled: true,
+                    streamer_mode: "auto".into(),
+                    animations: "system".into(),
+                },
+                SystemTime::now(),
+            ),
+        ]);
 
         flush(
             &http,
-            "http://127.0.0.1:0/track",
+            &unreachable_params(),
             "test-ua",
             &ctx,
             &consent,
-            &mut buffer,
+            &mut state,
+            &dropped,
         );
 
-        // The event was dropped locally (buffer emptied) before any network
-        // send was attempted; no request was made to the unreachable port.
-        assert!(buffer.is_empty());
+        // Dropped locally before any network send was attempted.
+        assert!(state.buffer.is_empty());
+        assert_eq!(state.consecutive_failures, 0);
+    }
+
+    #[test]
+    fn flush_without_consent_drops_and_never_pings() {
+        let http = reqwest::blocking::Client::new();
+        let consent = Arc::new(Mutex::new(ConsentState::default()));
+        let dropped = Arc::new(AtomicU64::new(0));
+        let mut state = WorkerState {
+            buffer: vec![(Event::DeepLinkUsed, SystemTime::now())],
+            consecutive_failures: 0,
+            last_ping: None,
+        };
+
+        flush(
+            &http,
+            &unreachable_params(),
+            "test-ua",
+            &test_ctx(),
+            &consent,
+            &mut state,
+            &dropped,
+        );
+
+        assert!(state.buffer.is_empty());
+        // An installation that never completed onboarding must not be counted
+        // as a daily active user.
+        assert!(state.last_ping.is_none());
+    }
+
+    #[test]
+    fn a_failed_flush_keeps_the_batch_for_the_next_attempt() {
+        let http = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_millis(200))
+            .connect_timeout(Duration::from_millis(200))
+            .build()
+            .unwrap();
+        let consent = Arc::new(Mutex::new(ConsentState {
+            mode_a: true,
+            mode_b: false,
+            install_id: None,
+            anonymous_id: Some("797f20fe-94de-4e89-98a2-ae3a3273ad1e".into()),
+        }));
+        let dropped = Arc::new(AtomicU64::new(0));
+        let mut state = new_state(vec![(
+            Event::AppLaunched { duration_ms: 10 },
+            SystemTime::now(),
+        )]);
+
+        flush(
+            &http,
+            &unreachable_params(),
+            "test-ua",
+            &test_ctx(),
+            &consent,
+            &mut state,
+            &dropped,
+        );
+
+        assert_eq!(state.buffer.len(), 1, "batch must survive a failed send");
+        assert_eq!(state.consecutive_failures, 1);
+    }
+
+    #[test]
+    fn the_ping_is_minted_once_then_once_a_day() {
+        assert!(ping_is_due(None));
+        assert!(!ping_is_due(Some(Instant::now())));
+    }
+
+    #[test]
+    fn backoff_grows_then_stops_at_the_ceiling() {
+        let params = QueueParams::default();
+        assert_eq!(retry_interval(&params, 0), params.flush_interval);
+        assert_eq!(retry_interval(&params, 1), params.flush_interval * 2);
+        assert_eq!(retry_interval(&params, 2), params.flush_interval * 4);
+        // Capped, and never zero: an offline machine still comes back on its
+        // own once the network returns.
+        assert_eq!(retry_interval(&params, 30), params.max_backoff);
+        assert!(retry_interval(&params, 30) > Duration::ZERO);
+    }
+
+    #[test]
+    fn the_buffer_has_a_ceiling_and_counts_what_it_drops() {
+        let dropped = Arc::new(AtomicU64::new(0));
+        let mut buffer = Vec::new();
+        for i in 0..(MAX_BUFFERED_EVENTS + 5) {
+            push_bounded(
+                &mut buffer,
+                (
+                    Event::AppLaunched {
+                        duration_ms: i as u64,
+                    },
+                    SystemTime::now(),
+                ),
+                &dropped,
+            );
+        }
+
+        assert_eq!(buffer.len(), MAX_BUFFERED_EVENTS);
+        assert_eq!(dropped.load(Ordering::Relaxed), 5);
+        // Oldest first: the five discarded events are the five oldest.
+        let first = &buffer[0].0;
+        assert!(matches!(first, Event::AppLaunched { duration_ms: 5 }));
     }
 }

--- a/crates/accshift-core/src/telemetry/time.rs
+++ b/crates/accshift-core/src/telemetry/time.rs
@@ -1,0 +1,106 @@
+//! RFC 3339 formatting for telemetry timestamps, without a date-time crate.
+//!
+//! Events carry the instant they happened rather than the instant their batch
+//! reached the server: a batch spans up to the flush interval, so a
+//! server-stamped time collapses several minutes of activity onto one point
+//! and loses the ordering with it.
+//!
+//! Second resolution on purpose. Milliseconds would add nothing to any
+//! dashboard and would sharpen the timing correlation between two events of
+//! the same anonymous batch.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Formats a `SystemTime` as `2026-08-04T12:34:56Z`.
+///
+/// A clock set before 1970 yields the epoch rather than an error: the Worker
+/// clamps implausible client timestamps anyway, and telemetry must never fail
+/// a caller.
+pub fn to_rfc3339_utc(t: SystemTime) -> String {
+    let secs = t
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    format_unix_seconds(secs)
+}
+
+/// Formats a Unix timestamp in seconds as RFC 3339 UTC.
+pub fn format_unix_seconds(secs: i64) -> String {
+    let days = secs.div_euclid(86_400);
+    let secs_of_day = secs.rem_euclid(86_400);
+    let (year, month, day) = civil_from_days(days);
+    let hours = secs_of_day / 3600;
+    let minutes = (secs_of_day % 3600) / 60;
+    let seconds = secs_of_day % 60;
+    format!("{year:04}-{month:02}-{day:02}T{hours:02}:{minutes:02}:{seconds:02}Z")
+}
+
+/// Days since the Unix epoch to a civil (year, month, day).
+///
+/// Howard Hinnant's `civil_from_days`, which shifts the year to start in March
+/// so the leap day lands last and the month-length pattern becomes a single
+/// linear expression. Correct for every proleptic Gregorian date, so no
+/// special-casing of leap years is needed here.
+fn civil_from_days(days: i64) -> (i64, u32, u32) {
+    // Shift the epoch to 0000-03-01, the start of a 400-year era.
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let day_of_era = z.rem_euclid(146_097);
+    let year_of_era =
+        (day_of_era - day_of_era / 1460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_prime = (5 * day_of_year + 2) / 153;
+    let day = (day_of_year - (153 * month_prime + 2) / 5 + 1) as u32;
+    let month = if month_prime < 10 {
+        month_prime + 3
+    } else {
+        month_prime - 9
+    } as u32;
+    (if month <= 2 { year + 1 } else { year }, month, day)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn formats_the_epoch() {
+        assert_eq!(format_unix_seconds(0), "1970-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn formats_a_known_instant() {
+        // 2026-08-04T12:34:56Z
+        assert_eq!(format_unix_seconds(1_785_846_896), "2026-08-04T12:34:56Z");
+    }
+
+    #[test]
+    fn handles_leap_days() {
+        // 2024-02-29T00:00:00Z
+        assert_eq!(format_unix_seconds(1_709_164_800), "2024-02-29T00:00:00Z");
+        // 2000-02-29, the century that is a leap year.
+        assert_eq!(format_unix_seconds(951_782_400), "2000-02-29T00:00:00Z");
+        // 1900 was not, so 2100-02-28 is followed by March.
+        assert_eq!(format_unix_seconds(4_107_542_400), "2100-03-01T00:00:00Z");
+    }
+
+    #[test]
+    fn handles_year_boundaries() {
+        assert_eq!(format_unix_seconds(1_767_225_599), "2025-12-31T23:59:59Z");
+        assert_eq!(format_unix_seconds(1_767_225_600), "2026-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn a_pre_epoch_clock_does_not_panic() {
+        let before = UNIX_EPOCH - Duration::from_secs(60);
+        assert_eq!(to_rfc3339_utc(before), "1970-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn system_time_round_trips_through_the_formatter() {
+        let stamp = to_rfc3339_utc(UNIX_EPOCH + Duration::from_secs(1_785_846_896));
+        assert_eq!(stamp, "2026-08-04T12:34:56Z");
+    }
+}

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -19,6 +19,11 @@ the counters, so turning those off is a separate and deliberate action. Said
 plainly, without dressing it up: **the anonymous tier is opt-out, the enhanced
 tier is opt-in.**
 
+The `accshift` command-line binary reads the same two switches. It reports one
+event per command, it never sends a daily ping (a command you run five times is
+one person, not five), and with both switches off it starts no reporting at
+all.
+
 ## What is never collected
 
 Accshift manages game accounts, so this list matters more than the one below it.
@@ -35,39 +40,69 @@ None of the following ever leaves your machine, in any mode:
 
 An event says "an account was added on Steam". It cannot say which account,
 because the app never puts that in the payload. The Rust code that builds the
-payload is 40 lines long and is linked at the bottom of this page.
+payload is one function, and it is linked at the bottom of this page.
 
 ## What is collected
 
-Nine events, and that is the complete list.
+Eighteen events, and that is the complete list.
 
-| Event                     | When                             | Fields beyond the common ones              |
-| ------------------------- | -------------------------------- | ------------------------------------------ |
-| `ping`                    | Once a day while the app runs    | none                                       |
-| `app_launched`            | Startup finished                 | `duration_ms`                              |
-| `platform_switch`         | You switched an account          | `platform`, `duration_ms`, success flag    |
-| `persona_switch`          | You activated a persona          | number of platforms, number that succeeded |
-| `account_added`           | You finished adding an account   | `platform`                                 |
-| `streamer_mode_activated` | Streamer mode auto-enabled       | none                                       |
-| `deep_link_used`          | An `accshift://` link was opened | none                                       |
-| `session_ended`           | You closed the window            | `duration_ms`                              |
-| `accounts_snapshot`       | Each app start, enhanced only    | `platform`, how many accounts on it        |
+| Event                     | When                                     | Fields beyond the common ones                                 |
+| ------------------------- | ---------------------------------------- | ------------------------------------------------------------- |
+| `ping`                    | Once a day while the app runs            | `dropped_events`, only if any were                            |
+| `first_run`               | The first launch of an installation      | none                                                          |
+| `app_launched`            | Startup finished                         | `duration_ms`                                                 |
+| `platform_switch`         | You switched an account                  | `platform`, `duration_ms`, `success`, `error_code` on failure |
+| `persona_switch`          | You activated a persona                  | number of platforms, number that succeeded                    |
+| `account_add_started`     | You opened an add-account flow           | `platform`                                                    |
+| `account_add_cancelled`   | You closed one without adding an account | `platform`                                                    |
+| `account_added`           | You finished adding an account           | `platform`                                                    |
+| `operation_failed`        | A named operation failed                 | `operation`, `error_code`, `platform`                         |
+| `update_available`        | An update was found                      | `target_version`                                              |
+| `update_downloaded`       | It finished downloading                  | `target_version`                                              |
+| `update_applied`          | It was installed                         | `target_version`                                              |
+| `update_failed`           | Any of the three above failed            | `target_version`, `error_code`                                |
+| `cli_command`             | A CLI command finished                   | `command`, `success`, `error_code`                            |
+| `streamer_mode_activated` | Streamer mode auto-enabled               | none                                                          |
+| `deep_link_used`          | An `accshift://` link was opened         | none                                                          |
+| `session_ended`           | You closed the window                    | `duration_ms`                                                 |
+| `accounts_snapshot`       | Each app start, enhanced only            | `platform`, how many accounts on it                           |
+| `settings_snapshot`       | Each app start, enhanced only            | the settings listed below                                     |
 
-Every event also carries three common fields: the app version, the OS version,
-and your locale (for example `fr_FR`). The server adds one more, the country
+One more event exists and is not in that table because it is not tied to an
+installation at all: `consent_choice`, recorded once when you answer the
+first-launch screen. It carries the answer and the app version, and lands on a
+single shared counter so the three possible answers have a denominator.
+
+Every event also carries seven common fields: the app version, a fixed OS
+identifier (`windows`, `macos`, `linux`), the architecture, the OS version,
+your locale (for example `fr-FR`), whether it came from the app or the CLI, and
+the time it happened, to the second. The server adds one more, the country
 code, derived from your IP address without storing the address itself.
 
 `platform` is always a fixed identifier like `steam` or `riot`, never anything
-you typed.
+you typed. So are `error_code`, `operation` and `command`: each is matched
+against a fixed list in the code, and anything unrecognised is recorded as
+`other` rather than sent as it was. That is what makes it impossible for an
+error message, which routinely contains a file path with your username in it,
+to travel inside one of those fields.
 
-`accounts_snapshot` is the only event that counts anything about your library,
-and it counts only how many accounts exist per platform. It is sent in enhanced
-mode only: the app drops it before upload in anonymous mode.
+`accounts_snapshot` counts how many accounts exist per platform, and nothing
+else about your library. `settings_snapshot` reports your interface language,
+which platforms are enabled, and whether personas, the PIN lock, the CLI and
+deep links are on. No theme name, because a custom theme is one you named
+yourself. Both are sent in enhanced mode only: the app drops them before upload
+in anonymous mode. Nine low-entropy settings together are a weak fingerprint,
+and the anonymous tier exists precisely so that two events cannot be tied to
+one installation across days.
 
-Every release up to and including 1.0.2 skipped Steam in this event, because the
-list it was built from only covered platforms whose accounts live in the config
-file. Snapshots recorded by those releases say nothing about Steam, in either
-direction.
+Every release up to and including 1.0.2 skipped Steam in `accounts_snapshot`,
+because the list it was built from only covered platforms whose accounts live
+in the config file. Snapshots recorded by those releases say nothing about
+Steam, in either direction.
+
+`first_run` means "first launch that knew how to report one", so for an
+installation that predates the release introducing it, it fires on the first
+launch after the update rather than on the day it was installed.
 
 This table is checked against the code on every release. Where this page and the
 code disagree, the code is right and the page is a bug worth reporting.
@@ -84,25 +119,42 @@ This is a real batch, exactly as it leaves the machine in anonymous mode:
     {
       "name": "ping",
       "app_version": "1.4.2",
-      "os_version": "Windows 11 (10.0.26200)",
-      "locale": "fr_FR"
+      "os": "windows",
+      "arch": "x86_64",
+      "os_version": "Windows 11 Pro 26200",
+      "surface": "gui",
+      "client_ts": "2026-08-04T12:34:56Z",
+      "locale": "fr-FR"
     },
     {
       "name": "platform_switch",
       "app_version": "1.4.2",
-      "os_version": "Windows 11 (10.0.26200)",
-      "locale": "fr_FR",
+      "os": "windows",
+      "arch": "x86_64",
+      "os_version": "Windows 11 Pro 26200",
+      "surface": "gui",
+      "client_ts": "2026-08-04T12:36:02Z",
+      "locale": "fr-FR",
       "platform": "steam",
       "duration_ms": 842,
+      "success": true,
       "count": 1
     }
   ]
 }
 ```
 
-That is the whole thing. Batches are sent at most once every five minutes and
-are held in memory only: telemetry is never written to your disk, so an app that
-never reaches the network simply forgets its events.
+That is the whole thing. `count` duplicates `success` here for one boring
+reason: it carried the success flag before `success` existed, and the
+dashboards built against it still read it.
+
+Batches are sent at most once every five minutes, the first one about twenty
+seconds after launch, and are held in memory only: telemetry is never written
+to your disk, so an app that never reaches the network simply forgets its
+events. A batch that fails to send is kept in memory and retried, with the
+delay doubling up to an hour; at most 200 events are held that way, and the
+oldest are discarded past that. `ping` reports how many were lost, which is the
+only reason that count exists.
 
 ## The two switches
 
@@ -186,14 +238,17 @@ the app.
 Nothing here has to be taken on trust. The code that decides what is sent is
 small and self-contained:
 
-| What                                     | Where                                                                                             |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| The event list and every field           | [`crates/accshift-core/src/telemetry/events.rs`](../crates/accshift-core/src/telemetry/events.rs) |
-| The exact payload built for the network  | [`crates/accshift-core/src/telemetry/client.rs`](../crates/accshift-core/src/telemetry/client.rs) |
-| The queue, and why it never touches disk | [`crates/accshift-core/src/telemetry/queue.rs`](../crates/accshift-core/src/telemetry/queue.rs)   |
-| The consent gate                         | [`crates/accshift-core/src/telemetry/mod.rs`](../crates/accshift-core/src/telemetry/mod.rs)       |
-| The server, in full                      | [`server/src/index.ts`](../server/src/index.ts)                                                   |
-| The server's own README                  | [`server/README.md`](../server/README.md)                                                         |
+| What                                        | Where                                                                                                           |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| The event list and every field              | [`crates/accshift-core/src/telemetry/events.rs`](../crates/accshift-core/src/telemetry/events.rs)               |
+| The fixed vocabularies codes are matched to | [`crates/accshift-core/src/telemetry/events.rs`](../crates/accshift-core/src/telemetry/events.rs)               |
+| The exact payload built for the network     | [`crates/accshift-core/src/telemetry/client.rs`](../crates/accshift-core/src/telemetry/client.rs)               |
+| The queue, and why it never touches disk    | [`crates/accshift-core/src/telemetry/queue.rs`](../crates/accshift-core/src/telemetry/queue.rs)                 |
+| The consent gate                            | [`crates/accshift-core/src/telemetry/mod.rs`](../crates/accshift-core/src/telemetry/mod.rs)                     |
+| What the OS fields are read from            | [`crates/accshift-core/src/telemetry/platform_info.rs`](../crates/accshift-core/src/telemetry/platform_info.rs) |
+| The CLI's own reporting                     | [`crates/accshift-cli/src/telemetry.rs`](../crates/accshift-cli/src/telemetry.rs)                               |
+| The server, in full                         | [`server/src/index.ts`](../server/src/index.ts)                                                                 |
+| The server's own README                     | [`server/README.md`](../server/README.md)                                                                       |
 
 This page is versioned alongside the code it describes, so `git log` on it shows
 every change ever made to what gets collected.

--- a/server/README.md
+++ b/server/README.md
@@ -75,6 +75,17 @@ The app could POST to PostHog itself. It does not, for four reasons:
   retention metrics, cohorts and per-installation deletion possible, and it is
   why it is a separate opt-in.
 - Country is stored as an event property.
+- Every property is validated in `buildBatch` before it is forwarded, and any
+  property not written there cannot reach PostHog at all. Codes must match
+  `[a-z0-9_]{1,40}`, platform ids `[a-z0-9_-]{1,32}`, versions
+  `[A-Za-z0-9.+-]{1,32}`; counts must be finite and non-negative. The app maps
+  these onto closed vocabularies before sending, and this is the half of that
+  guarantee that does not assume the client is the one we shipped.
+- Events are stored under `client_ts`, the instant they happened on the
+  machine, when it parses and sits within 24 hours of the Worker's clock.
+  Otherwise they fall back to arrival time. A batch covers up to five minutes,
+  so stamping it all at arrival used to flatten that window onto one point and
+  lose the ordering inside it.
 - Onboarding choices store no identifier at all. Even a refusal is recorded
   against a single shared aggregate id, never one tied to an installation.
 - Anti-abuse rate limiting masks IPs (/24 v4, /48 v6) in alert emails.

--- a/server/src/index.test.ts
+++ b/server/src/index.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { buildBatch, maskIp, readJsonCapped, redactUuids, type TelemetryEvent } from "./index";
+import {
+  buildBatch,
+  eventTimestamp,
+  maskIp,
+  readJsonCapped,
+  redactUuids,
+  type TelemetryEvent,
+} from "./index";
 
 function streamingRequest(chunks: Uint8Array[], contentLength?: number): Request {
   const stream = new ReadableStream<Uint8Array>({
@@ -136,6 +143,128 @@ describe("buildBatch", () => {
     expect(item!.properties).not.toHaveProperty("platform");
     expect(item!.properties).not.toHaveProperty("duration_ms");
     expect(item!.properties).not.toHaveProperty("count");
+  });
+
+  it("forwards the new event properties the app reports", () => {
+    const failed: TelemetryEvent = {
+      name: "platform_switch",
+      app_version: "1.2.3",
+      os_version: "Windows 11",
+      os: "windows",
+      arch: "x86_64",
+      surface: "gui",
+      platform: "battle-net",
+      duration_ms: 900,
+      count: 0,
+      success: false,
+      error_code: "client_running",
+    };
+    const [item] = buildBatch("A", [failed], IDS, "FR", TS);
+
+    expect(item!.properties.os).toBe("windows");
+    expect(item!.properties.arch).toBe("x86_64");
+    expect(item!.properties.surface).toBe("gui");
+    // The dashed registry id has to survive verbatim; renaming it on the wire
+    // would break the dashboards a second time.
+    expect(item!.properties.platform).toBe("battle-net");
+    expect(item!.properties.success).toBe(false);
+    expect(item!.properties.error_code).toBe("client_running");
+  });
+
+  it("drops a property whose shape is not the one the app sends", () => {
+    // A modified client is the threat here: the app maps these onto closed
+    // vocabularies, and this is the half of that guarantee that does not
+    // depend on the client being ours.
+    const hostile = {
+      name: "operation_failed",
+      app_version: "1.2.3",
+      os_version: "Windows 11",
+      operation: "account_add",
+      error_code: "C:\\Users\\alice\\steam missing",
+      platform: "steam; DROP TABLE",
+      enabled_platforms: ["steam", "../../etc/passwd"],
+      duration_ms: -5,
+      target_version: "<script>alert(1)</script>",
+    } as unknown as TelemetryEvent;
+    const [item] = buildBatch("A", [hostile], IDS, "FR", TS);
+
+    expect(item!.properties.operation).toBe("account_add");
+    expect(item!.properties).not.toHaveProperty("error_code");
+    expect(item!.properties).not.toHaveProperty("platform");
+    expect(item!.properties).not.toHaveProperty("duration_ms");
+    expect(item!.properties).not.toHaveProperty("target_version");
+    // The valid entries of a list survive; the rest is discarded.
+    expect(item!.properties.enabled_platforms).toEqual(["steam"]);
+  });
+
+  it("keeps a settings snapshot as booleans and codes", () => {
+    const snapshot: TelemetryEvent = {
+      name: "settings_snapshot",
+      app_version: "1.2.3",
+      os_version: "Windows 11",
+      ui_language: "pt_br",
+      enabled_platforms: ["steam", "riot"],
+      personas_enabled: true,
+      pin_enabled: false,
+      cli_enabled: true,
+      deep_links_enabled: true,
+      streamer_mode: "auto",
+      animations: "system",
+    };
+    const [item] = buildBatch("B", [snapshot], IDS, "BR", TS);
+
+    expect(item!.properties.ui_language).toBe("pt_br");
+    expect(item!.properties.enabled_platforms).toEqual(["steam", "riot"]);
+    expect(item!.properties.pin_enabled).toBe(false);
+    // False must survive: `if (ev.pin_enabled)` would have dropped it.
+    expect(item!.properties).toHaveProperty("pin_enabled");
+  });
+
+  it("stamps each event with the instant it happened", () => {
+    const first = { ...launch, client_ts: "2026-01-15T09:58:01Z" };
+    const second = { ...launch, client_ts: "2026-01-15T09:59:47Z" };
+    const batch = buildBatch("A", [first, second], IDS, "FR", TS);
+
+    // Both events arrived in the same batch; flattening them onto TS would
+    // lose the ordering and the two minutes between them.
+    expect(batch[0]!.timestamp).toBe("2026-01-15T09:58:01Z");
+    expect(batch[1]!.timestamp).toBe("2026-01-15T09:59:47Z");
+  });
+
+  it("falls back to arrival time when the client clock is unusable", () => {
+    const batch = buildBatch(
+      "A",
+      [
+        { ...launch, client_ts: "2031-01-15T10:00:00Z" },
+        { ...launch, client_ts: "not-a-timestamp" },
+        { ...launch },
+      ],
+      IDS,
+      "FR",
+      TS,
+    );
+
+    for (const item of batch) expect(item.timestamp).toBe(TS);
+  });
+});
+
+describe("eventTimestamp", () => {
+  const SERVER = "2026-01-15T10:00:00.000Z";
+
+  it("trusts a plausible client timestamp", () => {
+    expect(eventTimestamp("2026-01-15T09:55:00Z", SERVER)).toBe("2026-01-15T09:55:00Z");
+  });
+
+  it("rejects a timestamp beyond a day of skew in either direction", () => {
+    expect(eventTimestamp("2026-01-13T10:00:00Z", SERVER)).toBe(SERVER);
+    expect(eventTimestamp("2026-01-17T10:00:00Z", SERVER)).toBe(SERVER);
+  });
+
+  it("rejects anything that is not the exact wire format", () => {
+    expect(eventTimestamp("2026-01-15T10:00:00.123Z", SERVER)).toBe(SERVER);
+    expect(eventTimestamp("2026-01-15 10:00:00", SERVER)).toBe(SERVER);
+    expect(eventTimestamp(42, SERVER)).toBe(SERVER);
+    expect(eventTimestamp(undefined, SERVER)).toBe(SERVER);
   });
 });
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -57,10 +57,35 @@ export interface TelemetryEvent {
   name: string;
   app_version: string;
   os_version: string;
+  // Fixed identifiers, so grouping by platform no longer means parsing
+  // `os_version` prose on the dashboard side.
+  os?: string;
+  arch?: string;
+  surface?: string;
   locale?: string;
+  // When the event happened on the client, RFC 3339 UTC with second
+  // resolution. A batch spans up to five minutes, so stamping every event
+  // with its arrival time collapsed that window onto one point.
+  client_ts?: string;
   platform?: string;
   duration_ms?: number;
   count?: number;
+  success?: boolean;
+  succeeded?: number;
+  platforms?: number;
+  dropped_events?: number;
+  error_code?: string;
+  operation?: string;
+  target_version?: string;
+  command?: string;
+  ui_language?: string;
+  enabled_platforms?: string[];
+  personas_enabled?: boolean;
+  pin_enabled?: boolean;
+  cli_enabled?: boolean;
+  deep_links_enabled?: boolean;
+  streamer_mode?: string;
+  animations?: string;
 }
 
 interface TrackPayload {
@@ -405,6 +430,64 @@ export interface BatchIdentifiers {
   pingIdentifier: string;
 }
 
+// ─── Property validation ─────────────────────────────────────────
+//
+// Everything below runs on a payload a modified client could have written, so
+// each value is checked for shape before it is forwarded. The app already
+// maps these fields onto closed vocabularies; this is the half of that
+// guarantee that does not depend on the client being the one we shipped.
+
+const CODE_RE = /^[a-z0-9_]{1,40}$/;
+const PLATFORM_RE = /^[a-z0-9_-]{1,32}$/;
+const VERSION_RE = /^[A-Za-z0-9.+-]{1,32}$/;
+const CLIENT_TS_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
+
+const MAX_ENABLED_PLATFORMS = 16;
+
+/// How far a client timestamp may sit from the server's clock.
+///
+/// A wrong client clock is common (a machine fresh out of a long sleep, a
+/// dual-boot with local-time RTC). Beyond a day the value stops being a
+/// better estimate than arrival time and starts dragging events into weeks
+/// that never happened, so it is dropped rather than trusted.
+const MAX_CLOCK_SKEW_MS = 24 * 60 * 60 * 1000;
+
+function code(value: unknown): string | undefined {
+  return typeof value === "string" && CODE_RE.test(value) ? value : undefined;
+}
+
+function platformId(value: unknown): string | undefined {
+  return typeof value === "string" && PLATFORM_RE.test(value) ? value : undefined;
+}
+
+function version(value: unknown): string | undefined {
+  return typeof value === "string" && VERSION_RE.test(value) ? value : undefined;
+}
+
+function count(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function flag(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function platformList(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const ids = value.map(platformId).filter((id): id is string => id !== undefined);
+  return ids.length === 0 ? undefined : ids.slice(0, MAX_ENABLED_PLATFORMS);
+}
+
+// Picks the timestamp an event is stored under: the client's own, when it is
+// well-formed and plausible, otherwise the moment the batch arrived.
+export function eventTimestamp(clientTs: unknown, serverIso: string): string {
+  if (typeof clientTs !== "string" || !CLIENT_TS_RE.test(clientTs)) return serverIso;
+  const parsed = Date.parse(clientTs);
+  const server = Date.parse(serverIso);
+  if (!Number.isFinite(parsed) || !Number.isFinite(server)) return serverIso;
+  return Math.abs(parsed - server) > MAX_CLOCK_SKEW_MS ? serverIso : clientTs;
+}
+
 // Turns a validated /track payload into PostHog batch items.
 //
 // Pure on purpose: this is where the privacy model becomes concrete bytes, so
@@ -432,11 +515,37 @@ export function buildBatch(
       os_version: ev.os_version ?? "",
     };
     // Optional fields are omitted rather than sent empty, so an absent value
-    // stays distinguishable from an empty one on the dashboard side.
-    if (ev.locale) properties.locale = ev.locale;
-    if (ev.platform) properties.platform = ev.platform;
-    if (typeof ev.duration_ms === "number") properties.duration_ms = ev.duration_ms;
-    if (typeof ev.count === "number") properties.count = ev.count;
+    // stays distinguishable from an empty one on the dashboard side. Each one
+    // is validated: this function is the only place a property can be written,
+    // so anything not listed here cannot reach PostHog at all.
+    const optional: Array<[string, unknown]> = [
+      ["os", code(ev.os)],
+      ["arch", code(ev.arch)],
+      ["surface", code(ev.surface)],
+      ["locale", typeof ev.locale === "string" && ev.locale.length <= 35 ? ev.locale : undefined],
+      ["platform", platformId(ev.platform)],
+      ["duration_ms", count(ev.duration_ms)],
+      ["count", count(ev.count)],
+      ["success", flag(ev.success)],
+      ["succeeded", count(ev.succeeded)],
+      ["platforms", count(ev.platforms)],
+      ["dropped_events", count(ev.dropped_events)],
+      ["error_code", code(ev.error_code)],
+      ["operation", code(ev.operation)],
+      ["target_version", version(ev.target_version)],
+      ["command", code(ev.command)],
+      ["ui_language", code(ev.ui_language)],
+      ["enabled_platforms", platformList(ev.enabled_platforms)],
+      ["personas_enabled", flag(ev.personas_enabled)],
+      ["pin_enabled", flag(ev.pin_enabled)],
+      ["cli_enabled", flag(ev.cli_enabled)],
+      ["deep_links_enabled", flag(ev.deep_links_enabled)],
+      ["streamer_mode", code(ev.streamer_mode)],
+      ["animations", code(ev.animations)],
+    ];
+    for (const [key, value] of optional) {
+      if (value !== undefined) properties[key] = value;
+    }
     // Person properties are Mode B only, by construction: Mode A has no person
     // to attach them to.
     if (isModeB) {
@@ -447,7 +556,12 @@ export function buildBatch(
         ...(ev.locale ? { locale: ev.locale } : {}),
       };
     }
-    return { event: ev.name, distinct_id: distinctId, timestamp, properties };
+    return {
+      event: ev.name,
+      distinct_id: distinctId,
+      timestamp: eventTimestamp(ev.client_ts, timestamp),
+      properties,
+    };
   });
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -161,21 +161,44 @@ pub fn finish_boot(
     };
     let _ = crate::logging::append_app_log(&ctx(&app_handle), "info", &source, message, None);
 
-    // Telemetry: first boot completion triggers app_launched, ping, accounts_snapshot.
+    // Telemetry: first boot completion triggers first_run, app_launched and
+    // accounts_snapshot. `ping` is not emitted here: the queue owns it, so
+    // that an app left open for three days reports three days instead of one.
     if was_first_completion {
         let duration_ms = tstate
             .app_start
             .elapsed()
             .as_millis()
             .min(u128::from(u64::MAX)) as u64;
+        emit_first_run_once(&app_handle, &tstate);
         tstate
             .handle
             .track(telemetry::Event::AppLaunched { duration_ms });
-        tstate.handle.track(telemetry::Event::Ping);
         emit_accounts_snapshots(&app_handle, &tstate);
     }
 
     crate::app_runtime::show_main_window(&app_handle)
+}
+
+/// Emits `first_run` on the first launch that has consent, then never again.
+///
+/// The flag is only persisted when the event was actually queued. An
+/// installation that turns telemetry on later still reports its first run at
+/// the next launch, rather than having burned the event while nothing was
+/// being sent.
+fn emit_first_run_once(app_handle: &tauri::AppHandle, tstate: &TelemetryState) {
+    let c = ctx(app_handle);
+    let cfg = crate::config::load_config(&c);
+    if cfg.telemetry.first_run_reported || !cfg.telemetry.onboarding_completed {
+        return;
+    }
+    if !cfg.telemetry.mode_a_enabled && !cfg.telemetry.mode_b_enabled {
+        return;
+    }
+    tstate.handle.track(telemetry::Event::FirstRun);
+    let _ = crate::config::update_config(&c, |current| {
+        current.telemetry.first_run_reported = true;
+    });
 }
 
 /// Emits one `accounts_snapshot` per non-empty platform.
@@ -344,10 +367,18 @@ pub async fn platform_switch_account(
     .await;
     let duration_ms = t0.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
     let tstate = app_handle.state::<TelemetryState>();
+    // A switch that failed used to be indistinguishable from any other failed
+    // switch, which made "what should I fix first" unanswerable. The code is
+    // the typed error family, never the message.
+    let error_code = result
+        .as_ref()
+        .err()
+        .map(|e| telemetry::error_code_for_kind(e.kind).to_string());
     tstate.handle.track(telemetry::Event::PlatformSwitch {
         platform: platform_for_event,
         duration_ms,
         success: result.is_ok(),
+        error_code,
     });
     result
 }

--- a/src-tauri/src/commands_telemetry.rs
+++ b/src-tauri/src/commands_telemetry.rs
@@ -211,6 +211,101 @@ pub fn telemetry_track_account_added(app_handle: tauri::AppHandle, platform_id: 
     });
 }
 
+/// Records the opening of an add-account flow, so the abandonment rate of a
+/// platform's setup becomes visible instead of only its successes.
+#[tauri::command]
+pub fn telemetry_track_account_add_started(app_handle: tauri::AppHandle, platform_id: String) {
+    let tstate = app_handle.state::<TelemetryState>();
+    tstate.handle.track(telemetry::Event::AccountAddStarted {
+        platform: platform_id,
+    });
+}
+
+/// Records an add-account flow abandoned before it produced an account.
+#[tauri::command]
+pub fn telemetry_track_account_add_cancelled(app_handle: tauri::AppHandle, platform_id: String) {
+    let tstate = app_handle.state::<TelemetryState>();
+    tstate.handle.track(telemetry::Event::AccountAddCancelled {
+        platform: platform_id,
+    });
+}
+
+/// Records a failed operation. Both `operation` and `error_code` are mapped
+/// onto closed vocabularies before they leave the process, so a caller cannot
+/// turn either into a free-text field.
+#[tauri::command]
+pub fn telemetry_track_operation_failed(
+    app_handle: tauri::AppHandle,
+    operation: String,
+    error_code: String,
+    platform_id: Option<String>,
+) {
+    let tstate = app_handle.state::<TelemetryState>();
+    tstate.handle.track(telemetry::Event::OperationFailed {
+        operation,
+        platform: platform_id,
+        error_code,
+    });
+}
+
+/// Records a stage of the updater flow.
+///
+/// An update that fails silently used to look exactly like a user who stopped
+/// launching the app: both simply stop reporting a new `app_version`.
+#[tauri::command]
+pub fn telemetry_track_update(
+    app_handle: tauri::AppHandle,
+    stage: String,
+    target_version: Option<String>,
+    error_code: Option<String>,
+) {
+    let stage = match stage.as_str() {
+        "available" => telemetry::UpdateStage::Available,
+        "downloaded" => telemetry::UpdateStage::Downloaded,
+        "applied" => telemetry::UpdateStage::Applied,
+        "failed" => telemetry::UpdateStage::Failed,
+        // An unknown stage is a frontend bug, not a user event.
+        _ => return,
+    };
+    let tstate = app_handle.state::<TelemetryState>();
+    tstate.handle.track(telemetry::Event::Update {
+        stage,
+        target_version,
+        error_code,
+    });
+}
+
+/// Records the non-identifying app settings once per launch.
+///
+/// Mode B only, enforced by the queue: nine low-entropy fields together are a
+/// weak fingerprint, and Mode A exists so that two events cannot be tied to
+/// one installation across days.
+#[allow(clippy::too_many_arguments)]
+#[tauri::command]
+pub fn telemetry_track_settings_snapshot(
+    app_handle: tauri::AppHandle,
+    ui_language: String,
+    enabled_platforms: Vec<String>,
+    personas_enabled: bool,
+    pin_enabled: bool,
+    cli_enabled: bool,
+    deep_links_enabled: bool,
+    streamer_mode: String,
+    animations: String,
+) {
+    let tstate = app_handle.state::<TelemetryState>();
+    tstate.handle.track(telemetry::Event::SettingsSnapshot {
+        ui_language,
+        enabled_platforms,
+        personas_enabled,
+        pin_enabled,
+        cli_enabled,
+        deep_links_enabled,
+        streamer_mode,
+        animations,
+    });
+}
+
 /// Records a streamer-mode overlay auto-activation. No payload.
 #[tauri::command]
 pub fn telemetry_track_streamer_mode(app_handle: tauri::AppHandle) {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -449,6 +449,11 @@ fn main() {
             commands_telemetry::telemetry_complete_onboarding,
             commands_telemetry::telemetry_track_persona_switch,
             commands_telemetry::telemetry_track_account_added,
+            commands_telemetry::telemetry_track_account_add_started,
+            commands_telemetry::telemetry_track_account_add_cancelled,
+            commands_telemetry::telemetry_track_operation_failed,
+            commands_telemetry::telemetry_track_update,
+            commands_telemetry::telemetry_track_settings_snapshot,
             commands_telemetry::telemetry_track_streamer_mode,
             commands_telemetry::telemetry_export,
         ])

--- a/src-tauri/src/telemetry_runtime.rs
+++ b/src-tauri/src/telemetry_runtime.rs
@@ -4,7 +4,7 @@
 //! and offers a clean shutdown path on window close.
 
 use accshift_core::context::AppContext;
-use accshift_core::telemetry::{self, Handle, QueueParams, TelemetryContext, Worker};
+use accshift_core::telemetry::{self, Handle, QueueParams, Worker};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
@@ -35,11 +35,7 @@ impl TelemetryState {
             }
         }
         let consent = telemetry::consent_from_config(&cfg.telemetry);
-        let tctx = TelemetryContext {
-            app_version: env!("CARGO_PKG_VERSION").to_string(),
-            os_version: detect_os_version(),
-            locale: telemetry::detect_locale(),
-        };
+        let tctx = telemetry::context_for(env!("CARGO_PKG_VERSION"), "gui");
         let worker = Worker::spawn(tctx, consent, QueueParams::default());
         Self {
             handle: worker.handle(),
@@ -56,78 +52,18 @@ impl TelemetryState {
             guard.take()
         };
         if let Some(worker) = taken {
-            worker.shutdown(Duration::from_millis(1500));
+            worker.shutdown(SHUTDOWN_FLUSH_DEADLINE);
         }
     }
 }
 
-#[cfg(windows)]
-pub fn detect_os_version() -> String {
-    use winreg::enums::HKEY_LOCAL_MACHINE;
-    use winreg::RegKey;
-    let Ok(key) = RegKey::predef(HKEY_LOCAL_MACHINE)
-        .open_subkey("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion")
-    else {
-        return "Windows".to_string();
-    };
-    let product: String = key
-        .get_value::<String, _>("ProductName")
-        .unwrap_or_else(|_| "Windows".into());
-    let build: String = key
-        .get_value::<String, _>("CurrentBuildNumber")
-        .unwrap_or_default();
-    format_windows_version(&product, &build)
-}
-
-/// Combines the registry `ProductName` and `CurrentBuildNumber` into a display
-/// string. Pure so it can be unit-tested without the registry.
+/// How long window close waits for the final flush.
 ///
-/// ProductName stays "Windows 10" on Win11; the build number is the only
-/// reliable discriminator. Builds >= 22000 are Windows 11, so a leading
-/// "Windows 10" is rewritten to "Windows 11" while keeping the edition suffix
-/// (e.g. "Windows 10 Pro" -> "Windows 11 Pro"). The build number is kept.
-#[cfg(windows)]
-fn format_windows_version(product: &str, build: &str) -> String {
-    let mut product = product.to_string();
-    if build.parse::<u32>().is_ok_and(|n| n >= 22000) {
-        if let Some(suffix) = product.strip_prefix("Windows 10") {
-            product = format!("Windows 11{suffix}");
-        }
-    }
-    if build.is_empty() {
-        product
-    } else {
-        format!("{product} {build}")
-    }
-}
-
-#[cfg(target_os = "linux")]
-pub fn detect_os_version() -> String {
-    let arch = std::env::consts::ARCH;
-    // Prefer /etc/os-release PRETTY_NAME (e.g. "CachyOS Linux", "Ubuntu 24.04").
-    if let Ok(content) = std::fs::read_to_string("/etc/os-release") {
-        for line in content.lines() {
-            let Some((key, value)) = line.split_once('=') else {
-                continue;
-            };
-            if key != "PRETTY_NAME" {
-                continue;
-            }
-            let trimmed = value.trim().trim_matches('"').trim_matches('\'');
-            if !trimmed.is_empty() {
-                return format!("{trimmed} {arch}");
-            }
-        }
-    }
-    format!("Linux {arch}")
-}
-
-#[cfg(all(not(windows), not(target_os = "linux")))]
-pub fn detect_os_version() -> String {
-    let os = std::env::consts::OS;
-    let arch = std::env::consts::ARCH;
-    format!("{os} {arch}")
-}
+/// The window is already hidden when this runs, so the cost is a process that
+/// lingers, not a frozen UI. Long enough for one request on a normal link and
+/// still bounded, because the HTTP client alone would wait five seconds to
+/// find out a connection is going nowhere.
+const SHUTDOWN_FLUSH_DEADLINE: Duration = Duration::from_millis(2500);
 
 /// Reads the latest persisted config and pushes the resulting consent to the
 /// worker. Call after any UI mutation to the telemetry toggles.
@@ -135,64 +71,4 @@ pub fn refresh_consent_from_config(state: &TelemetryState, ctx: &dyn AppContext)
     let cfg = accshift_core::config::load_config(ctx);
     let consent = telemetry::consent_from_config(&cfg.telemetry);
     state.handle.update_consent(consent);
-}
-
-#[cfg(all(test, windows))]
-mod tests {
-    use super::format_windows_version;
-
-    #[test]
-    fn win11_build_upgrades_product_and_keeps_edition() {
-        // ProductName lies ("Windows 10") on Win11; build >= 22000 fixes it.
-        assert_eq!(
-            format_windows_version("Windows 10 Pro", "22631"),
-            "Windows 11 Pro 22631"
-        );
-        assert_eq!(
-            format_windows_version("Windows 10 Home", "22000"),
-            "Windows 11 Home 22000"
-        );
-        assert_eq!(
-            format_windows_version("Windows 10", "26100"),
-            "Windows 11 26100"
-        );
-    }
-
-    #[test]
-    fn win10_build_stays_windows_10() {
-        // 22000 is the threshold; anything below stays Windows 10.
-        assert_eq!(
-            format_windows_version("Windows 10 Pro", "19045"),
-            "Windows 10 Pro 19045"
-        );
-        assert_eq!(
-            format_windows_version("Windows 10 Pro", "21999"),
-            "Windows 10 Pro 21999"
-        );
-    }
-
-    #[test]
-    fn non_windows_10_product_is_left_alone() {
-        // Don't rewrite a product that doesn't start with "Windows 10".
-        assert_eq!(
-            format_windows_version("Windows Server 2022 Datacenter", "20348"),
-            "Windows Server 2022 Datacenter 20348"
-        );
-    }
-
-    #[test]
-    fn missing_build_falls_back_to_product_only() {
-        assert_eq!(
-            format_windows_version("Windows 10 Pro", ""),
-            "Windows 10 Pro"
-        );
-    }
-
-    #[test]
-    fn non_numeric_build_is_not_treated_as_win11() {
-        assert_eq!(
-            format_windows_version("Windows 10 Pro", "not-a-number"),
-            "Windows 10 Pro not-a-number"
-        );
-    }
 }

--- a/src/lib/app/platformAddFlow.svelte.ts
+++ b/src/lib/app/platformAddFlow.svelte.ts
@@ -1,4 +1,9 @@
-import { invoke } from "@tauri-apps/api/core";
+import {
+  trackAccountAdded,
+  trackAccountAddCancelled,
+  trackAccountAddStarted,
+  trackOperationFailed,
+} from "$lib/app/telemetryClient";
 import type { PlatformAccount, PlatformAddFlowStatus } from "$lib/shared/platform";
 import type { CardExtensionContent } from "$lib/shared/cardExtension";
 import { getPlatform } from "$lib/shared/platform";
@@ -111,6 +116,11 @@ export function createPlatformAddFlowController({
   async function cancel() {
     const current = flow;
     const flowAdapter = current ? getPlatform(current.platformId) : undefined;
+    if (current) {
+      // Counted whether or not the adapter has anything to cancel: what the
+      // funnel measures is the user walking away, not the cleanup.
+      trackAccountAddCancelled(current.platformId);
+    }
     if (!current || !flowAdapter?.cancelAddFlow) {
       stop();
       return;
@@ -160,12 +170,14 @@ export function createPlatformAddFlowController({
       }
 
       if (nextStatus.state === "failed") {
+        reportAddFailure(current.platformId);
         return;
       }
 
       schedulePoll();
     } catch (error) {
       if (!flow || flow.status.setupId !== current.status.setupId) return;
+      reportAddFailure(current.platformId);
       flow = {
         ...flow,
         status: {
@@ -177,8 +189,18 @@ export function createPlatformAddFlowController({
     }
   }
 
+  /**
+   * The adapters report a failed setup as a message, not a typed kind, so the
+   * code lands on `other`. The platform and the count are the part that
+   * answers "which setup should I fix first"; a typed reason can be added
+   * once the adapters carry one.
+   */
+  function reportAddFailure(platformId: string) {
+    trackOperationFailed("account_add", "other", platformId);
+  }
+
   function handleReady(platformId: string, status: PlatformAddFlowStatus) {
-    void invoke("telemetry_track_account_added", { platformId }).catch(() => {});
+    trackAccountAdded(platformId);
     const adapter = getPlatform(platformId);
     if (getPlatformDefinition(platformId)?.capabilities?.primeProfileAfterAdd && status.accountId) {
       void adapter?.getProfileInfo?.(status.accountId).catch(() => null);
@@ -201,15 +223,21 @@ export function createPlatformAddFlowController({
 
   function start(platformId: string, status: PlatformAddFlowStatus) {
     flow = { platformId, status };
+    // The opening of the flow is the denominator the funnel was missing:
+    // `account_added` alone counts successes and says nothing about how many
+    // people give up halfway through a platform's setup.
+    trackAccountAddStarted(platformId);
     // Some setups finish instantly (e.g. Discord adopting the already
     // signed-in session): run the ready handling instead of polling.
     if (status.state === "ready") {
       handleReady(platformId, status);
       return;
     }
-    if (status.state !== "failed") {
-      schedulePoll();
+    if (status.state === "failed") {
+      reportAddFailure(platformId);
+      return;
     }
+    schedulePoll();
   }
 
   function getSetupExtensionContent(accountId: string): CardExtensionContent | null {

--- a/src/lib/app/telemetryClient.ts
+++ b/src/lib/app/telemetryClient.ts
@@ -1,0 +1,60 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Fire-and-forget telemetry calls.
+ *
+ * Every one of these is best-effort by design: the backend drops the event
+ * when the user has not consented, and the mock backend rejects the whole
+ * `telemetry_` prefix outright. Neither is a problem worth surfacing, so the
+ * rejection is swallowed here instead of at twenty call sites.
+ */
+function track(command: string, args?: Record<string, unknown>): void {
+  void invoke(command, args).catch(() => {});
+}
+
+export function trackAccountAddStarted(platformId: string): void {
+  track("telemetry_track_account_add_started", { platformId });
+}
+
+export function trackAccountAddCancelled(platformId: string): void {
+  track("telemetry_track_account_add_cancelled", { platformId });
+}
+
+export function trackAccountAdded(platformId: string): void {
+  track("telemetry_track_account_added", { platformId });
+}
+
+/**
+ * Operation names and error codes are both closed vocabularies on the Rust
+ * side; anything unlisted is recorded as `other` rather than sent as typed.
+ */
+export function trackOperationFailed(
+  operation: string,
+  errorCode: string,
+  platformId?: string,
+): void {
+  track("telemetry_track_operation_failed", { operation, errorCode, platformId });
+}
+
+export type UpdateStage = "available" | "downloaded" | "applied" | "failed";
+
+export function trackUpdate(stage: UpdateStage, targetVersion?: string, errorCode?: string): void {
+  track("telemetry_track_update", { stage, targetVersion, errorCode });
+}
+
+export type SettingsSnapshot = {
+  uiLanguage: string;
+  enabledPlatforms: string[];
+  personasEnabled: boolean;
+  pinEnabled: boolean;
+  cliEnabled: boolean;
+  deepLinksEnabled: boolean;
+  streamerMode: string;
+  animations: string;
+};
+
+/** Mode B only, enforced by the queue. No theme id: a custom theme is named
+ * by the user, and nothing here can tell a built-in id from that. */
+export function trackSettingsSnapshot(snapshot: SettingsSnapshot): void {
+  track("telemetry_track_settings_snapshot", { ...snapshot });
+}

--- a/src/lib/app/useAppLifecycle.svelte.ts
+++ b/src/lib/app/useAppLifecycle.svelte.ts
@@ -7,6 +7,7 @@ import type { RuntimeOs } from "$lib/shared/platform";
 import { getBootPayload } from "$lib/app/bootPayload";
 import { getInitialActiveTab, isPlatformUsable } from "$lib/app/platformShell.svelte";
 import { getPlatformDefinition } from "$lib/platforms/registry";
+import { trackSettingsSnapshot } from "$lib/app/telemetryClient";
 import { applyCustomThemePayloads, loadCustomThemes } from "$lib/theme/themes";
 import {
   CLIENT_STORE_ACCOUNT_CARD_COLORS,
@@ -123,6 +124,21 @@ export function createAppLifecycleController({
     }
 
     markBootReady();
+
+    // Once per launch, after the settings have been read. Answers the
+    // questions the event stream alone cannot: which translations are
+    // actually in use, and whether a platform nobody switches on is unpopular
+    // or simply switched off. The backend drops it outside the enhanced tier.
+    trackSettingsSnapshot({
+      uiLanguage: shell.settings.language,
+      enabledPlatforms: shell.settings.enabledPlatforms,
+      personasEnabled: shell.settings.personasEnabled,
+      pinEnabled: shell.settings.pinEnabled,
+      cliEnabled: shell.settings.cliEnabled,
+      deepLinksEnabled: shell.settings.deepLinksEnabled,
+      streamerMode: shell.settings.streamerMode,
+      animations: shell.settings.animations,
+    });
 
     if (isPlatformUsable(shell.activeTab, shell.runtimeOs)) {
       await loadAccounts(false, false, false, false, true);

--- a/src/lib/app/useAppUpdater.svelte.ts
+++ b/src/lib/app/useAppUpdater.svelte.ts
@@ -1,5 +1,6 @@
 import { check } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
+import { trackUpdate } from "$lib/app/telemetryClient";
 import type { MessageKey, TranslationParams } from "$lib/i18n";
 
 type PendingUpdate = NonNullable<Awaited<ReturnType<typeof check>>>;
@@ -39,6 +40,11 @@ export function createAppUpdater({ t, addToast, beforeRelaunch }: AppUpdaterOpti
     updateCheckStarted = true;
     updateState = "checking";
 
+    // Which half failed matters: a check that never reaches the manifest is a
+    // release-infrastructure problem, a download that dies is a payload or a
+    // network one. Both used to look identical from outside, and both look
+    // like a user who simply stopped launching the app.
+    let stage: "check" | "download" = "check";
     try {
       const update = await check();
       if (!update) {
@@ -49,10 +55,13 @@ export function createAppUpdater({ t, addToast, beforeRelaunch }: AppUpdaterOpti
       pendingUpdate = update;
       updateVersion = update.version;
       updateState = "downloading";
+      trackUpdate("available", updateVersion);
 
+      stage = "download";
       await update.download();
 
       updateState = "ready";
+      trackUpdate("downloaded", updateVersion);
       addToast(
         updateVersion
           ? t("update.readyToastVersion", { version: updateVersion })
@@ -60,6 +69,11 @@ export function createAppUpdater({ t, addToast, beforeRelaunch }: AppUpdaterOpti
       );
     } catch (error) {
       console.error("Updater check/download failed:", error);
+      trackUpdate(
+        "failed",
+        updateVersion || undefined,
+        stage === "check" ? "check_failed" : "download_failed",
+      );
       pendingUpdate = null;
       updateVersion = "";
       updateState = "idle";
@@ -70,13 +84,23 @@ export function createAppUpdater({ t, addToast, beforeRelaunch }: AppUpdaterOpti
   async function applyReadyUpdate() {
     if (updateState !== "ready" || !pendingUpdate) return;
 
+    let stage: "install" | "relaunch" = "install";
     try {
       updateState = "applying";
       await beforeRelaunch?.();
       await pendingUpdate.install();
+      stage = "relaunch";
+      // Emitted before the relaunch, not after: the process is about to be
+      // replaced, so there is no "after" in which to report anything.
+      trackUpdate("applied", updateVersion);
       await relaunch();
     } catch (error) {
       console.error("Failed to restart for update:", error);
+      trackUpdate(
+        "failed",
+        updateVersion || undefined,
+        stage === "install" ? "install_failed" : "relaunch_failed",
+      );
       pendingUpdate = null;
       updateVersion = "";
       updateState = "idle";


### PR DESCRIPTION
Audit of the telemetry pipeline, then the fixes it turned up. Most of what was
missing was lost between the app and PostHog, or absent as a property on an
event that already existed, rather than a missing event.

## Pipeline

- A failed flush kept its batch instead of clearing it, and retries with a
  delay that doubles up to an hour. A network blip used to cost a whole batch,
  which silently under-counted every user with an unreliable connection.
  The queue stays RAM-only: nothing is written to disk.
- The buffer has a 200-event ceiling and counts what it drops, as does the
  channel. `ping` reports the total.
- First flush at 20 seconds instead of 300. Everything a launch produces is
  emitted in the first second, so any shorter session depended entirely on the
  bounded flush at window close.
- `ping` moved into the queue, on a daily ticker. It used to fire once per
  process boot, so an app left open for three days reported one day, and it is
  minted at flush time so it can never be emitted before consent exists.
- Window-close flush deadline 1500ms to 2500ms.

## New events

`first_run`, `account_add_started`, `account_add_cancelled`,
`operation_failed`, `update_available`, `update_downloaded`, `update_applied`,
`update_failed`, `cli_command`, `settings_snapshot`.

The CLI reported nothing at all before this, under the same consent as the app
and with no ping of its own.

## New properties

`os`, `arch`, `surface` and `client_ts` on every event. `error_code` on a
failed switch, typed from `PlatformErrorKind`. `success` and `succeeded`
alongside `count`, which carried three different meanings depending on the
event; `count` is unchanged so existing dashboards keep working.

Events are now stored under the instant they happened. The Worker used to
stamp a whole batch with its arrival time, flattening up to five minutes onto
one point.

## Fixes

- macOS reported no version at all (`macos aarch64`), so "what is the oldest
  macOS still in use" had no answer. Read from `SystemVersion.plist`.
- Windows reported no architecture, so Windows on ARM was invisible.
- `locale` was read from `LANG`/`LC_ALL`, which a normal Windows session does
  not set, so it was empty for most of that install base. Now
  `GetUserDefaultLocaleName`, POSIX elsewhere.

## Privacy

Codes go through closed vocabularies rather than a sanitizer. Normalising a
string is not enough: `C:\Users\alice\...` survives character filtering with
the name intact, and an error message is exactly the kind of string that
carries one. Anything unlisted becomes `other`. Platform ids are matched
against the registry verbatim, so `battle-net` keeps its spelling.

`settings_snapshot` is enhanced-tier only, like `accounts_snapshot`, and
carries no theme name: a custom theme is named by the user.

The Worker validates every property it forwards, and a property not written in
`buildBatch` cannot reach PostHog at all. Client timestamps are rejected past
24 hours of clock skew.

`docs/analytics.md` is updated, including three places where it disagreed with
the code: the ping described as daily when it was per boot, "nine events, and
that is the complete list" which omitted `consent_choice`, and the "success
flag" that arrived as `count`.

## Not covered

- `session_ended` still only fires on a clean window close, so crashes and
  kills are invisible and session durations are biased. Fixing it needs a
  session marker on disk, which the RAM-only design exists to avoid.
- Mode A cannot count unique users outside `ping`, by construction.
- `operation_failed` on a failed account add reports `other`: the adapters
  return a message, not a typed kind.

## Tests

`cargo test --workspace` 403 passing, clippy and fmt clean, `vp test run` 773
passing, `svelte-check` 0 errors. Booted under `pnpm dev:mock dev` to confirm
the app still starts and the new frontend calls reach the IPC layer.
