### PR TITLE
feat(platforms): enable detected launchers on first run

### DIFF
--- a/crates/accshift-core/src/platforms/mod.rs
+++ b/crates/accshift-core/src/platforms/mod.rs
@@ -3,6 +3,7 @@ use crate::error::PlatformError;
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -201,6 +202,27 @@ pub trait PlatformService: Send + Sync {
         Err(PlatformError::other("Path management not supported"))
     }
 
+    /// Whether this launcher looks present on this machine.
+    ///
+    /// Only used to pick the platforms enabled by default on a fresh install,
+    /// never to gate a feature: a user can always switch a platform on by
+    /// hand, and detection has no way to be exhaustive.
+    ///
+    /// The default reads `get_path`, which every path-managing platform
+    /// resolves from the real install (or from the user's override) and fails
+    /// when it finds nothing. Existence is rechecked here because an override
+    /// can outlive the folder it points at. Platforms without path management
+    /// override this.
+    fn is_installed(&self, app: AppCtx) -> bool {
+        match self.get_path(app) {
+            Ok(path) => {
+                let trimmed = path.trim();
+                !trimmed.is_empty() && Path::new(trimmed).exists()
+            }
+            Err(_) => false,
+        }
+    }
+
     // Account labeling (default: not supported)
     fn set_account_label(
         &self,
@@ -241,6 +263,17 @@ pub fn get_service(platform_id: &str) -> Option<&'static dyn PlatformService> {
     platform_registry().get(platform_id).copied()
 }
 
+/// Ids of the platforms whose launcher was found on this machine, in
+/// `ids::ALL` order. Platforms with no service on this OS are skipped, so the
+/// result is always a set the app can actually enable.
+pub fn detect_installed(app: AppCtx) -> Vec<String> {
+    ids::ALL
+        .iter()
+        .filter(|id| get_service(id).is_some_and(|service| service.is_installed(app.clone())))
+        .map(|id| (*id).to_string())
+        .collect()
+}
+
 pub fn require_service(platform_id: &str) -> Result<&'static dyn PlatformService, PlatformError> {
     get_service(platform_id)
         .ok_or_else(|| PlatformError::other(format!("Unknown platform: {platform_id}")))
@@ -249,6 +282,53 @@ pub fn require_service(platform_id: &str) -> Result<&'static dyn PlatformService
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Detection reads the real machine, so what it finds cannot be asserted.
+    // The shape can: an id nobody can enable, a duplicate or a reordering
+    // would each break the caller, which feeds the result straight into
+    // `enabledPlatforms`.
+    struct TempCtx {
+        root: std::path::PathBuf,
+    }
+
+    impl AppContext for TempCtx {
+        fn app_config_dir(&self) -> Result<std::path::PathBuf, String> {
+            Ok(self.root.clone())
+        }
+        fn app_data_dir(&self) -> Result<std::path::PathBuf, String> {
+            Ok(self.root.clone())
+        }
+        fn app_local_data_dir(&self) -> Result<std::path::PathBuf, String> {
+            Ok(self.root.clone())
+        }
+        fn app_cache_dir(&self) -> Result<std::path::PathBuf, String> {
+            Ok(self.root.clone())
+        }
+    }
+
+    #[test]
+    fn detect_installed_only_returns_enableable_ids_in_display_order() {
+        let ctx: AppCtx = std::sync::Arc::new(TempCtx {
+            root: std::env::temp_dir().join(format!("accshift-detect-test-{}", std::process::id())),
+        });
+
+        let detected = detect_installed(ctx);
+
+        for id in &detected {
+            assert!(
+                get_service(id).is_some(),
+                "detected {id} has no service on this OS"
+            );
+        }
+
+        let mut expected_order = detected.clone();
+        expected_order.sort_by_key(|id| ids::ALL.iter().position(|known| known == id));
+        expected_order.dedup();
+        assert_eq!(
+            detected, expected_order,
+            "ids must follow ids::ALL, once each"
+        );
+    }
 
     #[test]
     fn now_unix_ms_returns_positive_timestamp() {

--- a/crates/accshift-core/src/platforms/roblox.rs
+++ b/crates/accshift-core/src/platforms/roblox.rs
@@ -6,6 +6,8 @@ use crate::platforms::{log_platform_error, log_platform_info, PlatformService, S
 use crate::{AppContext, AppCtx};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::env;
+use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 use std::time::UNIX_EPOCH;
 use uuid::Uuid;
@@ -1049,6 +1051,16 @@ impl PlatformService for RobloxService {
 
     fn cancel_setup(&self, _app: AppCtx, setup_id: &str) -> Result<(), PlatformError> {
         cancel_account_setup(setup_id).map_err(Into::into)
+    }
+
+    /// Roblox has no launcher path to resolve: the player installs itself
+    /// under LOCALAPPDATA and the session lives in HKCU. Either one means the
+    /// machine has seen Roblox, which is what the caller asks about.
+    fn is_installed(&self, _app: AppCtx) -> bool {
+        let player_installed = env::var("LOCALAPPDATA")
+            .map(|dir| PathBuf::from(dir).join("Roblox").is_dir())
+            .unwrap_or(false);
+        player_installed || matches!(read_cookie_from_registry(), Ok(Some(_)))
     }
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -483,6 +483,22 @@ pub async fn platform_set_path(
     run_blocking("platform_set_path", move || service.set_path(c, &path)).await
 }
 
+/// Ids of the platforms whose launcher is installed on this machine.
+///
+/// Called once, on a fresh install, so the app enables the tabs the user
+/// actually has instead of assuming Steam. Filesystem and registry probes
+/// only, hence the blocking pool. An empty list is a valid answer and the
+/// frontend falls back on its own default.
+#[tauri::command]
+pub async fn platform_detect_installed(app_handle: tauri::AppHandle) -> Vec<String> {
+    let c = ctx(&app_handle);
+    run_blocking("platform_detect_installed", move || {
+        Ok(crate::platforms::detect_installed(c))
+    })
+    .await
+    .unwrap_or_default()
+}
+
 #[tauri::command]
 pub fn platform_select_path(platform_id: String) -> Result<String, PlatformError> {
     require_service(&platform_id)?.select_path()

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -407,6 +407,7 @@ fn main() {
             commands::platform_get_path,
             commands::platform_set_path,
             commands::platform_select_path,
+            commands::platform_detect_installed,
             commands::platform_set_account_label,
             // Utility
             commands::open_url,

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -11,6 +11,7 @@
     PlatformAccount,
   } from "$lib/shared/platform";
   import { getPlatform } from "$lib/shared/platform";
+  import { getDetectedPlatforms } from "$lib/app/detectedPlatforms.svelte";
   import type { ItemRef, FolderInfo } from "$lib/features/folders/types";
   import {
     syncAccounts,
@@ -272,6 +273,15 @@
   });
   const personas = createPersonaController();
   // Enabled, implemented platforms usable on this OS, offered as persona slots.
+  // Detection returns ids; the onboarding shows names. Empty until the first
+  // launch detects something, which is exactly when it has nothing to show.
+  let detectedPlatformDefs = $derived(
+    ALL_PLATFORMS.filter((p) => getDetectedPlatforms().includes(p.id)).map((p) => ({
+      id: p.id,
+      name: p.name,
+    })),
+  );
+
   let personaPlatforms = $derived(
     ALL_PLATFORMS.filter(
       (p) =>
@@ -1567,6 +1577,7 @@
       {t}
       version={appVersion}
       compatiblePlatforms={shell.compatiblePlatforms}
+      detectedPlatforms={detectedPlatformDefs}
       onTourActive={(active) => {
         if (active) activateTourMock();
         else deactivateTourMock();

--- a/src/lib/app/detectedPlatforms.svelte.ts
+++ b/src/lib/app/detectedPlatforms.svelte.ts
@@ -1,0 +1,18 @@
+/**
+ * What launcher detection found this launch.
+ *
+ * Set once, during boot, and only on a fresh install: detection runs to pick
+ * the platforms enabled by default. The onboarding reads it so its first
+ * screen lists what is actually on the machine rather than what the OS could
+ * support. Empty means detection did not run, or ran and found nothing, and
+ * callers fall back to the compatibility list.
+ */
+let detected = $state<string[]>([]);
+
+export function setDetectedPlatforms(platformIds: string[]) {
+  detected = [...platformIds];
+}
+
+export function getDetectedPlatforms(): string[] {
+  return detected;
+}

--- a/src/lib/app/useAppLifecycle.svelte.ts
+++ b/src/lib/app/useAppLifecycle.svelte.ts
@@ -5,6 +5,8 @@ import { translate } from "$lib/i18n";
 import type { AppSettings } from "$lib/features/settings/types";
 import type { RuntimeOs } from "$lib/shared/platform";
 import { getBootPayload } from "$lib/app/bootPayload";
+import { setDetectedPlatforms } from "$lib/app/detectedPlatforms.svelte";
+import { getSettings, hasStoredSettings, saveSettings } from "$lib/features/settings/store";
 import { getInitialActiveTab, isPlatformUsable } from "$lib/app/platformShell.svelte";
 import { getPlatformDefinition } from "$lib/platforms/registry";
 import { trackSettingsSnapshot } from "$lib/app/telemetryClient";
@@ -74,6 +76,30 @@ export function createAppLifecycleController({
 }: AppLifecycleDeps) {
   let externalStorageRefreshInFlight = false;
 
+  /// On a fresh install, enable the platforms whose launcher is on the machine
+  /// instead of the hardcoded Steam default: someone who installed accshift for
+  /// Riot or Roblox should not land on an empty Steam tab. Runs once, before
+  /// the first tab is picked, and only while nothing is persisted. Detection
+  /// finding nothing leaves the default alone and retries on the next launch,
+  /// which covers a launcher installed after accshift.
+  async function enableDetectedPlatformsOnFirstRun() {
+    if (hasStoredSettings()) return;
+
+    const detected = await invoke<string[]>("platform_detect_installed").catch((reason) => {
+      console.error("Failed to detect installed platforms:", reason);
+      return [] as string[];
+    });
+    const usable = detected.filter((platformId) => isPlatformUsable(platformId, shell.runtimeOs));
+    setDetectedPlatforms(usable);
+    if (usable.length === 0) return;
+
+    const settings = getSettings();
+    settings.enabledPlatforms = usable;
+    settings.defaultPlatformId = usable[0];
+    saveSettings(settings);
+    shell.refreshSettings();
+  }
+
   async function initializeAppShell() {
     // The boot payload (fetched in main.ts before mount) carries the
     // migration result, custom themes and runtime OS in one round trip.
@@ -118,6 +144,7 @@ export function createAppLifecycleController({
         : "unknown";
 
     shell.setRuntimeOs(normalizedOs);
+    await enableDetectedPlatformsOnFirstRun();
     const nextTab = getInitialActiveTab(shell.settings, shell.runtimeOs);
     if (nextTab !== shell.activeTab) {
       shell.setActiveTab(nextTab);

--- a/src/lib/features/settings/TelemetryOnboarding.svelte
+++ b/src/lib/features/settings/TelemetryOnboarding.svelte
@@ -17,15 +17,30 @@
     t,
     version,
     compatiblePlatforms,
+    detectedPlatforms,
     onTourActive,
     onComplete,
   }: {
     t: (key: MessageKey, params?: TranslationParams) => string;
     version: string;
     compatiblePlatforms: PlatformLike[];
+    /** What launcher detection found. Empty when it did not run or found nothing. */
+    detectedPlatforms: PlatformLike[];
     onTourActive: (active: boolean) => void;
     onComplete: () => void;
   } = $props();
+
+  // Naming what is installed beats naming what the OS allows, but only when
+  // detection actually found something: on an empty result the compatibility
+  // list is all there is to show.
+  const welcomePlatforms = $derived(
+    detectedPlatforms.length > 0 ? detectedPlatforms : compatiblePlatforms,
+  );
+  const welcomeLabelKey = $derived<MessageKey>(
+    detectedPlatforms.length > 0
+      ? "onboarding.welcome.detectedPlatforms"
+      : "onboarding.welcome.compatibleWith",
+  );
 
   let step = $state<Step>("welcome");
   let submitting = $state(false);
@@ -301,9 +316,9 @@
             {t("onboarding.welcome.title")}
             <span class="version-plain">{t("onboarding.welcome.version", { version: version || "?" })}</span>
           </h2>
-          <p class="compat-label">{t("onboarding.welcome.compatibleWith")}</p>
+          <p class="compat-label">{t(welcomeLabelKey)}</p>
           <ul class="compat-list">
-            {#each compatiblePlatforms as p (p.id)}
+            {#each welcomePlatforms as p (p.id)}
               <li class="compat-chip">{p.name}</li>
             {/each}
           </ul>

--- a/src/lib/features/settings/store.ts
+++ b/src/lib/features/settings/store.ts
@@ -229,6 +229,13 @@ function loadSettingsFromStorage(): AppSettings {
   return sanitizeSettings(getClientStoreValue(CLIENT_STORE_SETTINGS) ?? {});
 }
 
+/// Whether settings were ever persisted. False only on a fresh install, which
+/// is the single moment the app may pick `enabledPlatforms` itself: once the
+/// store exists the set belongs to the user, however it got there.
+export function hasStoredSettings(): boolean {
+  return getClientStoreValue(CLIENT_STORE_SETTINGS) != null;
+}
+
 /// Shared, non-cloned view of the settings. Callers must treat it as
 /// read-only: it is the very object `getSettings` clones, so mutating it
 /// corrupts the cache for everyone. Use this on hot paths that read one

--- a/src/lib/i18n/messages.es.ts
+++ b/src/lib/i18n/messages.es.ts
@@ -154,6 +154,7 @@ export const ES_MESSAGES: Record<MessageKey, string> = {
   "onboarding.welcome.title": "Te damos la bienvenida a Accshift",
   "onboarding.welcome.version": "v{version}",
   "onboarding.welcome.compatibleWith": "Tu sistema operativo es compatible con:",
+  "onboarding.welcome.detectedPlatforms": "Estas son las plataformas detectadas en tu equipo:",
   "onboarding.welcome.next": "Dame un tour",
   "onboarding.welcome.skip": "Omitir",
   "onboarding.features.hint": "Esta parte de la app no está visible ahora mismo.",

--- a/src/lib/i18n/messages.fr.ts
+++ b/src/lib/i18n/messages.fr.ts
@@ -154,6 +154,7 @@ export const FR_MESSAGES: Record<MessageKey, string> = {
   "onboarding.welcome.title": "Bienvenue dans Accshift",
   "onboarding.welcome.version": "v{version}",
   "onboarding.welcome.compatibleWith": "Ton système d'exploitation est compatible avec :",
+  "onboarding.welcome.detectedPlatforms": "Voici les plateformes détectées sur ta machine :",
   "onboarding.welcome.next": "Fais-moi visiter",
   "onboarding.welcome.skip": "Passer",
   "onboarding.features.hint": "Cette partie de l'app n'est pas visible pour l'instant.",

--- a/src/lib/i18n/messages.pt-br.ts
+++ b/src/lib/i18n/messages.pt-br.ts
@@ -154,6 +154,7 @@ export const PT_BR_MESSAGES: Record<MessageKey, string> = {
   "onboarding.welcome.title": "Bem-vindo ao Accshift",
   "onboarding.welcome.version": "v{version}",
   "onboarding.welcome.compatibleWith": "Seu sistema operacional é compatível com:",
+  "onboarding.welcome.detectedPlatforms": "Estas são as plataformas detectadas no seu computador:",
   "onboarding.welcome.next": "Quero conhecer",
   "onboarding.welcome.skip": "Pular",
   "onboarding.features.hint": "Esta parte do app não está visível agora.",

--- a/src/lib/i18n/messages.pt.ts
+++ b/src/lib/i18n/messages.pt.ts
@@ -154,6 +154,7 @@ export const PT_MESSAGES: Record<MessageKey, string> = {
   "onboarding.welcome.title": "Bem-vindo ao Accshift",
   "onboarding.welcome.version": "v{version}",
   "onboarding.welcome.compatibleWith": "O teu sistema operativo é compatível com:",
+  "onboarding.welcome.detectedPlatforms": "Estas são as plataformas detetadas no teu computador:",
   "onboarding.welcome.next": "Mostra-me a aplicação",
   "onboarding.welcome.skip": "Ignorar",
   "onboarding.features.hint": "Esta parte da aplicação não está visível neste momento.",

--- a/src/lib/i18n/messages.ru.ts
+++ b/src/lib/i18n/messages.ru.ts
@@ -153,6 +153,7 @@ export const RU_MESSAGES: Record<MessageKey, string> = {
   "onboarding.welcome.title": "Добро пожаловать в Accshift",
   "onboarding.welcome.version": "v{version}",
   "onboarding.welcome.compatibleWith": "Ваша операционная система совместима с:",
+  "onboarding.welcome.detectedPlatforms": "На вашем компьютере обнаружены эти платформы:",
   "onboarding.welcome.next": "Показать обзор",
   "onboarding.welcome.skip": "Пропустить",
   "onboarding.features.hint": "Эта часть приложения сейчас не видна.",

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -145,6 +145,7 @@ export const EN_MESSAGES = {
   "onboarding.welcome.title": "Welcome to Accshift",
   "onboarding.welcome.version": "v{version}",
   "onboarding.welcome.compatibleWith": "Your operating system is compatible with:",
+  "onboarding.welcome.detectedPlatforms": "We found these platforms on your machine:",
   "onboarding.welcome.next": "Show me around",
   "onboarding.welcome.skip": "Skip",
   "onboarding.features.hint": "This part of the app isn't visible right now.",

--- a/src/lib/i18n/messages.zh.ts
+++ b/src/lib/i18n/messages.zh.ts
@@ -149,6 +149,7 @@ export const ZH_MESSAGES: Record<MessageKey, string> = {
   "onboarding.welcome.title": "欢迎使用 Accshift",
   "onboarding.welcome.version": "v{version}",
   "onboarding.welcome.compatibleWith": "你的操作系统兼容以下平台：",
+  "onboarding.welcome.detectedPlatforms": "在你的电脑上检测到以下平台：",
   "onboarding.welcome.next": "带我看看",
   "onboarding.welcome.skip": "跳过",
   "onboarding.features.hint": "应用的这一部分目前不可见。",

--- a/src/lib/mock/fixtures.ts
+++ b/src/lib/mock/fixtures.ts
@@ -44,6 +44,13 @@ export interface MockSpec {
   handlers?: Record<string, Handler>;
 }
 
+function detectedPlatforms(spec: MockSpec): string[] {
+  const settings = spec.stores["client.settings"] as { enabledPlatforms?: unknown } | undefined;
+  const enabled = settings?.enabledPlatforms;
+  if (!Array.isArray(enabled)) return [];
+  return enabled.filter((id): id is string => typeof id === "string");
+}
+
 export function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -182,6 +189,11 @@ export function createHandlers(spec: MockSpec): Record<string, Handler> {
     // real desktop of whoever is running this, so the mock never yields one.
     get_desktop_wallpaper: () => null,
     detect_streaming_software: () => false,
+    // Never probes the real disk: a scenario declares which launchers its
+    // machine has through the platforms it enables, and detection answers
+    // exactly that. Otherwise a capture would depend on what is installed on
+    // the recording machine.
+    platform_detect_installed: () => detectedPlatforms(spec),
     telemetry_get_state: () => ({
       mode_a_enabled: false,
       mode_b_enabled: false,


### PR DESCRIPTION
A fresh install enabled Steam only, whatever the machine had. Someone who installed accshift for Riot or Roblox opened it on an empty Steam tab.

`PlatformService` gains `is_installed`. The default reads `get_path`, which every path-managing platform resolves from the real install or the user override and fails when it finds nothing; existence is rechecked because an override can outlive its folder. Roblox overrides it, having no launcher path: `%LOCALAPPDATA%\Roblox` or the HKCU session.

`platform_detect_installed` returns the ids found, in display order, skipping platforms with no service on the running OS.

The boot path applies the result once, before the first tab is picked, and only while no settings are persisted. Detection finding nothing leaves the Steam default in place and retries next launch, which covers a launcher installed after accshift. `DEFAULTS.enabledPlatforms` is unchanged as the fallback.

The onboarding welcome screen now lists what was detected instead of what the OS supports, with a new string in the seven locales. It falls back to the previous wording when detection did not run or found nothing, so the screen never claims to have detected a platform it did not.

The mock answers `platform_detect_installed` from the platforms its scenario enables, so a recording never depends on what is installed on the machine.

Detection on a Windows 11 machine returns steam, riot, battle-net, ubisoft, roblox, epic, discord. A unit test covers the shape of the result rather than its content: every id enableable, no duplicates, `ids::ALL` order. The first-run path itself is not covered end to end, it needs a profile with no stored settings.
