### PR TITLE
style: replace monospace elements and fallback fonts

### DIFF
--- a/src/lib/platforms/steam/BulkEditBar.svelte
+++ b/src/lib/platforms/steam/BulkEditBar.svelte
@@ -264,7 +264,7 @@
                 {#each launchOptionEdits as edit (edit.appId)}
                   <div class="launch-item">
                     <span class="launch-game">{gameName(edit.appId)}</span>
-                    <code class="launch-value">{edit.value}</code>
+                    <span class="launch-value">{edit.value}</span>
                     <button
                       class="remove-btn"
                       aria-label={t("common.close")}

--- a/src/lib/shared/components/WaveText.svelte
+++ b/src/lib/shared/components/WaveText.svelte
@@ -183,7 +183,7 @@
        Courier New, Han to the CJK families, so the overlay never shows tofu. */
     font-family:
       "VT323", "Courier New", "Microsoft YaHei UI", "PingFang SC", "Hiragino Sans GB",
-      "Noto Sans CJK SC", "Noto Sans SC Subset", monospace !important;
+      "Noto Sans CJK SC", "Noto Sans SC Subset", sans-serif !important;
     font-size: 1.18em;
     font-weight: 700;
     line-height: 0.9;


### PR DESCRIPTION
Replace the launch option value code tag with a span in BulkEditBar and swap the monospace fallback keyword for sans-serif in WaveText.
