### PR TITLE
fix(ui): wider Windows caption buttons, no avatar placeholder flash

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -89,6 +89,12 @@
      Details in .claude/CLAUDE.md, section "Animations". */
   --motion-card-entrance: 260ms;
   --motion-page-entrance: 200ms;
+  /* Avatars: an <img> stays transparent until its bytes are decoded, then
+     fades in. The defer delay is how long a still-unresolved avatar shows a
+     bare box before falling back to initials or a spinner, so a profile that
+     resolves quickly never flashes a placeholder. */
+  --motion-avatar-fade: 220ms;
+  --motion-avatar-defer: 380ms;
 }
 
 /* The in-app motion preference must cover third-party/Svelte transitions and
@@ -177,6 +183,18 @@ html,
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+/* Avatar placeholder (initials or spinner) revealing itself after the defer
+   delay. `backwards` keeps it invisible during the delay, so it never shows
+   at all when the real avatar lands first. */
+@keyframes avatar-placeholder-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
   }
 }
 

--- a/src/lib/app/AppWorkspace.svelte
+++ b/src/lib/app/AppWorkspace.svelte
@@ -264,6 +264,7 @@
     avatarUrl={avatarState?.url}
     isLoadingAvatar={isPendingSetupAccount(account.id) ? true : (avatarState?.loading ?? false)}
     isRefreshingAvatar={avatarState?.refreshing ?? false}
+    avatarPending={!avatarState}
     isDragged={isAccountDragged}
     warningInfo={bulkEditMode ? undefined : (isPendingSetupAccount(account.id) ? undefined : warningStates[account.id])}
     usernameBadge={bulkEditMode || isPendingSetupAccount(account.id) ? null : getUsernameBadge(account.id)}

--- a/src/lib/shared/avatarFadeIn.ts
+++ b/src/lib/shared/avatarFadeIn.ts
@@ -1,0 +1,30 @@
+/** Reveals an avatar `<img>` once its bytes are decoded.
+ *
+ * The element starts at `opacity: 0` (component CSS) so a picture that is still
+ * downloading shows the neutral avatar box instead of a half-painted frame, then
+ * fades in. The reveal is an inline style rather than a class: Svelte prunes
+ * scoped selectors it cannot see in the markup, and a class added from an action
+ * is invisible to that analysis.
+ */
+export function fadeInOnLoad(node: HTMLImageElement) {
+  const reveal = () => {
+    node.style.opacity = "1";
+  };
+
+  // Cached image: `load` already fired before the action ran.
+  if (node.complete && node.naturalWidth > 0) {
+    reveal();
+    return;
+  }
+
+  node.addEventListener("load", reveal);
+  // A broken URL must never leave a permanently invisible avatar.
+  node.addEventListener("error", reveal);
+
+  return {
+    destroy() {
+      node.removeEventListener("load", reveal);
+      node.removeEventListener("error", reveal);
+    },
+  };
+}

--- a/src/lib/shared/components/AccountCard.svelte
+++ b/src/lib/shared/components/AccountCard.svelte
@@ -7,6 +7,7 @@
   import CardExtensionPanel from "./CardExtensionPanel.svelte";
   import { formatRelativeTimeCompact } from "$lib/shared/time";
   import { getAvatarGradientStyle, getAvatarInitials, getAvatarSeed } from "$lib/shared/avatarFallback";
+  import { fadeInOnLoad } from "$lib/shared/avatarFadeIn";
   import { DEFAULT_LOCALE, translate, type Locale, type MessageKey } from "$lib/i18n";
   import { trackDependencies } from "$lib/shared/trackDependencies";
 
@@ -20,6 +21,7 @@
     avatarUrl = null,
     isLoadingAvatar = false,
     isRefreshingAvatar = false,
+    avatarPending = false,
     warningInfo = undefined,
     extensionContent = null,
     forceExtensionOpen = false,
@@ -47,6 +49,10 @@
     avatarUrl?: string | null;
     isLoadingAvatar?: boolean;
     isRefreshingAvatar?: boolean;
+    /** No avatar state resolved yet for this account. The gradient + initials
+        fallback still renders, but deferred, so an avatar that lands fast never
+        flashes a placeholder first. */
+    avatarPending?: boolean;
     warningInfo?: AccountWarningPresentation;
     extensionContent?: CardExtensionContent | null;
     forceExtensionOpen?: boolean;
@@ -319,39 +325,40 @@
     class:ban-red={hasRedWarning}
     class:ban-yellow={hasOrangeWarning}
   >
-    <div
-      class="avatar"
-      class:active={isActive}
-      style={!avatarUrl && !isLoadingAvatar ? getAvatarGradientStyle(avatarSeed) : ""}
-    >
+    <div class="avatar" class:active={isActive}>
       <div class="avatar-media">
-        {#if isLoadingAvatar}
-          <div class="loader-anchor">
-            <div class="loader"></div>
-          </div>
-        {:else if avatarUrl}
+        {#if avatarUrl}
           <img
             src={avatarUrl}
             alt=""
             loading="lazy"
             decoding="async"
             draggable={false}
+            use:fadeInOnLoad
             class:blurred={isRefreshingAvatar || showConfirm || isSwitching}
           />
-          {#if isRefreshingAvatar || isSwitching}
-            <div class="loader-anchor">
-              <div class="loader"></div>
-            </div>
-          {/if}
-        {:else}
-          <span class="initials" class:blurred-text={showConfirm || isSwitching}>
-            {getAvatarInitials(account.displayName || account.username)}
-          </span>
-          {#if isSwitching}
-            <div class="loader-anchor">
-              <div class="loader"></div>
-            </div>
-          {/if}
+        {:else if !isLoadingAvatar}
+          <!-- Gradient lives on this layer, not on .avatar: it has to fade in
+               with the initials instead of snapping under them. -->
+          <div
+            class="avatar-fallback"
+            class:deferred={avatarPending}
+            style={getAvatarGradientStyle(avatarSeed)}
+          >
+            <span class="initials" class:blurred-text={showConfirm || isSwitching}>
+              {getAvatarInitials(account.displayName || account.username)}
+            </span>
+          </div>
+        {/if}
+
+        {#if isLoadingAvatar}
+          <div class="loader-anchor deferred">
+            <div class="loader"></div>
+          </div>
+        {:else if isRefreshingAvatar || isSwitching}
+          <div class="loader-anchor">
+            <div class="loader"></div>
+          </div>
         {/if}
 
         {#if showConfirm && !isDragged}
@@ -718,13 +725,33 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
-    transition: transform 220ms ease-out, filter 300ms ease-out;
+    /* fadeInOnLoad flips the inline opacity once the picture is decoded. */
+    opacity: 0;
+    transition: opacity var(--motion-avatar-fade) ease-out, transform 220ms ease-out,
+      filter 300ms ease-out;
     -webkit-user-drag: none;
     user-select: none;
   }
 
   .avatar-media img.blurred {
     filter: blur(6px) brightness(0.5);
+  }
+
+  .avatar-fallback {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* Unresolved avatar: hold the initials back, `backwards` keeps them hidden
+     during the delay so a fast profile never flashes a placeholder. */
+  .avatar-fallback.deferred,
+  .loader-anchor.deferred {
+    animation: avatar-placeholder-in var(--motion-avatar-fade) ease-out
+      var(--motion-avatar-defer) backwards;
   }
 
   .avatar-media .initials {

--- a/src/lib/shared/components/ListRow.svelte
+++ b/src/lib/shared/components/ListRow.svelte
@@ -4,6 +4,7 @@
   import type { FolderInfo } from "../../features/folders/types";
   import { formatRelativeTimeCompact } from "$lib/shared/time";
   import { getAvatarGradientStyle, getAvatarInitials, getAvatarSeed } from "$lib/shared/avatarFallback";
+  import { fadeInOnLoad } from "$lib/shared/avatarFadeIn";
   import { DEFAULT_LOCALE, translate, type Locale, type MessageKey } from "$lib/i18n";
 
   let {
@@ -16,6 +17,7 @@
     isDragOver = false,
     avatarUrl = null,
     isLoadingAvatar = false,
+    avatarPending = false,
     isSwitching = false,
     allowMetaWrap = false,
     warningInfo = undefined,
@@ -39,6 +41,9 @@
     isDragOver?: boolean;
     avatarUrl?: string | null;
     isLoadingAvatar?: boolean;
+    /** No avatar state resolved yet: the initials fallback is deferred so a
+        fast profile never flashes a placeholder first. */
+    avatarPending?: boolean;
     isSwitching?: boolean;
     allowMetaWrap?: boolean;
     warningInfo?: AccountWarningPresentation;
@@ -123,19 +128,32 @@
       class="avatar"
       class:ban-red={hasRedWarning}
       class:ban-orange={hasOrangeWarning}
-      style={!avatarUrl && !isLoadingAvatar ? getAvatarGradientStyle(avatarSeed) : ""}
     >
+      {#if avatarUrl}
+        <img
+          src={avatarUrl}
+          alt=""
+          loading="lazy"
+          decoding="async"
+          draggable={false}
+          use:fadeInOnLoad
+          class:blurred={isSwitching}
+        />
+      {:else if !isLoadingAvatar}
+        <!-- Gradient on this layer, not on .avatar: it fades in with the
+             initials instead of snapping under them. -->
+        <div
+          class="avatar-fallback"
+          class:deferred={avatarPending}
+          style={getAvatarGradientStyle(avatarSeed)}
+        >
+          <span class="initials">{getAvatarInitials(account.displayName || account.username)}</span>
+        </div>
+      {/if}
       {#if isLoadingAvatar}
-        <div class="loader"></div>
+        <div class="loader deferred"></div>
       {:else if isSwitching}
-        {#if avatarUrl}
-          <img src={avatarUrl} alt="" loading="lazy" decoding="async" draggable={false} class="blurred" />
-        {/if}
         <div class="loader switching-loader"></div>
-      {:else if avatarUrl}
-        <img src={avatarUrl} alt="" loading="lazy" decoding="async" draggable={false} />
-      {:else}
-        <span class="initials">{getAvatarInitials(account.displayName || account.username)}</span>
       {/if}
     </div>
     <div class="info">
@@ -270,8 +288,26 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
+    /* fadeInOnLoad flips the inline opacity once the picture is decoded. */
+    opacity: 0;
+    transition: opacity var(--motion-avatar-fade) ease-out;
     -webkit-user-drag: none;
     user-select: none;
+  }
+
+  .avatar-fallback {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* Unresolved avatar: `backwards` keeps the placeholder hidden during the
+     delay, so a fast profile never flashes one. */
+  .avatar-fallback.deferred {
+    animation: avatar-placeholder-in var(--motion-avatar-fade) ease-out
+      var(--motion-avatar-defer) backwards;
   }
 
   .avatar .initials {
@@ -348,6 +384,13 @@
     border: 2px solid color-mix(in srgb, var(--fg) 24%, transparent);
     border-top-color: var(--fg);
     animation: spin 0.75s linear infinite;
+  }
+
+  /* Spinner must keep spinning: the deferred reveal is a second animation on
+     the same element, not a replacement. */
+  .loader.deferred {
+    animation: spin 0.75s linear infinite,
+      avatar-placeholder-in var(--motion-avatar-fade) ease-out var(--motion-avatar-defer) backwards;
   }
 
   .switching-loader {

--- a/src/lib/shared/components/ListView.svelte
+++ b/src/lib/shared/components/ListView.svelte
@@ -150,6 +150,7 @@
       isSelected={selectedAccountId === account.id}
       avatarUrl={avatarState?.url}
       isLoadingAvatar={isPendingSetup || (avatarState?.loading ?? false)}
+      avatarPending={!avatarState}
       isSwitching={switchingAccountId === account.id}
       allowMetaWrap={isPendingSetup}
       warningInfo={warningStates[account.id]}
@@ -261,6 +262,7 @@
         isActive={selectedAccount.id === currentAccountId}
         avatarUrl={selectedAvatarState?.url}
         isLoadingAvatar={selectedIsPendingSetup || (selectedAvatarState?.loading ?? false)}
+        avatarPending={!selectedAvatarState}
         showSwitchButton={!selectedIsPendingSetup}
         allowMetaWrap={selectedIsPendingSetup}
         accountNote={getAccountNote(selectedAccount.id)}

--- a/src/lib/shared/components/PreviewPanel.svelte
+++ b/src/lib/shared/components/PreviewPanel.svelte
@@ -3,6 +3,7 @@
   import type { AccountWarningPresentation } from "../accountWarnings";
   import { formatRelativeTimeCompact } from "$lib/shared/time";
   import { getAvatarGradientStyle, getAvatarInitials, getAvatarSeed } from "$lib/shared/avatarFallback";
+  import { fadeInOnLoad } from "$lib/shared/avatarFadeIn";
   import { DEFAULT_LOCALE, translate, type Locale, type MessageKey } from "$lib/i18n";
 
   let {
@@ -10,6 +11,7 @@
     isActive = false,
     avatarUrl = null,
     isLoadingAvatar = false,
+    avatarPending = false,
     showUsername = true,
     showLastLogin = false,
     allowMetaWrap = false,
@@ -27,6 +29,9 @@
     isActive?: boolean;
     avatarUrl?: string | null;
     isLoadingAvatar?: boolean;
+    /** No avatar state resolved yet: the initials fallback is deferred so a
+        fast profile never flashes a placeholder first. */
+    avatarPending?: boolean;
     showUsername?: boolean;
     showLastLogin?: boolean;
     allowMetaWrap?: boolean;
@@ -53,16 +58,21 @@
   class:custom-color={!!cardColor}
   style={cardColor ? `--preview-custom-color: ${cardColor};` : ""}
 >
-  <div
-    class="avatar-large"
-    style={!avatarUrl && !isLoadingAvatar ? getAvatarGradientStyle(avatarSeed) : ""}
-  >
-    {#if isLoadingAvatar}
-      <div class="loader"></div>
-    {:else if avatarUrl}
-      <img src={avatarUrl} alt={account.displayName} loading="lazy" decoding="async" />
+  <div class="avatar-large">
+    {#if avatarUrl}
+      <img src={avatarUrl} alt={account.displayName} loading="lazy" decoding="async" use:fadeInOnLoad />
+    {:else if isLoadingAvatar}
+      <div class="loader deferred"></div>
     {:else}
-      <span class="initials">{getAvatarInitials(account.displayName || account.username)}</span>
+      <!-- Gradient on this layer, not on .avatar-large: it fades in with the
+           initials instead of snapping under them. -->
+      <div
+        class="avatar-fallback"
+        class:deferred={avatarPending}
+        style={getAvatarGradientStyle(avatarSeed)}
+      >
+        <span class="initials">{getAvatarInitials(account.displayName || account.username)}</span>
+      </div>
     {/if}
   </div>
 
@@ -132,6 +142,7 @@
   }
 
   .avatar-large {
+    position: relative;
     width: 120px;
     height: 120px;
     border-radius: 8px;
@@ -147,6 +158,24 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
+    /* fadeInOnLoad flips the inline opacity once the picture is decoded. */
+    opacity: 0;
+    transition: opacity var(--motion-avatar-fade) ease-out;
+  }
+
+  .avatar-fallback {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* Unresolved avatar: `backwards` keeps the placeholder hidden during the
+     delay, so a fast profile never flashes one. */
+  .avatar-fallback.deferred {
+    animation: avatar-placeholder-in var(--motion-avatar-fade) ease-out
+      var(--motion-avatar-defer) backwards;
   }
 
   .avatar-large .initials {
@@ -261,6 +290,13 @@
     border: 4px solid color-mix(in srgb, var(--fg) 24%, transparent);
     border-top-color: var(--fg);
     animation: spin 0.75s linear infinite;
+  }
+
+  /* Spinner must keep spinning: the deferred reveal is a second animation on
+     the same element, not a replacement. */
+  .loader.deferred {
+    animation: spin 0.75s linear infinite,
+      avatar-placeholder-in var(--motion-avatar-fade) ease-out var(--motion-avatar-defer) backwards;
   }
 
   .ban-badges {

--- a/src/lib/shared/components/TitleBar.svelte
+++ b/src/lib/shared/components/TitleBar.svelte
@@ -220,30 +220,35 @@
     {/if}
 
     {#if !isMacOs}
-      <button class="win-btn" onclick={minimize} title={translate(locale, "titlebar.minimize")}>
-        <svg width="12" height="12" viewBox="0 0 12 12">
-          <rect x="1" y="5.5" width="10" height="1" fill="currentColor" />
-        </svg>
-      </button>
-
-      <button class="win-btn" onclick={toggleMaximize} title={translate(locale, isMaximized ? "titlebar.restore" : "titlebar.maximize")}>
-        {#if isMaximized}
+      <!-- Caption strip: full titlebar height, flush to the window edge, no gap
+           between the three. Matches the native Windows hit areas instead of
+           three small floating squares. -->
+      <div class="win-controls">
+        <button class="win-btn" onclick={minimize} title={translate(locale, "titlebar.minimize")}>
           <svg width="12" height="12" viewBox="0 0 12 12">
-            <rect x="1.6" y="3.4" width="7" height="7" fill="none" stroke="currentColor" stroke-width="1.2" />
-            <path d="M3.4 3.4V1.6h7v7H8.6" fill="none" stroke="currentColor" stroke-width="1.2" />
+            <rect x="1" y="5.5" width="10" height="1" fill="currentColor" />
           </svg>
-        {:else}
-          <svg width="12" height="12" viewBox="0 0 12 12">
-            <rect x="1.6" y="1.6" width="8.8" height="8.8" fill="none" stroke="currentColor" stroke-width="1.2" />
-          </svg>
-        {/if}
-      </button>
+        </button>
 
-      <button class="win-btn close" onclick={close} title={translate(locale, "titlebar.close")}>
-        <svg width="12" height="12" viewBox="0 0 12 12">
-          <path d="M1 1l10 10M11 1L1 11" stroke="currentColor" stroke-width="1.2" />
-        </svg>
-      </button>
+        <button class="win-btn" onclick={toggleMaximize} title={translate(locale, isMaximized ? "titlebar.restore" : "titlebar.maximize")}>
+          {#if isMaximized}
+            <svg width="12" height="12" viewBox="0 0 12 12">
+              <rect x="1.6" y="3.4" width="7" height="7" fill="none" stroke="currentColor" stroke-width="1.2" />
+              <path d="M3.4 3.4V1.6h7v7H8.6" fill="none" stroke="currentColor" stroke-width="1.2" />
+            </svg>
+          {:else}
+            <svg width="12" height="12" viewBox="0 0 12 12">
+              <rect x="1.6" y="1.6" width="8.8" height="8.8" fill="none" stroke="currentColor" stroke-width="1.2" />
+            </svg>
+          {/if}
+        </button>
+
+        <button class="win-btn close" onclick={close} title={translate(locale, "titlebar.close")}>
+          <svg width="12" height="12" viewBox="0 0 12 12">
+            <path d="M1 1l10 10M11 1L1 11" stroke="currentColor" stroke-width="1.2" />
+          </svg>
+        </button>
+      </div>
     {/if}
   </div>
 </div>
@@ -410,10 +415,17 @@
   .right {
     display: flex;
     align-items: center;
+    /* Full titlebar height so the caption buttons can bleed to the top and
+       bottom edges instead of floating in the middle. */
+    align-self: stretch;
     gap: 6px;
     flex: 1;
     justify-content: flex-end;
-    padding-right: 2px;
+  }
+
+  /* macOS has no caption strip here: keep the old breathing room. */
+  .titlebar.macos .right {
+    padding-right: 8px;
   }
 
   .update-btn {
@@ -439,17 +451,29 @@
     cursor: default;
   }
 
+  .win-controls {
+    display: flex;
+    align-self: stretch;
+    margin-left: 4px;
+  }
+
   .win-btn {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 36px;
-    height: 36px;
+    /* Native Windows caption metrics: 46px wide, full titlebar height. */
+    width: 46px;
+    align-self: stretch;
+    padding: 0;
     border: none;
     background: transparent;
     color: var(--fg-muted);
     cursor: pointer;
-    transition: background 120ms;
+    transition: background 120ms ease-out, color 120ms ease-out;
+  }
+
+  .win-btn svg {
+    transition: transform 120ms ease-out;
   }
 
   .win-btn:hover {
@@ -457,8 +481,23 @@
     color: var(--fg);
   }
 
+  /* Pressed reads as a deeper fill, not a shrinking button: a scaled caption
+     button would break the flush strip. */
+  .win-btn:active {
+    background: var(--bg-elevated);
+  }
+
+  .win-btn:active svg {
+    transform: scale(0.9);
+  }
+
   .win-btn.close:hover {
     background: var(--danger);
-    color: var(--fg);
+    color: #fff;
+  }
+
+  .win-btn.close:active {
+    background: color-mix(in srgb, var(--danger) 78%, #000);
+    color: #fff;
   }
 </style>


### PR DESCRIPTION
Two UI fixes.

**Windows caption buttons.** Minimize, maximize and close now sit in a strip flush to the window edge, 46px wide and the full titlebar height (native Windows metrics), instead of three 36x36 squares separated by 6px gaps and offset 2px from the edge. Hover fills the whole button, close turns red up to the corner. Pressed deepens the fill and shrinks the icon rather than the button, which would break the strip.

**Avatar loading.** Account avatars flashed the gradient + initials placeholder for a fraction of a second before the real picture appeared. An `<img>` now starts at `opacity: 0` and is revealed once its bytes are decoded (new `fadeInOnLoad` action), and the fallback moved from the avatar box itself to an inner layer whose entrance is held back by an animation delay with `fill-mode: backwards`. An avatar that resolves quickly never paints a placeholder; a slow one still gets its initials, and a fetch in flight still gets its spinner. Same treatment in the grid card, the list row and the preview panel, driven by a new `avatarPending` prop for the state that is not resolved yet.

New motion tokens `--motion-avatar-fade` and `--motion-avatar-defer` plus the shared `avatar-placeholder-in` keyframe live in `app.css`. The global reduced-motion layer already zeroes both, so `animations: off` shows everything instantly.

Checked in the app with the mock backend: caption buttons measure 46x35 and the last one ends exactly at the window width, avatars reveal at `opacity: 1`, and the deferred fallback computes as `avatar-placeholder-in / 0.38s / backwards` starting at `opacity: 0`. `svelte-check` reports 0 errors.
