### PR TITLE
feat(bulk-edit): card color action, keep selection across folders

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -24,6 +24,7 @@
   import { createAccountLoader } from "$lib/shared/useAccountLoader.svelte";
   import {
     getAccountCardColor as getStoredAccountCardColor,
+    setAccountCardColor,
   } from "$lib/shared/accountCardColors";
   import { getAccountCardNote as getStoredAccountCardNote } from "$lib/shared/accountCardNotes";
   import {
@@ -1017,6 +1018,22 @@
     addToast(t("bulkEdit.urlsCopied", { count: urls.length }), { type: "success" });
   }
 
+  // Card colors are a client-side store, so a bulk color needs no platform
+  // round trip: write every selected id, then bump the version that the card
+  // color getters track.
+  function applyBulkEditCardColor(color: string) {
+    const ids = [...bulkEdit.bulkEditSelectedIds];
+    if (ids.length === 0) return;
+    for (const id of ids) setAccountCardColor(id, color);
+    cardColorVersion += 1;
+    addToast(
+      color
+        ? t("bulkEdit.colorApplied", { count: ids.length })
+        : t("bulkEdit.colorCleared", { count: ids.length }),
+      { type: "success" },
+    );
+  }
+
   async function loadAccounts(
     silent = false,
     showRefreshedToast = false,
@@ -1520,6 +1537,7 @@
     onBulkEditSelectAll={bulkEdit.bulkEditSelectAll}
     onBulkEditDeselectAll={bulkEdit.bulkEditDeselectAll}
     onBulkEditCopyUrls={copyBulkEditUrls}
+    onBulkEditSetCardColor={applyBulkEditCardColor}
     onBulkEditClose={bulkEdit.closeBulkEdit}
     onBulkEditResult={dialogs.handleBulkEditResult}
     {t}

--- a/src/lib/app/AppDialogs.svelte
+++ b/src/lib/app/AppDialogs.svelte
@@ -43,6 +43,7 @@
     onBulkEditSelectAll,
     onBulkEditDeselectAll,
     onBulkEditCopyUrls,
+    onBulkEditSetCardColor,
     onBulkEditClose,
     onBulkEditResult,
     t,
@@ -67,6 +68,7 @@
     onBulkEditSelectAll: () => void;
     onBulkEditDeselectAll: () => void;
     onBulkEditCopyUrls: (urls: string[]) => void;
+    onBulkEditSetCardColor: (color: string) => void;
     onBulkEditClose: () => void;
     onBulkEditResult: (result: PlatformBulkEditResult) => void;
     t: (key: MessageKey, params?: TranslationParams) => string;
@@ -117,6 +119,7 @@
     onSelectAll={onBulkEditSelectAll}
     onDeselectAll={onBulkEditDeselectAll}
     onCopyUrls={onBulkEditCopyUrls}
+    onSetCardColor={onBulkEditSetCardColor}
     onClose={onBulkEditClose}
     onResult={onBulkEditResult}
     {t}

--- a/src/lib/app/useBulkEdit.svelte.ts
+++ b/src/lib/app/useBulkEdit.svelte.ts
@@ -90,8 +90,13 @@ export function createBulkEditController({
     bulkEditSelectedIds = next;
   }
 
+  // Additive: the selection spans the whole platform, not just the current
+  // folder, so selecting all inside a folder must not drop what was already
+  // picked at the root (or in another folder). "Deselect all" is the reset.
   function bulkEditSelectAll() {
-    bulkEditSelectedIds = new Set(getVisibleAccountIds());
+    const next = new Set(bulkEditSelectedIds);
+    for (const id of getVisibleAccountIds()) next.add(id);
+    bulkEditSelectedIds = next;
   }
 
   function bulkEditDeselectAll() {

--- a/src/lib/app/useBulkEdit.test.ts
+++ b/src/lib/app/useBulkEdit.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { createBulkEditController } from "./useBulkEdit.svelte";
+
+function controllerOver(visibleIds: () => string[]) {
+  return createBulkEditController({
+    getCurrentAccountId: () => null,
+    getVisibleAccountIds: visibleIds,
+    getBulkEditCapability: () => null,
+  });
+}
+
+describe("bulk edit selection", () => {
+  it("keeps what was picked elsewhere when selecting all inside a folder", () => {
+    let visible = ["root-1", "root-2"];
+    const bulk = controllerOver(() => visible);
+
+    bulk.bulkEditSelectAll();
+    expect([...bulk.bulkEditSelectedIds]).toEqual(["root-1", "root-2"]);
+
+    // Navigating into a folder only changes what is on screen.
+    visible = ["folder-1"];
+    bulk.bulkEditSelectAll();
+
+    expect([...bulk.bulkEditSelectedIds]).toEqual(["root-1", "root-2", "folder-1"]);
+  });
+
+  it("keeps a manual pick made in another folder", () => {
+    let visible = ["root-1"];
+    const bulk = controllerOver(() => visible);
+
+    bulk.toggleBulkEditAccount("root-1");
+    visible = ["folder-1"];
+    bulk.toggleBulkEditAccount("folder-1");
+
+    expect([...bulk.bulkEditSelectedIds]).toEqual(["root-1", "folder-1"]);
+  });
+
+  it("deselect all is the reset, across folders", () => {
+    const bulk = controllerOver(() => ["root-1"]);
+
+    bulk.bulkEditSelectAll();
+    bulk.toggleBulkEditAccount("folder-1");
+    bulk.bulkEditDeselectAll();
+
+    expect(bulk.bulkEditSelectedIds.size).toBe(0);
+  });
+});

--- a/src/lib/i18n/messages.es.ts
+++ b/src/lib/i18n/messages.es.ts
@@ -600,6 +600,9 @@ export const ES_MESSAGES: Record<MessageKey, string> = {
   "bulkEdit.loadingGames": "Cargando juegos...",
   "bulkEdit.copyUrls": "Copiar URL",
   "bulkEdit.urlsCopied": "{count} URL de perfil copiada(s)",
+  "bulkEdit.cardColor": "Color de tarjeta",
+  "bulkEdit.colorApplied": "Color aplicado a {count} tarjeta(s)",
+  "bulkEdit.colorCleared": "Color eliminado de {count} tarjeta(s)",
 
   "common.retry": "Reintentar",
 

--- a/src/lib/i18n/messages.fr.ts
+++ b/src/lib/i18n/messages.fr.ts
@@ -596,6 +596,9 @@ export const FR_MESSAGES: Record<MessageKey, string> = {
   "bulkEdit.loadingGames": "Chargement des jeux...",
   "bulkEdit.copyUrls": "Copier les URLs",
   "bulkEdit.urlsCopied": "{count} URL(s) de profil copiée(s)",
+  "bulkEdit.cardColor": "Couleur de carte",
+  "bulkEdit.colorApplied": "Couleur appliquée à {count} carte(s)",
+  "bulkEdit.colorCleared": "Couleur retirée de {count} carte(s)",
 
   "common.retry": "Réessayer",
 

--- a/src/lib/i18n/messages.pt-br.ts
+++ b/src/lib/i18n/messages.pt-br.ts
@@ -598,6 +598,9 @@ export const PT_BR_MESSAGES: Record<MessageKey, string> = {
   "bulkEdit.loadingGames": "Carregando jogos...",
   "bulkEdit.copyUrls": "Copiar URLs",
   "bulkEdit.urlsCopied": "{count} URL(s) de perfil copiada(s)",
+  "bulkEdit.cardColor": "Cor do card",
+  "bulkEdit.colorApplied": "Cor aplicada a {count} card(s)",
+  "bulkEdit.colorCleared": "Cor removida de {count} card(s)",
 
   "common.retry": "Tentar de novo",
 

--- a/src/lib/i18n/messages.pt.ts
+++ b/src/lib/i18n/messages.pt.ts
@@ -598,6 +598,9 @@ export const PT_MESSAGES: Record<MessageKey, string> = {
   "bulkEdit.loadingGames": "A carregar jogos...",
   "bulkEdit.copyUrls": "Copiar URLs",
   "bulkEdit.urlsCopied": "{count} URL(s) de perfil copiada(s)",
+  "bulkEdit.cardColor": "Cor do cartão",
+  "bulkEdit.colorApplied": "Cor aplicada a {count} cartão(ões)",
+  "bulkEdit.colorCleared": "Cor removida de {count} cartão(ões)",
 
   "common.retry": "Repetir",
 

--- a/src/lib/i18n/messages.ru.ts
+++ b/src/lib/i18n/messages.ru.ts
@@ -602,6 +602,9 @@ export const RU_MESSAGES: Record<MessageKey, string> = {
   "bulkEdit.loadingGames": "Загрузка игр...",
   "bulkEdit.copyUrls": "Копировать ссылки",
   "bulkEdit.urlsCopied": "Скопировано ссылок на профиль: {count}",
+  "bulkEdit.cardColor": "Цвет карточки",
+  "bulkEdit.colorApplied": "Цвет применён к карточкам: {count}",
+  "bulkEdit.colorCleared": "Цвет снят с карточек: {count}",
 
   "common.retry": "Повторить",
 

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -589,6 +589,9 @@ export const EN_MESSAGES = {
   "bulkEdit.loadingGames": "Loading games...",
   "bulkEdit.copyUrls": "Copy URLs",
   "bulkEdit.urlsCopied": "{count} profile URL(s) copied",
+  "bulkEdit.cardColor": "Card color",
+  "bulkEdit.colorApplied": "Color applied to {count} card(s)",
+  "bulkEdit.colorCleared": "Color cleared on {count} card(s)",
 
   "common.retry": "Retry",
 

--- a/src/lib/i18n/messages.zh.ts
+++ b/src/lib/i18n/messages.zh.ts
@@ -570,6 +570,9 @@ export const ZH_MESSAGES: Record<MessageKey, string> = {
   "bulkEdit.loadingGames": "正在加载游戏...",
   "bulkEdit.copyUrls": "复制链接",
   "bulkEdit.urlsCopied": "已复制 {count} 个个人资料链接",
+  "bulkEdit.cardColor": "卡片颜色",
+  "bulkEdit.colorApplied": "已为 {count} 张卡片应用颜色",
+  "bulkEdit.colorCleared": "已清除 {count} 张卡片的颜色",
 
   "common.retry": "重试",
 

--- a/src/lib/platforms/steam/BulkEditBar.svelte
+++ b/src/lib/platforms/steam/BulkEditBar.svelte
@@ -8,6 +8,8 @@
     type BulkEditResult,
   } from "./steamApi";
   import { toProfileUrl } from "./steamIdUtils";
+  import { ACCOUNT_CARD_COLOR_PRESETS } from "$lib/shared/accountCardColors";
+  import { COLOR_LABEL_KEYS } from "$lib/shared/contextMenu/accountAppearanceActions";
 
   type TriState = "unchanged" | "enabled" | "disabled";
 
@@ -17,6 +19,7 @@
     onSelectAll,
     onDeselectAll,
     onCopyUrls,
+    onSetCardColor,
     onClose,
     onResult,
     t,
@@ -26,6 +29,7 @@
     onSelectAll: () => void;
     onDeselectAll: () => void;
     onCopyUrls: (urls: string[]) => void;
+    onSetCardColor: (color: string) => void;
     onClose: () => void;
     onResult: (result: BulkEditResult) => void;
     t: (key: MessageKey, params?: TranslationParams) => string;
@@ -33,6 +37,26 @@
 
   function copyUrls() {
     onCopyUrls([...selectedIds].map(toProfileUrl));
+  }
+
+  let colorMenuOpen = $state(false);
+  let colorWrapRef = $state<HTMLDivElement | null>(null);
+
+  function toggleColorMenu() {
+    colorMenuOpen = !colorMenuOpen;
+  }
+
+  function applyColor(color: string) {
+    colorMenuOpen = false;
+    onSetCardColor(color);
+  }
+
+  // Click anywhere outside the popover closes it. Capture phase so a click on
+  // another bar button both closes this and runs its own action.
+  function handleWindowPointerDown(event: PointerEvent) {
+    if (!colorMenuOpen) return;
+    if (colorWrapRef?.contains(event.target as Node)) return;
+    colorMenuOpen = false;
   }
 
   let step = $state<"select" | "settings">("select");
@@ -116,12 +140,16 @@
 
   function handleOverlayKeydown(e: KeyboardEvent) {
     if (e.key !== "Escape") return;
+    if (colorMenuOpen) {
+      colorMenuOpen = false;
+      return;
+    }
     if (step === "settings") step = "select";
     else onClose();
   }
 </script>
 
-<svelte:window onkeydown={handleOverlayKeydown} />
+<svelte:window onkeydown={handleOverlayKeydown} onpointerdown={handleWindowPointerDown} />
 
 {#if step === "select"}
   <div class="bar">
@@ -131,6 +159,35 @@
       <button class="tool-btn" disabled={selectedIds.size === 0} onclick={copyUrls}>
         {t("bulkEdit.copyUrls")}
       </button>
+      <div class="color-wrap" bind:this={colorWrapRef}>
+        <button
+          class="tool-btn"
+          class:active={colorMenuOpen}
+          disabled={selectedIds.size === 0}
+          aria-expanded={colorMenuOpen}
+          onclick={toggleColorMenu}
+        >
+          {t("bulkEdit.cardColor")}
+        </button>
+        {#if colorMenuOpen}
+          <div class="color-popover" role="group" aria-label={t("bulkEdit.cardColor")}>
+            {#each ACCOUNT_CARD_COLOR_PRESETS as preset (preset.id)}
+              <button
+                class="swatch"
+                title={t(COLOR_LABEL_KEYS[preset.id])}
+                aria-label={t(COLOR_LABEL_KEYS[preset.id])}
+                onclick={() => applyColor(preset.color)}
+              >
+                {#if preset.color}
+                  <span class="swatch-fill" style={`background:${preset.color};`}></span>
+                {:else}
+                  <span class="swatch-fill default"></span>
+                {/if}
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </div>
       <span class="count">{t("bulkEdit.selected", { count: selectedIds.size })}</span>
     </div>
     <div class="bar-right">
@@ -293,6 +350,61 @@
   .tool-btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+
+  .tool-btn.active {
+    background: var(--bg-card-hover);
+    color: var(--fg);
+  }
+
+  /* ── Card color popover ── */
+
+  .color-wrap {
+    position: relative;
+    display: flex;
+  }
+
+  .color-popover {
+    position: absolute;
+    bottom: calc(100% + 6px);
+    left: 0;
+    z-index: 101;
+    display: flex;
+    gap: 6px;
+    padding: 7px 8px;
+    background: var(--bg-overlay);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  }
+
+  .swatch {
+    width: 18px;
+    height: 18px;
+    padding: 0;
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    background: transparent;
+    cursor: pointer;
+    display: grid;
+    place-items: center;
+  }
+
+  .swatch:hover,
+  .swatch:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--fg) 35%, transparent);
+  }
+
+  .swatch-fill {
+    width: 12px;
+    height: 12px;
+    border-radius: 3px;
+    display: block;
+  }
+
+  .swatch-fill.default {
+    background: linear-gradient(135deg, var(--bg-muted) 0 50%, var(--bg-elevated) 50% 100%);
   }
 
   .btn-secondary {

--- a/src/lib/shared/platform.ts
+++ b/src/lib/shared/platform.ts
@@ -92,6 +92,8 @@ export interface PlatformBulkEditBarProps {
   onSelectAll: () => void;
   onDeselectAll: () => void;
   onCopyUrls: (urls: string[]) => void;
+  /** Applies a card color (hex, or "" to clear) to every selected account. */
+  onSetCardColor: (color: string) => void;
   onClose: () => void;
   onResult: (result: PlatformBulkEditResult) => void;
   t: (key: MessageKey, params?: TranslationParams) => string;


### PR DESCRIPTION
Adds a card color action to the Steam bulk edit bar: a swatch popover applies one of the existing card color presets to every selected account at once, `none` clears them. Colors are a client-side store, so the action needs no platform round trip; a toast reports how many cards changed.

Also makes `Select all` union with the current selection instead of replacing it. Selecting all inside a folder used to drop everything picked at the root, since it only ever targets the accounts on screen. `Deselect all` stays the reset.

New unit tests cover the selection behaviour across folders. Both changes were checked in the running app with the mock backend.
