### PR TITLE
feat(logging): turn the log into a queryable diagnostic layer

### DIFF
--- a/crates/accshift-cli/src/diagnostics.rs
+++ b/crates/accshift-cli/src/diagnostics.rs
@@ -1,0 +1,569 @@
+//! `accshift diag`: read the log, explain a code, check the invariants, pack a
+//! report.
+//!
+//! Deliberately not gated behind the GUI's "allow the CLI" toggle: the user who
+//! needs this is the one whose app is misbehaving, and a support tool that
+//! refuses to run in that case is no tool at all. Nothing here switches an
+//! account or writes anything outside the log directory.
+
+use crate::exit;
+use crate::output::{emit_err, emit_json_ok, Format};
+use accshift_core::diagnostics::{bundle, event::Level, health, levels, query, schema};
+use clap::Subcommand;
+use serde_json::{json, Value};
+
+#[derive(Subcommand)]
+pub enum Diag {
+    /// Print log records, newest last.
+    Logs {
+        /// Only this event code. Repeat for several. Aliases resolve.
+        #[arg(long = "code")]
+        codes: Vec<String>,
+        /// Minimum level: trace, debug, info, warn, error.
+        #[arg(long)]
+        level: Option<String>,
+        /// Only records belonging to this operation.
+        #[arg(long = "op")]
+        op_id: Option<String>,
+        /// Only records from this process launch.
+        #[arg(long = "run")]
+        run_id: Option<String>,
+        /// Only records whose `platform` field matches.
+        #[arg(long)]
+        platform: Option<String>,
+        /// Only records from this module, dot-bounded (`platform` matches
+        /// `platform.steam`).
+        #[arg(long)]
+        source: Option<String>,
+        /// Only the last period: 90s, 30m, 6h, 7d.
+        #[arg(long)]
+        since: Option<String>,
+        /// Substring of the message or the fields, case-insensitive.
+        #[arg(long)]
+        contains: Option<String>,
+        /// Maximum records to print.
+        #[arg(long, default_value_t = 200)]
+        limit: usize,
+        /// Print everything retained, ignoring --limit.
+        #[arg(long)]
+        all: bool,
+    },
+    /// Print what an event code means and what to do about it.
+    Explain {
+        /// Event code, or one of its former spellings.
+        code: String,
+    },
+    /// Run the health invariants and report what holds.
+    Check,
+    /// Show or change the per-module log level.
+    Level {
+        /// Module the level applies to. Omit for the default level.
+        #[arg(long)]
+        module: Option<String>,
+        /// New level: trace, debug, info, warn, error.
+        #[arg(long)]
+        set: Option<String>,
+        /// Drop the override for this module (or the default level).
+        #[arg(long, conflicts_with = "set")]
+        reset: bool,
+        /// Turn on verbose logging for a while, then revert on its own: 15m.
+        #[arg(long = "debug-for")]
+        debug_for: Option<String>,
+        /// End the temporary window now.
+        #[arg(long, conflicts_with = "debug_for")]
+        stop_debug: bool,
+    },
+    /// Write a single pasteable diagnostic report, locally.
+    Bundle {
+        /// Records to include.
+        #[arg(long, default_value_t = bundle::DEFAULT_RECORDS)]
+        records: usize,
+        /// Minimum level of the included records.
+        #[arg(long, default_value = "info")]
+        level: String,
+        /// Restrict the log section to one operation.
+        #[arg(long = "op")]
+        op_id: Option<String>,
+        /// Leave the configuration summary out entirely.
+        #[arg(long)]
+        no_config: bool,
+        /// Print the report instead of only saying where it went.
+        #[arg(long)]
+        print: bool,
+    },
+    /// Print the record schema and the code catalog.
+    Schema {
+        /// Regenerate docs/log-schema.json and docs/log-catalog.json.
+        #[arg(long)]
+        write: Option<std::path::PathBuf>,
+    },
+}
+
+impl Diag {
+    /// Name reported to telemetry: the action, never its arguments.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Diag::Logs { .. } => "diag-logs",
+            Diag::Explain { .. } => "diag-explain",
+            Diag::Check => "diag-check",
+            Diag::Level { .. } => "diag-level",
+            Diag::Bundle { .. } => "diag-bundle",
+            Diag::Schema { .. } => "diag-schema",
+        }
+    }
+}
+
+pub fn run(format: Format, action: Diag) -> u8 {
+    match action {
+        Diag::Logs {
+            codes,
+            level,
+            op_id,
+            run_id,
+            platform,
+            source,
+            since,
+            contains,
+            limit,
+            all,
+        } => cmd_logs(
+            format,
+            LogArgs {
+                codes,
+                level,
+                op_id,
+                run_id,
+                platform,
+                source,
+                since,
+                contains,
+                limit,
+                all,
+            },
+        ),
+        Diag::Explain { code } => cmd_explain(format, &code),
+        Diag::Check => cmd_check(format),
+        Diag::Level {
+            module,
+            set,
+            reset,
+            debug_for,
+            stop_debug,
+        } => cmd_level(format, module, set, reset, debug_for, stop_debug),
+        Diag::Bundle {
+            records,
+            level,
+            op_id,
+            no_config,
+            print,
+        } => cmd_bundle(format, records, &level, op_id, no_config, print),
+        Diag::Schema { write } => cmd_schema(format, write),
+    }
+}
+
+struct LogArgs {
+    codes: Vec<String>,
+    level: Option<String>,
+    op_id: Option<String>,
+    run_id: Option<String>,
+    platform: Option<String>,
+    source: Option<String>,
+    since: Option<String>,
+    contains: Option<String>,
+    limit: usize,
+    all: bool,
+}
+
+fn cmd_logs(format: Format, args: LogArgs) -> u8 {
+    let ctx = match crate::build_ctx(format, "diag-logs") {
+        Ok(ctx) => ctx,
+        Err(code) => return code,
+    };
+
+    let min_level = match args.level.as_deref().map(parse_level).transpose() {
+        Ok(level) => level,
+        Err(message) => {
+            emit_err(format, "diag-logs", "bad_argument", &message);
+            return exit::GENERIC;
+        }
+    };
+    let since_ms = match args.since.as_deref().map(parse_since).transpose() {
+        Ok(since) => since,
+        Err(message) => {
+            emit_err(format, "diag-logs", "bad_argument", &message);
+            return exit::GENERIC;
+        }
+    };
+
+    let filter = query::Filter {
+        codes: args.codes,
+        min_level,
+        op_id: args.op_id,
+        run_id: args.run_id,
+        platform: args.platform,
+        source: args.source,
+        outcome: None,
+        since_ms,
+        until_ms: None,
+        contains: args.contains,
+        limit: if args.all { None } else { Some(args.limit) },
+    };
+
+    let result = match query::search(&*ctx, &filter) {
+        Ok(result) => result,
+        Err(reason) => {
+            emit_err(format, "diag-logs", "io", &reason);
+            return exit::IO;
+        }
+    };
+
+    match format {
+        Format::Json => emit_json_ok(
+            "diag-logs",
+            json!({
+                "records": result.entries.iter().map(|entry| entry.raw.clone()).collect::<Vec<_>>(),
+                "scanned": result.scanned,
+                "unparsable": result.unparsable,
+                "droppedByLimit": result.dropped_by_limit,
+                "files": result.files,
+            }),
+        ),
+        Format::Human => {
+            if result.entries.is_empty() {
+                println!("No record matches. Scanned {} lines.", result.scanned);
+            }
+            for entry in &result.entries {
+                println!("{}", entry.to_line());
+            }
+            if result.dropped_by_limit > 0 {
+                println!(
+                    "({} older matches hidden, pass --all or raise --limit)",
+                    result.dropped_by_limit
+                );
+            }
+        }
+    }
+
+    exit::OK
+}
+
+fn cmd_explain(format: Format, code: &str) -> u8 {
+    let Some(entry) = query::explain(code) else {
+        emit_err(
+            format,
+            "diag-explain",
+            "unknown_code",
+            &format!("No event code named {code}. `accshift diag schema` lists them all."),
+        );
+        return exit::GENERIC;
+    };
+
+    match format {
+        Format::Json => emit_json_ok("diag-explain", entry),
+        Format::Human => {
+            println!("{}", entry["code"].as_str().unwrap_or(code));
+            println!("  level:   {}", text(&entry["level"]));
+            println!("  meaning: {}", text(&entry["meaning"]));
+            println!("  action:  {}", text(&entry["action"]));
+            print_fields("  required:", &entry["requiredFields"]);
+            print_fields("  optional:", &entry["optionalFields"]);
+            let aliases = entry["aliases"].as_array().cloned().unwrap_or_default();
+            if !aliases.is_empty() {
+                println!(
+                    "  also known as: {}",
+                    aliases.iter().map(text).collect::<Vec<_>>().join(", ")
+                );
+            }
+        }
+    }
+
+    exit::OK
+}
+
+fn print_fields(label: &str, fields: &Value) {
+    let Some(fields) = fields.as_array() else {
+        return;
+    };
+    if fields.is_empty() {
+        return;
+    }
+    let rendered: Vec<String> = fields
+        .iter()
+        .map(|field| format!("{} ({})", text(&field["name"]), text(&field["type"])))
+        .collect();
+    println!("{label} {}", rendered.join(", "));
+}
+
+fn text(value: &Value) -> String {
+    value.as_str().unwrap_or_default().to_string()
+}
+
+fn cmd_check(format: Format) -> u8 {
+    let ctx = match crate::build_ctx(format, "diag-check") {
+        Ok(ctx) => ctx,
+        Err(code) => return code,
+    };
+
+    let report = health::startup_report(&*ctx);
+    health::emit(&*ctx, &report, None, None);
+
+    match format {
+        Format::Json => emit_json_ok("diag-check", report.to_json()),
+        Format::Human => {
+            for result in &report.results {
+                println!(
+                    "{:<5} {:<16} {}",
+                    result.status.as_str(),
+                    result.check,
+                    result.detail
+                );
+                if !result.action.is_empty() {
+                    println!("      {}", result.action);
+                }
+            }
+            if report.ok() {
+                println!("All invariants hold.");
+            }
+        }
+    }
+
+    if report.ok() {
+        exit::OK
+    } else {
+        exit::GENERIC
+    }
+}
+
+fn cmd_level(
+    format: Format,
+    module: Option<String>,
+    set: Option<String>,
+    reset: bool,
+    debug_for: Option<String>,
+    stop_debug: bool,
+) -> u8 {
+    let ctx = match crate::build_ctx(format, "diag-level") {
+        Ok(ctx) => ctx,
+        Err(code) => return code,
+    };
+
+    let outcome = if let Some(duration) = debug_for {
+        match parse_duration_ms(&duration) {
+            Err(message) => Err(message),
+            Ok(duration_ms) => levels::start_temporary_debug(
+                &*ctx,
+                Level::Debug,
+                module.clone().into_iter().collect(),
+                duration_ms,
+            ),
+        }
+    } else if stop_debug {
+        levels::stop_temporary_debug(&*ctx)
+    } else if reset {
+        levels::set_level(&*ctx, module.as_deref(), None)
+    } else if let Some(level) = set {
+        match parse_level(&level) {
+            Err(message) => Err(message),
+            Ok(level) => levels::set_level(&*ctx, module.as_deref(), Some(level)),
+        }
+    } else {
+        Ok(levels::load(&*ctx))
+    };
+
+    let config = match outcome {
+        Ok(config) => config,
+        Err(message) => {
+            emit_err(format, "diag-level", "bad_argument", &message);
+            return exit::GENERIC;
+        }
+    };
+
+    let now_ms = accshift_core::diagnostics::event::now_unix_ms();
+    match format {
+        Format::Json => emit_json_ok("diag-level", config.to_json(now_ms)),
+        Format::Human => {
+            println!("default: {}", config.default.as_str());
+            for (module, level) in &config.modules {
+                println!("{module}: {}", level.as_str());
+            }
+            match &config.temporary {
+                Some(temporary) if config.temporary_active(now_ms) => {
+                    let remaining = temporary.until_ms.saturating_sub(now_ms) / 1000;
+                    let scope = if temporary.modules.is_empty() {
+                        "everything".to_string()
+                    } else {
+                        temporary.modules.join(", ")
+                    };
+                    println!(
+                        "temporary {} on {scope}, {remaining}s left",
+                        temporary.level.as_str()
+                    );
+                }
+                _ => println!("no temporary window"),
+            }
+        }
+    }
+
+    exit::OK
+}
+
+fn cmd_bundle(
+    format: Format,
+    records: usize,
+    level: &str,
+    op_id: Option<String>,
+    no_config: bool,
+    print: bool,
+) -> u8 {
+    let ctx = match crate::build_ctx(format, "diag-bundle") {
+        Ok(ctx) => ctx,
+        Err(code) => return code,
+    };
+
+    let min_level = match parse_level(level) {
+        Ok(level) => level,
+        Err(message) => {
+            emit_err(format, "diag-bundle", "bad_argument", &message);
+            return exit::GENERIC;
+        }
+    };
+
+    let options = bundle::Options {
+        records,
+        min_level,
+        op_id,
+        include_config: !no_config,
+        app_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+    };
+
+    let (path, bytes) = match bundle::write(&*ctx, &options) {
+        Ok(written) => written,
+        Err(reason) => {
+            emit_err(format, "diag-bundle", "io", &reason);
+            return exit::IO;
+        }
+    };
+
+    if print {
+        match std::fs::read_to_string(&path) {
+            Ok(text) => println!("{text}"),
+            Err(reason) => {
+                emit_err(format, "diag-bundle", "io", &reason.to_string());
+                return exit::IO;
+            }
+        }
+        return exit::OK;
+    }
+
+    match format {
+        Format::Json => emit_json_ok(
+            "diag-bundle",
+            json!({ "path": path.display().to_string(), "bytes": bytes }),
+        ),
+        Format::Human => {
+            println!("Report written to {}", path.display());
+            println!(
+                "{bytes} bytes. Nothing was sent anywhere: read it, then paste it if you want."
+            );
+        }
+    }
+
+    exit::OK
+}
+
+fn cmd_schema(format: Format, write: Option<std::path::PathBuf>) -> u8 {
+    if let Some(dir) = write {
+        return match schema::write_docs(&dir) {
+            Ok(written) => {
+                match format {
+                    Format::Json => emit_json_ok("diag-schema", json!({ "written": written })),
+                    Format::Human => {
+                        for name in written {
+                            println!("wrote {}", dir.join(name).display());
+                        }
+                    }
+                }
+                exit::OK
+            }
+            Err(reason) => {
+                emit_err(format, "diag-schema", "io", &reason);
+                exit::IO
+            }
+        };
+    }
+
+    match format {
+        Format::Json => emit_json_ok("diag-schema", schema::to_json()),
+        Format::Human => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&schema::to_json()).unwrap_or_default()
+            );
+        }
+    }
+
+    exit::OK
+}
+
+fn parse_level(value: &str) -> Result<Level, String> {
+    Level::parse(value)
+        .ok_or_else(|| format!("Unknown level {value}. Use trace, debug, info, warn or error."))
+}
+
+/// `90s`, `30m`, `6h`, `7d`. A bare number is minutes, which is what people
+/// type when they mean "for a bit".
+fn parse_duration_ms(value: &str) -> Result<u64, String> {
+    let trimmed = value.trim();
+    let (digits, multiplier) = match trimmed.chars().last() {
+        Some('s') => (&trimmed[..trimmed.len() - 1], 1_000),
+        Some('m') => (&trimmed[..trimmed.len() - 1], 60 * 1_000),
+        Some('h') => (&trimmed[..trimmed.len() - 1], 60 * 60 * 1_000),
+        Some('d') => (&trimmed[..trimmed.len() - 1], 24 * 60 * 60 * 1_000),
+        _ => (trimmed, 60 * 1_000),
+    };
+
+    digits
+        .trim()
+        .parse::<u64>()
+        .map_err(|_| format!("Cannot read {value} as a duration. Try 15m, 2h or 7d."))
+        .map(|amount| amount.saturating_mul(multiplier))
+}
+
+fn parse_since(value: &str) -> Result<u128, String> {
+    let duration_ms = parse_duration_ms(value)?;
+    Ok(accshift_core::diagnostics::event::now_unix_ms().saturating_sub(u128::from(duration_ms)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn durations_read_the_way_people_type_them() {
+        assert_eq!(parse_duration_ms("90s"), Ok(90_000));
+        assert_eq!(parse_duration_ms("15m"), Ok(900_000));
+        assert_eq!(parse_duration_ms("2h"), Ok(7_200_000));
+        assert_eq!(parse_duration_ms("7d"), Ok(604_800_000));
+        assert_eq!(
+            parse_duration_ms("5"),
+            Ok(300_000),
+            "a bare number is minutes"
+        );
+        assert!(parse_duration_ms("soon").is_err());
+    }
+
+    #[test]
+    fn levels_accept_the_spellings_a_user_types() {
+        assert_eq!(parse_level("WARN"), Ok(Level::Warn));
+        assert_eq!(parse_level("warning"), Ok(Level::Warn));
+        assert!(parse_level("loud").is_err());
+    }
+
+    #[test]
+    fn since_is_a_point_in_the_past() {
+        let now = accshift_core::diagnostics::event::now_unix_ms();
+        let since = parse_since("1h").expect("duration");
+        assert!(since <= now);
+        assert!(now - since >= 3_600_000);
+    }
+}

--- a/crates/accshift-cli/src/diagnostics.rs
+++ b/crates/accshift-cli/src/diagnostics.rs
@@ -8,7 +8,9 @@
 
 use crate::exit;
 use crate::output::{emit_err, emit_json_ok, Format};
-use accshift_core::diagnostics::{bundle, event::Level, health, levels, query, schema};
+use accshift_core::diagnostics::{
+    bundle, event::Level, health, levels, query, sanitize_log_text, schema,
+};
 use clap::Subcommand;
 use serde_json::{json, Value};
 
@@ -298,6 +300,15 @@ fn text(value: &Value) -> String {
     value.as_str().unwrap_or_default().to_string()
 }
 
+fn format_check_line(result: &health::CheckResult) -> String {
+    format!(
+        "{:<5} {:<16} {}",
+        result.status.as_str(),
+        result.check,
+        sanitize_log_text(&result.detail)
+    )
+}
+
 fn cmd_check(format: Format) -> u8 {
     let ctx = match crate::build_ctx(format, "diag-check") {
         Ok(ctx) => ctx,
@@ -311,12 +322,7 @@ fn cmd_check(format: Format) -> u8 {
         Format::Json => emit_json_ok("diag-check", report.to_json()),
         Format::Human => {
             for result in &report.results {
-                println!(
-                    "{:<5} {:<16} {}",
-                    result.status.as_str(),
-                    result.check,
-                    result.detail
-                );
+                println!("{}", format_check_line(result));
                 if !result.action.is_empty() {
                     println!("      {}", result.action);
                 }
@@ -565,5 +571,31 @@ mod tests {
         let since = parse_since("1h").expect("duration");
         assert!(since <= now);
         assert!(now - since >= 3_600_000);
+    }
+
+    #[test]
+    fn human_check_output_redacts_paths_in_detail() {
+        let home = std::env::var("USERPROFILE")
+            .or_else(|_| std::env::var("HOME"))
+            .expect("a home directory to redact");
+        let raw = format!("writable, {home}\\accshift\\logs");
+        let result = health::CheckResult {
+            check: "logdir",
+            status: health::Status::Pass,
+            code: None,
+            detail: raw.clone(),
+            action: "",
+            fields: Default::default(),
+        };
+
+        let line = format_check_line(&result);
+        assert!(
+            !line.contains(&home),
+            "human output must not print the account path: {line}"
+        );
+        assert!(
+            raw.contains(&home),
+            "the fixture itself must carry a real path, or the test is a no-op"
+        );
     }
 }

--- a/crates/accshift-cli/src/main.rs
+++ b/crates/accshift-cli/src/main.rs
@@ -1,4 +1,5 @@
 mod context;
+mod diagnostics;
 mod folders;
 mod output;
 mod pin;
@@ -104,6 +105,11 @@ enum Command {
         /// Account identifier (see `accshift list <platform>`).
         account_id: String,
     },
+    /// Read the log, explain a code, check the invariants, pack a report.
+    Diag {
+        #[command(subcommand)]
+        action: diagnostics::Diag,
+    },
 }
 
 impl Command {
@@ -116,6 +122,7 @@ impl Command {
             Command::Switch { .. } => "switch",
             Command::Descriptors => "descriptors",
             Command::DryRun { .. } => "dry-run",
+            Command::Diag { action } => action.name(),
         }
     }
 }
@@ -164,6 +171,7 @@ fn main() -> ExitCode {
             platform,
             account_id,
         } => cmd_dry_run(format, &platform, &account_id),
+        Command::Diag { action } => diagnostics::run(format, action),
     };
 
     if let Some(reporter) = reporter {

--- a/crates/accshift-core/src/diagnostics/anomaly.rs
+++ b/crates/accshift-core/src/diagnostics/anomaly.rs
@@ -1,0 +1,435 @@
+//! Anomaly counters: the part that notices a problem before it breaks.
+//!
+//! A single failed switch is an incident the user already saw. Three in a row
+//! on the same platform, a switch that suddenly takes eight times its usual
+//! duration, a snapshot captured empty, a restore that wrote zero bytes: those
+//! are the shapes that predict the next failure, and none of them is visible
+//! from one log line.
+//!
+//! State lives in `anomalies.json` next to the log, guarded by an exclusive
+//! lock because the GUI and the CLI both write it. Events are emitted after
+//! the lock is released, so the log sink is never entered while this file's
+//! lock is held.
+
+use super::event::{now_unix_ms, Outcome};
+use super::{catalog, event};
+use crate::context::{AppContext, AppCtx};
+use fs4::FileExt;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+use std::fs::OpenOptions;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::PathBuf;
+
+pub const ANOMALY_FILE_NAME: &str = "anomalies.json";
+
+/// Failures in a row on one platform before it is worth a warning.
+const CONSECUTIVE_FAILURE_THRESHOLD: u64 = 3;
+/// Samples needed before the rolling baseline means anything.
+const MIN_SAMPLES_FOR_BASELINE: u64 = 8;
+/// A run must beat this many standard deviations over the mean.
+const SLOW_SIGMA: f64 = 3.0;
+/// ... and also this multiple of the mean, so a very stable fast operation
+/// does not report an outlier on a 30 ms hiccup.
+const SLOW_FACTOR: f64 = 1.5;
+/// ... and this floor, because nothing under it is worth a user's attention.
+const SLOW_FLOOR_MS: f64 = 750.0;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase", default)]
+pub struct PlatformCounters {
+    pub consecutive_failures: u64,
+    pub total_failures: u64,
+    pub total_successes: u64,
+    pub last_failure_ms: u64,
+}
+
+/// Welford accumulator: mean and variance without keeping the samples.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase", default)]
+pub struct DurationStats {
+    pub count: u64,
+    pub mean_ms: f64,
+    pub m2: f64,
+    pub max_ms: u64,
+}
+
+impl DurationStats {
+    fn observe(&mut self, value_ms: u64) {
+        let value = value_ms as f64;
+        self.count += 1;
+        let delta = value - self.mean_ms;
+        self.mean_ms += delta / self.count as f64;
+        self.m2 += delta * (value - self.mean_ms);
+        self.max_ms = self.max_ms.max(value_ms);
+    }
+
+    pub fn std_dev(&self) -> f64 {
+        if self.count < 2 {
+            return 0.0;
+        }
+        (self.m2 / (self.count - 1) as f64).max(0.0).sqrt()
+    }
+
+    /// Threshold a run has to beat to count as an outlier, or `None` while the
+    /// baseline is still too thin to accuse anything.
+    pub fn outlier_threshold_ms(&self) -> Option<f64> {
+        if self.count < MIN_SAMPLES_FOR_BASELINE {
+            return None;
+        }
+        let sigma_bound = self.mean_ms + SLOW_SIGMA * self.std_dev();
+        let factor_bound = self.mean_ms * SLOW_FACTOR;
+        Some(sigma_bound.max(factor_bound).max(SLOW_FLOOR_MS))
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase", default)]
+pub struct AnomalyState {
+    pub platforms: BTreeMap<String, PlatformCounters>,
+    /// Keyed by `<operation>` or `<operation>@<platform>`.
+    pub operations: BTreeMap<String, DurationStats>,
+}
+
+pub fn anomaly_file_path(app_handle: &dyn AppContext) -> Result<PathBuf, String> {
+    Ok(crate::storage::app_log_root(app_handle)?.join(ANOMALY_FILE_NAME))
+}
+
+/// Current counters, for the diagnostic report and the query command.
+pub fn state(app_handle: &dyn AppContext) -> AnomalyState {
+    let Ok(path) = anomaly_file_path(app_handle) else {
+        return AnomalyState::default();
+    };
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|text| serde_json::from_str(&text).ok())
+        .unwrap_or_default()
+}
+
+/// Read, mutate and write the counter file under an exclusive lock.
+///
+/// Returns whatever `mutate` produced. Callers emit from that, after the lock
+/// is gone: entering the log sink under this lock would nest two cross-process
+/// locks in an order nothing else respects.
+fn with_state<T>(
+    app_handle: &dyn AppContext,
+    mutate: impl FnOnce(&mut AnomalyState) -> T,
+) -> Option<T> {
+    let path = anomaly_file_path(app_handle).ok()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).ok()?;
+    }
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&path)
+        .ok()?;
+    // Best effort, exactly like the log sink: a counter is never worth
+    // failing a switch over.
+    let locked = FileExt::lock(&file).is_ok();
+
+    let mut text = String::new();
+    let mut state = match file.read_to_string(&mut text) {
+        // A truncated or hand-mangled file resets rather than poisons.
+        Ok(_) => serde_json::from_str(&text).unwrap_or_default(),
+        Err(_) => AnomalyState::default(),
+    };
+
+    let produced = mutate(&mut state);
+
+    if let Ok(payload) = serde_json::to_vec_pretty(&state) {
+        let _ = file.set_len(0);
+        let _ = file.seek(SeekFrom::Start(0));
+        let _ = file.write_all(&payload);
+        let _ = file.flush();
+    }
+    if locked {
+        let _ = FileExt::unlock(&file);
+    }
+
+    Some(produced)
+}
+
+fn operation_key(operation: &str, platform: Option<&str>) -> String {
+    match platform {
+        Some(platform) => format!("{operation}@{platform}"),
+        None => operation.to_string(),
+    }
+}
+
+/// What the counters concluded, decided under the lock and emitted outside it.
+struct Findings {
+    consecutive_failures: Option<(String, u64)>,
+    slow: Option<(u64, u64)>,
+}
+
+/// Fold one finished operation into the counters. Called by [`super::ops::Op`]
+/// on close, so instrumenting an operation is all it takes to get this.
+pub fn record_operation(
+    ctx: &AppCtx,
+    platform: Option<&str>,
+    operation: &'static str,
+    outcome: Outcome,
+    dur_ms: u64,
+) {
+    let key = operation_key(operation, platform);
+    let findings = with_state(&**ctx, |state| {
+        let mut findings = Findings {
+            consecutive_failures: None,
+            slow: None,
+        };
+
+        if let Some(platform) = platform {
+            let counters = state.platforms.entry(platform.to_string()).or_default();
+            match outcome {
+                Outcome::Failure => {
+                    counters.consecutive_failures += 1;
+                    counters.total_failures += 1;
+                    counters.last_failure_ms = now_unix_ms().min(u128::from(u64::MAX)) as u64;
+                    if counters.consecutive_failures >= CONSECUTIVE_FAILURE_THRESHOLD {
+                        findings.consecutive_failures =
+                            Some((platform.to_string(), counters.consecutive_failures));
+                    }
+                }
+                Outcome::Success => {
+                    counters.consecutive_failures = 0;
+                    counters.total_successes += 1;
+                }
+                // A cancelled attempt says nothing about the platform's health.
+                Outcome::Cancelled => {}
+            }
+        }
+
+        // Only successes feed the duration baseline: a failure that aborts
+        // early would drag the mean down and hide real slowdowns.
+        if matches!(outcome, Outcome::Success) {
+            let stats = state.operations.entry(key).or_default();
+            if let Some(threshold) = stats.outlier_threshold_ms() {
+                if dur_ms as f64 > threshold {
+                    findings.slow = Some((dur_ms, stats.mean_ms.round() as u64));
+                }
+            }
+            stats.observe(dur_ms);
+        }
+
+        findings
+    });
+
+    let Some(findings) = findings else {
+        return;
+    };
+
+    if let Some((platform, failures)) = findings.consecutive_failures {
+        let mut builder = event::event(&catalog::ANOMALY_PLATFORM_CONSECUTIVE_FAILURES)
+            .source("diagnostics.anomaly")
+            .field("platform", platform)
+            .field("failures", failures);
+        builder = builder.field("op", operation);
+        builder
+            .msg("Repeated failures on the same platform")
+            .emit(&**ctx);
+    }
+
+    if let Some((dur_ms, baseline_ms)) = findings.slow {
+        let mut builder = event::event(&catalog::ANOMALY_OPERATION_SLOW)
+            .source("diagnostics.anomaly")
+            .field("op", operation)
+            .field("durMs", dur_ms)
+            .field("baselineMs", baseline_ms);
+        if let Some(platform) = platform {
+            builder = builder.field("platform", platform);
+        }
+        builder
+            .msg("Operation far slower than its own baseline")
+            .emit(&**ctx);
+    }
+}
+
+/// A snapshot that captured nothing is a switch that will fail later, not now.
+pub fn record_snapshot(ctx: &AppCtx, platform: &str, entries: usize, path: Option<&str>) {
+    if entries > 0 {
+        return;
+    }
+    let mut builder = event::event(&catalog::ANOMALY_SNAPSHOT_EMPTY)
+        .source("diagnostics.anomaly")
+        .field("platform", platform);
+    if let Some(path) = path {
+        builder = builder.field("path", path);
+    }
+    builder.msg("Captured snapshot is empty").emit(&**ctx);
+}
+
+/// A restore that reports success without writing anything left the launcher
+/// on the previous account. The user finds out at the login screen.
+pub fn record_restore(ctx: &AppCtx, platform: &str, bytes_written: u64, path: Option<&str>) {
+    if bytes_written > 0 {
+        return;
+    }
+    let mut builder = event::event(&catalog::ANOMALY_RESTORE_NO_WRITE)
+        .source("diagnostics.anomaly")
+        .field("platform", platform);
+    if let Some(path) = path {
+        builder = builder.field("path", path);
+    }
+    builder
+        .msg("Restore completed without writing any byte")
+        .emit(&**ctx);
+}
+
+/// Counters as JSON, for the diagnostic report.
+pub fn to_json(app_handle: &dyn AppContext) -> Value {
+    let state = state(app_handle);
+    json!({
+        "platforms": state
+            .platforms
+            .iter()
+            .map(|(platform, counters)| {
+                (
+                    platform.clone(),
+                    json!({
+                        "consecutiveFailures": counters.consecutive_failures,
+                        "totalFailures": counters.total_failures,
+                        "totalSuccesses": counters.total_successes,
+                        "lastFailureMs": counters.last_failure_ms,
+                    }),
+                )
+            })
+            .collect::<serde_json::Map<String, Value>>(),
+        "operations": state
+            .operations
+            .iter()
+            .map(|(operation, stats)| {
+                (
+                    operation.clone(),
+                    json!({
+                        "count": stats.count,
+                        "meanMs": stats.mean_ms.round() as u64,
+                        "stdDevMs": stats.std_dev().round() as u64,
+                        "maxMs": stats.max_ms,
+                        "outlierAboveMs": stats.outlier_threshold_ms().map(|t| t.round() as u64),
+                    }),
+                )
+            })
+            .collect::<serde_json::Map<String, Value>>(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diagnostics::query;
+    use crate::diagnostics::test_support::TestCtx;
+
+    fn codes(ctx: &AppCtx, code: &str) -> usize {
+        let filter = query::Filter {
+            codes: vec![code.to_string()],
+            ..Default::default()
+        };
+        query::search(&**ctx, &filter).expect("query").entries.len()
+    }
+
+    #[test]
+    fn consecutive_failures_warn_only_at_the_threshold() {
+        let ctx = TestCtx::ctx("anomaly-consecutive");
+
+        for _ in 0..(CONSECUTIVE_FAILURE_THRESHOLD - 1) {
+            record_operation(&ctx, Some("steam"), "platform.switch", Outcome::Failure, 10);
+        }
+        assert_eq!(
+            codes(&ctx, "anomaly.platform.consecutive_failures"),
+            0,
+            "two failures are an incident, not a pattern"
+        );
+
+        record_operation(&ctx, Some("steam"), "platform.switch", Outcome::Failure, 10);
+        assert_eq!(codes(&ctx, "anomaly.platform.consecutive_failures"), 1);
+
+        // A success clears the streak, so the next failure starts over.
+        record_operation(&ctx, Some("steam"), "platform.switch", Outcome::Success, 10);
+        record_operation(&ctx, Some("steam"), "platform.switch", Outcome::Failure, 10);
+        assert_eq!(codes(&ctx, "anomaly.platform.consecutive_failures"), 1);
+    }
+
+    #[test]
+    fn a_thin_baseline_never_accuses_anything() {
+        let mut stats = DurationStats::default();
+        for _ in 0..(MIN_SAMPLES_FOR_BASELINE - 1) {
+            stats.observe(100);
+        }
+        assert!(stats.outlier_threshold_ms().is_none());
+        stats.observe(100);
+        assert!(stats.outlier_threshold_ms().is_some());
+    }
+
+    #[test]
+    fn a_run_far_over_the_baseline_is_reported() {
+        let ctx = TestCtx::ctx("anomaly-slow");
+        for _ in 0..12 {
+            record_operation(
+                &ctx,
+                Some("steam"),
+                "platform.switch",
+                Outcome::Success,
+                1_000,
+            );
+        }
+        assert_eq!(codes(&ctx, "anomaly.operation.slow"), 0);
+
+        record_operation(
+            &ctx,
+            Some("steam"),
+            "platform.switch",
+            Outcome::Success,
+            30_000,
+        );
+        assert_eq!(codes(&ctx, "anomaly.operation.slow"), 1);
+    }
+
+    // A stable 5 ms operation must not be called slow because one run took
+    // 40 ms: nobody can perceive it and the noise would bury real findings.
+    #[test]
+    fn a_fast_operation_needs_an_absolute_floor_too() {
+        let mut stats = DurationStats::default();
+        for _ in 0..20 {
+            stats.observe(5);
+        }
+        let threshold = stats.outlier_threshold_ms().expect("threshold");
+        assert!(threshold >= SLOW_FLOOR_MS, "{threshold}");
+    }
+
+    #[test]
+    fn empty_snapshots_and_silent_restores_are_reported() {
+        let ctx = TestCtx::ctx("anomaly-payloads");
+
+        record_snapshot(&ctx, "riot", 0, Some("C:/riot/profile.json"));
+        record_snapshot(&ctx, "riot", 3, None);
+        record_restore(&ctx, "riot", 0, None);
+        record_restore(&ctx, "riot", 4_096, None);
+
+        assert_eq!(codes(&ctx, "anomaly.snapshot.empty"), 1);
+        assert_eq!(codes(&ctx, "anomaly.restore.no_write"), 1);
+    }
+
+    #[test]
+    fn counters_survive_a_corrupt_state_file() {
+        let ctx = TestCtx::ctx("anomaly-corrupt");
+        let path = anomaly_file_path(&*ctx).expect("path");
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&path, "}}not json{{").expect("write");
+
+        record_operation(&ctx, Some("steam"), "platform.switch", Outcome::Failure, 5);
+
+        let state = state(&*ctx);
+        assert_eq!(
+            state
+                .platforms
+                .get("steam")
+                .map(|counters| counters.consecutive_failures),
+            Some(1)
+        );
+    }
+}

--- a/crates/accshift-core/src/diagnostics/bundle.rs
+++ b/crates/accshift-core/src/diagnostics/bundle.rs
@@ -1,0 +1,499 @@
+//! The diagnostic report: everything needed to debug an incident, in one
+//! local file the user can read before deciding to paste it anywhere.
+//!
+//! Nothing here touches the network. The report is written next to the log,
+//! redacted by default, and the only thing that ever leaves the machine is
+//! what the user copies out of it themselves. None of it joins the telemetry.
+//!
+//! The configuration is summarised deny-by-default: values are dropped unless
+//! their key is known to be harmless. That survives a config that grows new
+//! secret fields, which a deny-list would not.
+
+use super::event::{now_unix_ms, Level};
+use super::{anomaly, catalog, event, health, levels, query, redact};
+use crate::context::AppContext;
+use serde_json::{json, Map, Value};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+pub const BUNDLE_FILE_NAME: &str = "diagnostic-report.md";
+
+/// Beyond this the file stops being pasteable. The log tail is what gets cut,
+/// and the report says so.
+pub const MAX_BUNDLE_BYTES: usize = 256 * 1024;
+
+/// Default number of log records included, newest last.
+pub const DEFAULT_RECORDS: usize = 300;
+
+#[derive(Debug, Clone)]
+pub struct Options {
+    /// How many log records to include.
+    pub records: usize,
+    /// Minimum level of the included records.
+    pub min_level: Level,
+    /// Restrict the log section to one operation.
+    pub op_id: Option<String>,
+    /// Include the redacted configuration summary.
+    pub include_config: bool,
+    /// Version string of the caller (the GUI knows its own; core does not).
+    pub app_version: Option<String>,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Options {
+            records: DEFAULT_RECORDS,
+            min_level: Level::Info,
+            op_id: None,
+            include_config: true,
+            app_version: None,
+        }
+    }
+}
+
+/// Where the report is written. Next to the log, so a user looking for one
+/// finds the other.
+pub fn bundle_path(app_handle: &dyn AppContext) -> Result<PathBuf, String> {
+    Ok(crate::storage::app_log_root(app_handle)?.join(BUNDLE_FILE_NAME))
+}
+
+/// Build the report and write it. Returns its path and size.
+pub fn write(app_handle: &dyn AppContext, options: &Options) -> Result<(PathBuf, usize), String> {
+    let path = bundle_path(app_handle)?;
+    let text = render(app_handle, options);
+    super::write_atomic(&path, text.as_bytes())?;
+
+    event::event(&catalog::DIAGNOSTICS_BUNDLE_WRITTEN)
+        .source("diagnostics")
+        .msg("Diagnostic report written locally")
+        .field("path", path.display().to_string())
+        .field("bytes", text.len() as u64)
+        .emit(app_handle);
+
+    Ok((path, text.len()))
+}
+
+/// The report as text. Separated from the writing so it can be tested, and so
+/// a caller can show it before it exists on disk.
+pub fn render(app_handle: &dyn AppContext, options: &Options) -> String {
+    let mut out = String::new();
+
+    out.push_str("# accshift diagnostic report\n\n");
+    out.push_str(
+        "Generated locally. Nothing was sent anywhere: this file only leaves your machine if you paste it.\n\n",
+    );
+
+    section(&mut out, "Environment", &environment(options));
+
+    let health = health::startup_report(app_handle);
+    section(&mut out, "Health invariants", &health.to_json());
+
+    section(&mut out, "Anomaly counters", &anomaly::to_json(app_handle));
+
+    section(&mut out, "Log storage", &storage_summary(app_handle));
+
+    section(
+        &mut out,
+        "Log levels",
+        &levels::load(app_handle).to_json(now_unix_ms()),
+    );
+
+    if options.include_config {
+        section(
+            &mut out,
+            "Configuration (redacted)",
+            &config_summary(app_handle),
+        );
+    }
+
+    let (records, codes) = log_section(app_handle, options);
+    if !codes.is_empty() {
+        section(
+            &mut out,
+            "Codes present, and what to do about them",
+            &codes_help(&codes),
+        );
+    }
+
+    out.push_str("## Recent log\n\n");
+    out.push_str(
+        "JSONL, oldest first. The schema is in docs/log-schema.json, the codes in docs/log-catalog.json.\n\n",
+    );
+    out.push_str("```jsonl\n");
+
+    // The log tail is the only unbounded section, so it is the one that gets
+    // cut, and the cut is announced rather than silent.
+    let budget = MAX_BUNDLE_BYTES.saturating_sub(out.len() + 256);
+    let mut kept: Vec<&String> = Vec::new();
+    let mut used = 0usize;
+    for line in records.iter().rev() {
+        if used + line.len() + 1 > budget {
+            break;
+        }
+        used += line.len() + 1;
+        kept.push(line);
+    }
+    let dropped = records.len() - kept.len();
+    for line in kept.iter().rev() {
+        out.push_str(line);
+        out.push('\n');
+    }
+    out.push_str("```\n");
+    if dropped > 0 {
+        out.push_str(&format!(
+            "\n{dropped} older records were cut to keep this file pasteable. Use `accshift diag logs` for the rest.\n"
+        ));
+    }
+
+    out
+}
+
+fn section(out: &mut String, title: &str, value: &Value) {
+    out.push_str(&format!("## {title}\n\n```json\n"));
+    out.push_str(&serde_json::to_string_pretty(value).unwrap_or_else(|_| "{}".to_string()));
+    out.push_str("\n```\n\n");
+}
+
+fn environment(options: &Options) -> Value {
+    json!({
+        "appVersion": options
+            .app_version
+            .clone()
+            .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string()),
+        "coreVersion": env!("CARGO_PKG_VERSION"),
+        "os": sysinfo::System::name().unwrap_or_else(|| std::env::consts::OS.to_string()),
+        "osVersion": sysinfo::System::os_version().unwrap_or_else(|| "unknown".to_string()),
+        "kernelVersion": sysinfo::System::kernel_version().unwrap_or_else(|| "unknown".to_string()),
+        "arch": std::env::consts::ARCH,
+        "runId": event::run_id(),
+        "generatedAtMs": now_unix_ms(),
+        "schemaVersion": event::SCHEMA_VERSION,
+        "build": if cfg!(debug_assertions) { "debug" } else { "release" },
+    })
+}
+
+fn storage_summary(app_handle: &dyn AppContext) -> Value {
+    let mut files = Vec::new();
+    let mut total = 0u64;
+    if let Ok(paths) = query::retained_files(app_handle) {
+        for path in paths {
+            let size = std::fs::metadata(&path).map(|meta| meta.len()).unwrap_or(0);
+            total += size;
+            files.push(json!({
+                "file": path.file_name().map(|name| name.to_string_lossy().to_string()),
+                "bytes": size,
+            }));
+        }
+    }
+
+    json!({
+        "retention": crate::logging::retention_policy(),
+        "files": files,
+        "totalBytes": total,
+    })
+}
+
+fn log_section(app_handle: &dyn AppContext, options: &Options) -> (Vec<String>, BTreeSet<String>) {
+    let filter = query::Filter {
+        min_level: Some(options.min_level),
+        op_id: options.op_id.clone(),
+        limit: Some(options.records),
+        ..Default::default()
+    };
+    let Ok(result) = query::search(app_handle, &filter) else {
+        return (Vec::new(), BTreeSet::new());
+    };
+
+    let codes = result
+        .entries
+        .iter()
+        .map(|entry| entry.code.clone())
+        .collect();
+    let lines = result
+        .entries
+        .iter()
+        .map(|entry| entry.raw.to_string())
+        .collect();
+    (lines, codes)
+}
+
+/// The catalog entries for the codes actually present, so a reader never has
+/// to open another file to know what a line means.
+fn codes_help(codes: &BTreeSet<String>) -> Value {
+    Value::Array(
+        codes
+            .iter()
+            .filter_map(|code| catalog::lookup(code))
+            .map(|entry| {
+                json!({
+                    "code": entry.code,
+                    "meaning": entry.meaning,
+                    "action": entry.action,
+                })
+            })
+            .collect(),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Configuration summary
+// ---------------------------------------------------------------------------
+
+/// Keys whose string value is safe to show as-is. Anything absent from this
+/// list is summarised instead of printed, whatever it holds.
+const SAFE_STRING_KEYS: [&str; 14] = [
+    "theme",
+    "language",
+    "locale",
+    "viewMode",
+    "sortMode",
+    "sortOrder",
+    "updateChannel",
+    "platform",
+    "mode",
+    "scope",
+    "schemaVersion",
+    "version",
+    "startupBehavior",
+    "windowMode",
+];
+
+/// Key fragments that mean the value is a credential. Never printed, never
+/// summarised by length: only whether it is set at all.
+const SECRET_KEY_FRAGMENTS: [&str; 12] = [
+    "key",
+    "token",
+    "secret",
+    "password",
+    "passwd",
+    "cookie",
+    "auth",
+    "credential",
+    "session",
+    "mafile",
+    "identity",
+    "encrypted",
+];
+
+fn is_secret_key(key: &str) -> bool {
+    let lower = key.to_ascii_lowercase();
+    SECRET_KEY_FRAGMENTS
+        .iter()
+        .any(|fragment| lower.contains(fragment))
+}
+
+fn is_safe_string_key(key: &str) -> bool {
+    SAFE_STRING_KEYS.contains(&key)
+}
+
+/// Walk a configuration value keeping only what cannot identify anyone.
+///
+/// Deny by default: a key nobody allow-listed is reported by shape, never by
+/// value. A config that grows a new secret field is therefore safe on the day
+/// it is added, not on the day someone remembers to update this list.
+pub fn summarize_config_value(key: Option<&str>, value: &Value) -> Value {
+    if let Some(key) = key {
+        if is_secret_key(key) {
+            let set = match value {
+                Value::Null => false,
+                Value::String(text) => !text.is_empty(),
+                Value::Array(items) => !items.is_empty(),
+                Value::Object(map) => !map.is_empty(),
+                _ => true,
+            };
+            return json!(if set { "<set>" } else { "<unset>" });
+        }
+    }
+
+    match value {
+        Value::Bool(_) | Value::Number(_) | Value::Null => value.clone(),
+        Value::String(text) => {
+            if key.is_some_and(is_safe_string_key) {
+                json!(redact::sanitize_log_text(text))
+            } else if text.is_empty() {
+                json!("<empty>")
+            } else {
+                json!(format!("<redacted len={}>", text.chars().count()))
+            }
+        }
+        // Contents of a collection are the accounts, the notes, the paths: the
+        // most identifying part of the file. Only the count is diagnostic.
+        Value::Array(items) => json!({ "_arrayLen": items.len() }),
+        Value::Object(map) => {
+            let mut out = Map::with_capacity(map.len());
+            for (name, item) in map {
+                out.insert(name.clone(), summarize_config_value(Some(name), item));
+            }
+            Value::Object(out)
+        }
+    }
+}
+
+fn config_summary(app_handle: &dyn AppContext) -> Value {
+    let mut out = Map::new();
+    let sources: [(&str, Result<PathBuf, String>); 2] = [
+        ("portable", crate::storage::portable_config_path(app_handle)),
+        ("local", crate::storage::local_config_path(app_handle)),
+    ];
+
+    for (name, path) in sources {
+        let value = match path {
+            Err(reason) => json!({ "error": reason }),
+            Ok(path) => summarize_config_file(&path),
+        };
+        out.insert(name.to_string(), value);
+    }
+
+    Value::Object(out)
+}
+
+fn summarize_config_file(path: &Path) -> Value {
+    if !path.exists() {
+        return json!({ "present": false });
+    }
+    match std::fs::read_to_string(path) {
+        Err(reason) => json!({ "present": true, "error": reason.to_string() }),
+        Ok(text) => match serde_json::from_str::<Value>(&text) {
+            Err(reason) => json!({ "present": true, "parseError": reason.to_string() }),
+            Ok(value) => json!({
+                "present": true,
+                "bytes": text.len(),
+                "values": summarize_config_value(None, &value),
+            }),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diagnostics::test_support::TestCtx;
+
+    #[test]
+    fn a_secret_is_never_printed_whatever_its_shape() {
+        let config = json!({
+            "apiKey": "sk-live-abcdef",
+            "tokenEncrypted": "AAAA",
+            "steamApiKey": "",
+            "nested": { "sessionCookie": "id=42" },
+        });
+        let summary = summarize_config_value(None, &config);
+        let text = summary.to_string();
+
+        assert!(!text.contains("sk-live-abcdef"));
+        assert!(!text.contains("AAAA"));
+        assert!(!text.contains("id=42"));
+        assert_eq!(summary["apiKey"], json!("<set>"));
+        assert_eq!(summary["steamApiKey"], json!("<unset>"));
+        assert_eq!(summary["nested"]["sessionCookie"], json!("<set>"));
+    }
+
+    // The point of deny-by-default: a field nobody has heard of is still safe.
+    #[test]
+    fn an_unknown_string_field_is_summarised_not_printed() {
+        let config = json!({
+            "somethingAddedNextYear": "alice@example.com",
+            "theme": "dark",
+            "accounts": [{ "name": "alice" }, { "name": "bob" }],
+            "windowWidth": 1280,
+            "startMinimized": true,
+        });
+        let summary = summarize_config_value(None, &config);
+        let text = summary.to_string();
+
+        assert!(!text.contains("alice"));
+        assert!(!text.contains("bob"));
+        assert_eq!(
+            summary["somethingAddedNextYear"],
+            json!("<redacted len=17>")
+        );
+        assert_eq!(summary["theme"], json!("dark"));
+        assert_eq!(summary["accounts"], json!({ "_arrayLen": 2 }));
+        assert_eq!(summary["windowWidth"], json!(1280));
+        assert_eq!(summary["startMinimized"], json!(true));
+    }
+
+    // Even an allow-listed key goes through the log redaction: a theme name is
+    // safe, a theme name someone set to their email address is not.
+    #[test]
+    fn allow_listed_values_are_still_redacted() {
+        let summary = summarize_config_value(None, &json!({ "theme": "mine user@example.com" }));
+        assert_eq!(summary["theme"], json!("mine <email>"));
+    }
+
+    #[test]
+    fn the_report_holds_the_sections_a_reader_needs() {
+        let ctx = TestCtx::ctx("bundle-render");
+        event::event(&catalog::HEALTH_DISK_LOW)
+            .field("path", "C:/")
+            .field("availableBytes", 10u64)
+            .field("requiredBytes", 20u64)
+            .msg("nearly full")
+            .emit(&*ctx);
+
+        let text = render(&*ctx, &Options::default());
+
+        for heading in [
+            "## Environment",
+            "## Health invariants",
+            "## Anomaly counters",
+            "## Log storage",
+            "## Log levels",
+            "## Configuration (redacted)",
+            "## Recent log",
+        ] {
+            assert!(text.contains(heading), "missing section {heading}");
+        }
+        assert!(text.contains("health.disk.low"));
+        // The action travels with the report, so the reader does not need the
+        // catalog open beside it.
+        assert!(text.contains("Free space on that volume"));
+        assert!(text.contains("Nothing was sent anywhere"));
+    }
+
+    #[test]
+    fn the_report_stays_pasteable() {
+        let ctx = TestCtx::ctx("bundle-size");
+        let filler = "y".repeat(900);
+        for _ in 0..400 {
+            event::event(&catalog::HEALTH_PROFILE_CORRUPT)
+                .field("path", filler.clone())
+                .field("reason", filler.clone())
+                .msg("noise")
+                .emit(&*ctx);
+        }
+
+        let (path, bytes) = write(
+            &*ctx,
+            &Options {
+                records: 10_000,
+                ..Default::default()
+            },
+        )
+        .expect("write");
+
+        assert!(bytes <= MAX_BUNDLE_BYTES, "{bytes} bytes");
+        assert!(path.exists());
+        let text = std::fs::read_to_string(&path).expect("read");
+        assert!(text.contains("older records were cut"));
+    }
+
+    #[test]
+    fn writing_the_report_is_itself_logged() {
+        let ctx = TestCtx::ctx("bundle-logged");
+        write(&*ctx, &Options::default()).expect("write");
+
+        let found = query::search(
+            &*ctx,
+            &query::Filter {
+                codes: vec!["diagnostics.bundle.written".to_string()],
+                ..Default::default()
+            },
+        )
+        .expect("query");
+        assert_eq!(found.entries.len(), 1);
+        assert!(found.entries[0].raw["fields"]["bytes"]
+            .as_u64()
+            .is_some_and(|bytes| bytes > 0));
+    }
+}

--- a/crates/accshift-core/src/diagnostics/catalog.rs
+++ b/crates/accshift-core/src/diagnostics/catalog.rs
@@ -1,0 +1,621 @@
+//! The event catalog: one declaration site for every code the app can log.
+//!
+//! An entry carries its severity, its mandatory and optional fields, what it
+//! means and what to do about it. Nothing else in the codebase is allowed to
+//! invent a code: [`super::event`] only accepts a `&'static EventCode`, and the
+//! only way to obtain one is a constant generated here, so an undeclared code
+//! is a compile error rather than a string nobody can search for.
+//!
+//! Renaming a code is a breaking change for anyone grepping their own logs, so
+//! a rename keeps the old spelling in `aliases` and [`lookup`] resolves both.
+
+use super::event::Level;
+use serde_json::{json, Value};
+
+/// Type expected for a field value, checked by [`super::event`] before a
+/// record is written.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FieldType {
+    Str,
+    Int,
+    Float,
+    Bool,
+    StrList,
+    Object,
+}
+
+impl FieldType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FieldType::Str => "string",
+            FieldType::Int => "integer",
+            FieldType::Float => "number",
+            FieldType::Bool => "boolean",
+            FieldType::StrList => "string[]",
+            FieldType::Object => "object",
+        }
+    }
+
+    pub fn matches(self, value: &Value) -> bool {
+        match self {
+            FieldType::Str => value.is_string(),
+            FieldType::Int => value.is_i64() || value.is_u64(),
+            FieldType::Float => value.is_number(),
+            FieldType::Bool => value.is_boolean(),
+            FieldType::StrList => value
+                .as_array()
+                .is_some_and(|items| items.iter().all(Value::is_string)),
+            FieldType::Object => value.is_object(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct FieldSpec {
+    pub name: &'static str,
+    pub ty: FieldType,
+}
+
+/// A declared event. Constants of this type are the only accepted argument of
+/// [`super::event::event`], which is what makes the catalog exhaustive.
+#[derive(Debug)]
+pub struct EventCode {
+    pub code: &'static str,
+    /// Severity used when the call site does not override it.
+    pub level: Level,
+    pub required: &'static [FieldSpec],
+    pub optional: &'static [FieldSpec],
+    /// What happened, in one sentence, for whoever reads the line months later.
+    pub meaning: &'static str,
+    /// What to do about it. "None" is a valid answer and says so explicitly.
+    pub action: &'static str,
+    /// Previous spellings of `code`, still resolved by [`lookup`].
+    pub aliases: &'static [&'static str],
+}
+
+impl EventCode {
+    pub fn to_json(&self) -> Value {
+        json!({
+            "code": self.code,
+            "level": self.level.as_str(),
+            "requiredFields": fields_to_json(self.required),
+            "optionalFields": fields_to_json(self.optional),
+            "meaning": self.meaning,
+            "action": self.action,
+            "aliases": self.aliases,
+        })
+    }
+}
+
+fn fields_to_json(fields: &[FieldSpec]) -> Value {
+    Value::Array(
+        fields
+            .iter()
+            .map(|field| json!({ "name": field.name, "type": field.ty.as_str() }))
+            .collect(),
+    )
+}
+
+macro_rules! event_catalog {
+    (
+        $(
+            $(#[$attr:meta])*
+            $name:ident {
+                code: $code:literal,
+                level: $level:ident,
+                required: [ $( $req_name:literal : $req_ty:ident ),* $(,)? ],
+                optional: [ $( $opt_name:literal : $opt_ty:ident ),* $(,)? ],
+                meaning: $meaning:literal,
+                action: $action:literal,
+                aliases: [ $( $alias:literal ),* $(,)? ] $(,)?
+            }
+        ),* $(,)?
+    ) => {
+        $(
+            $(#[$attr])*
+            pub static $name: EventCode = EventCode {
+                code: $code,
+                level: Level::$level,
+                required: &[ $( FieldSpec { name: $req_name, ty: FieldType::$req_ty } ),* ],
+                optional: &[ $( FieldSpec { name: $opt_name, ty: FieldType::$opt_ty } ),* ],
+                meaning: $meaning,
+                action: $action,
+                aliases: &[ $( $alias ),* ],
+            };
+        )*
+
+        /// Every declared event, in declaration order.
+        pub static CATALOG: &[&EventCode] = &[ $( &$name ),* ];
+    };
+}
+
+event_catalog! {
+    // -----------------------------------------------------------------------
+    // Session and log plumbing
+    // -----------------------------------------------------------------------
+
+    /// Emitted once per process launch, first line of a session.
+    SESSION_STARTED {
+        code: "app.session.started",
+        level: Info,
+        required: ["appVersion": Str, "os": Str, "arch": Str],
+        optional: ["binary": Str],
+        meaning: "A new accshift process started logging under this runId.",
+        action: "None. Use the runId to scope everything that follows to this launch.",
+        aliases: [],
+    },
+
+    /// The active file hit its size cap, or a new session rotated the chain.
+    LOG_ROTATED {
+        code: "log.rotated",
+        level: Info,
+        required: ["reason": Str, "bytes": Int, "keptFiles": Int],
+        optional: [],
+        meaning: "The active log file was shifted to app.1.log and a fresh one opened.",
+        action: "None. Confirms the retention policy is running.",
+        aliases: [],
+    },
+
+    /// Files removed by the retention sweep (age or file-count budget).
+    LOG_RETENTION_PURGED {
+        code: "log.retention.purged",
+        level: Info,
+        required: ["removedFiles": Int, "freedBytes": Int, "reason": Str],
+        optional: [],
+        meaning: "Rotated log files were deleted to stay inside the announced disk budget.",
+        action: "None, unless files vanish faster than you can read them: raise the budget then.",
+        aliases: [],
+    },
+
+    /// The sink could not write. Logged on the next successful write.
+    LOG_WRITE_FAILED {
+        code: "log.write.failed",
+        level: Error,
+        required: ["reason": Str],
+        optional: ["path": Str],
+        meaning: "A log record could not be written to disk and was dropped.",
+        action: "Check free space and write permissions on the log directory.",
+        aliases: [],
+    },
+
+    // -----------------------------------------------------------------------
+    // Operation tracing
+    // -----------------------------------------------------------------------
+
+    /// Opens an operation. Everything sharing its opId belongs to this attempt.
+    OP_STARTED {
+        code: "op.started",
+        level: Debug,
+        required: ["op": Str],
+        optional: ["platform": Str, "trigger": Str],
+        meaning: "A user-visible operation started and was assigned an opId.",
+        action: "None. Query by opId to replay the whole attempt.",
+        aliases: [],
+    },
+
+    /// One step inside an operation.
+    OP_STEP {
+        code: "op.step",
+        level: Debug,
+        required: ["op": Str, "step": Str],
+        optional: ["platform": Str, "detail": Str],
+        meaning: "An operation reached a named step.",
+        action: "None. The last step before a failure is where to start reading.",
+        aliases: [],
+    },
+
+    /// Closes an operation. Carries durMs and outcome.
+    OP_FINISHED {
+        code: "op.finished",
+        level: Info,
+        required: ["op": Str],
+        optional: ["platform": Str, "steps": Int, "detail": Str],
+        meaning: "An operation ended; durMs and outcome say how long it took and how it went.",
+        action: "On outcome=failure, read errKind then the steps sharing this opId.",
+        aliases: [],
+    },
+
+    // -----------------------------------------------------------------------
+    // Health invariants, one code per problem
+    // -----------------------------------------------------------------------
+
+    HEALTH_PATH_MISSING {
+        code: "health.path.missing",
+        level: Error,
+        required: ["path": Str, "purpose": Str],
+        optional: ["platform": Str],
+        meaning: "A path the operation needs does not exist.",
+        action: "Set the path override for that platform, or reinstall the launcher.",
+        aliases: [],
+    },
+
+    HEALTH_PATH_PERMISSION_DENIED {
+        code: "health.path.permission_denied",
+        level: Error,
+        required: ["path": Str, "purpose": Str],
+        optional: ["platform": Str, "reason": Str],
+        meaning: "A path exists but this process cannot write to it.",
+        action: "Check the folder ACLs, an antivirus lock, or run the operation without elevation mismatch.",
+        aliases: [],
+    },
+
+    HEALTH_FILE_LOCKED {
+        code: "health.file.locked",
+        level: Warn,
+        required: ["path": Str],
+        optional: ["platform": Str, "holder": Str],
+        meaning: "A file the operation must rewrite is held by another process.",
+        action: "Close the launcher (or the other accshift instance) and retry.",
+        aliases: [],
+    },
+
+    HEALTH_LAUNCHER_RUNNING {
+        code: "health.launcher.running",
+        level: Warn,
+        required: ["platform": Str, "processes": StrList],
+        optional: [],
+        meaning: "The launcher is still alive when the operation needs it stopped.",
+        action: "Quit the launcher, or let the switch close it (graceful, then force).",
+        aliases: [],
+    },
+
+    HEALTH_DISK_LOW {
+        code: "health.disk.low",
+        level: Warn,
+        required: ["path": Str, "availableBytes": Int, "requiredBytes": Int],
+        optional: [],
+        meaning: "The volume holding this path is close to full.",
+        action: "Free space on that volume; snapshot writes and log rotation both need room.",
+        aliases: [],
+    },
+
+    HEALTH_PROFILE_CORRUPT {
+        code: "health.profile.corrupt",
+        level: Error,
+        required: ["path": Str, "reason": Str],
+        optional: ["platform": Str],
+        meaning: "A stored profile or config file is not valid JSON any more.",
+        action: "Restore the .bak sibling if there is one, otherwise recapture the account.",
+        aliases: [],
+    },
+
+    HEALTH_CLOCK_SKEW {
+        code: "health.clock.skew",
+        level: Warn,
+        required: ["skewMs": Int],
+        optional: [],
+        meaning: "The system clock moved backwards compared to records already on disk.",
+        action: "Expect out-of-order timestamps; sort by runId then by file order, not by tsMs alone.",
+        aliases: [],
+    },
+
+    HEALTH_CHECK_PASSED {
+        code: "health.check.passed",
+        level: Debug,
+        required: ["check": Str],
+        optional: ["platform": Str, "detail": Str],
+        meaning: "An invariant was verified and holds.",
+        action: "None. Visible at debug level so a clean preflight is provable, not assumed.",
+        aliases: [],
+    },
+
+    // -----------------------------------------------------------------------
+    // Anomaly counters: something still works, but not the way it should
+    // -----------------------------------------------------------------------
+
+    ANOMALY_PLATFORM_CONSECUTIVE_FAILURES {
+        code: "anomaly.platform.consecutive_failures",
+        level: Warn,
+        required: ["platform": Str, "failures": Int],
+        optional: ["op": Str],
+        meaning: "A platform failed several operations in a row.",
+        action: "Run the health checks for that platform; the launcher path or its config is likely stale.",
+        aliases: [],
+    },
+
+    ANOMALY_OPERATION_SLOW {
+        code: "anomaly.operation.slow",
+        level: Warn,
+        required: ["op": Str, "durMs": Int, "baselineMs": Int],
+        optional: ["platform": Str],
+        meaning: "An operation took far longer than its own rolling baseline.",
+        action: "Look for a locked file, an antivirus scan, or a launcher refusing to exit.",
+        aliases: [],
+    },
+
+    ANOMALY_SNAPSHOT_EMPTY {
+        code: "anomaly.snapshot.empty",
+        level: Warn,
+        required: ["platform": Str],
+        optional: ["path": Str],
+        meaning: "A session snapshot was captured but contains nothing.",
+        action: "The account was probably not signed in when captured; recapture it.",
+        aliases: [],
+    },
+
+    ANOMALY_RESTORE_NO_WRITE {
+        code: "anomaly.restore.no_write",
+        level: Error,
+        required: ["platform": Str],
+        optional: ["path": Str],
+        meaning: "A restore reported success without writing a single byte.",
+        action: "Treat the switch as failed: the target files were not replaced.",
+        aliases: [],
+    },
+
+    // -----------------------------------------------------------------------
+    // Diagnostics tooling itself
+    // -----------------------------------------------------------------------
+
+    DIAGNOSTICS_BUNDLE_WRITTEN {
+        code: "diagnostics.bundle.written",
+        level: Info,
+        required: ["path": Str, "bytes": Int],
+        optional: [],
+        meaning: "A diagnostic report was written locally. Nothing was sent anywhere.",
+        action: "None. The user decides whether to paste it.",
+        aliases: [],
+    },
+
+    DIAGNOSTICS_LEVEL_CHANGED {
+        code: "diagnostics.level.changed",
+        level: Info,
+        // `newLevel`, not `level`: the record already has a `level` column, and
+        // two spellings of the same word in one line is how a reader ends up
+        // filtering on the wrong one.
+        required: ["module": Str, "newLevel": Str],
+        optional: [],
+        meaning: "A per-module log level was changed at runtime.",
+        action: "None. Remember that a lowered level hides records permanently, not retroactively.",
+        aliases: [],
+    },
+
+    DIAGNOSTICS_DEBUG_ENABLED {
+        code: "diagnostics.debug.enabled",
+        level: Info,
+        required: ["durationMs": Int, "newLevel": Str],
+        optional: ["modules": StrList],
+        meaning: "Temporary verbose logging was turned on and will expire on its own.",
+        action: "Reproduce the bug now; the level reverts without any further action.",
+        aliases: [],
+    },
+
+    DIAGNOSTICS_DEBUG_EXPIRED {
+        code: "diagnostics.debug.expired",
+        level: Info,
+        required: [],
+        optional: [],
+        meaning: "Temporary verbose logging reached its deadline and the normal level is back.",
+        action: "None.",
+        aliases: [],
+    },
+
+    /// Self-report: a record reached the sink without satisfying its own
+    /// declaration. Debug builds panic instead, so this only ships in release.
+    DIAGNOSTICS_EVENT_INVALID {
+        code: "diagnostics.event.invalid",
+        level: Error,
+        required: ["offendingCode": Str, "defects": StrList],
+        optional: [],
+        meaning: "An event was emitted with a missing or mistyped mandatory field.",
+        action: "Fix the call site: the catalog entry lists what the code requires.",
+        aliases: [],
+    },
+
+    // -----------------------------------------------------------------------
+    // Platform vocabulary.
+    //
+    // Declared here so the platform layer adopts these codes instead of
+    // inventing its own spelling per module. The platform modules are being
+    // rewritten in parallel and are not instrumented yet; the codes exist so
+    // that migration is a call-site change and never a catalog change.
+    // -----------------------------------------------------------------------
+
+    PLATFORM_SWITCH_STARTED {
+        code: "platform.switch.started",
+        level: Info,
+        required: ["platform": Str],
+        optional: ["mode": Str],
+        meaning: "An account switch began for this platform.",
+        action: "None. Pairs with platform.switch.succeeded or .failed on the same opId.",
+        aliases: [],
+    },
+
+    PLATFORM_SWITCH_SUCCEEDED {
+        code: "platform.switch.succeeded",
+        level: Info,
+        required: ["platform": Str],
+        optional: ["mode": Str],
+        meaning: "The launcher was relaunched signed in as the requested account.",
+        action: "None.",
+        aliases: [],
+    },
+
+    PLATFORM_SWITCH_FAILED {
+        code: "platform.switch.failed",
+        level: Error,
+        required: ["platform": Str, "stage": Str],
+        optional: ["reason": Str],
+        meaning: "An account switch failed at a named stage.",
+        action: "Replay the opId: the preceding op.step and health.* records name the blocking condition.",
+        aliases: [],
+    },
+
+    PLATFORM_SNAPSHOT_CAPTURED {
+        code: "platform.snapshot.captured",
+        level: Info,
+        required: ["platform": Str, "entries": Int],
+        optional: [],
+        meaning: "A session snapshot was captured for an account.",
+        action: "None. entries=0 also raises anomaly.snapshot.empty.",
+        aliases: [],
+    },
+
+    PLATFORM_SNAPSHOT_RESTORED {
+        code: "platform.snapshot.restored",
+        level: Info,
+        required: ["platform": Str, "bytes": Int],
+        optional: [],
+        meaning: "A session snapshot was written back over the launcher's files.",
+        action: "None. bytes=0 also raises anomaly.restore.no_write.",
+        aliases: [],
+    },
+}
+
+/// Resolve a code (or one of its aliases) to its catalog entry.
+pub fn lookup(code: &str) -> Option<&'static EventCode> {
+    CATALOG
+        .iter()
+        .copied()
+        .find(|entry| entry.code == code || entry.aliases.contains(&code))
+}
+
+/// The whole catalog as JSON, for `docs/log-catalog.json` and for any agent
+/// that wants the vocabulary without parsing Rust.
+pub fn to_json() -> Value {
+    let mut entries: Vec<&EventCode> = CATALOG.to_vec();
+    entries.sort_by_key(|entry| entry.code);
+    json!({
+        "schemaVersion": super::event::SCHEMA_VERSION,
+        "events": entries.iter().map(|entry| entry.to_json()).collect::<Vec<_>>(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn codes_are_unique_and_dotted() {
+        let mut seen = HashSet::new();
+        for entry in CATALOG {
+            assert!(
+                seen.insert(entry.code),
+                "duplicate event code {}",
+                entry.code
+            );
+            assert!(
+                entry.code.contains('.'),
+                "{} must be dotted (area.subject.verb)",
+                entry.code
+            );
+            assert!(
+                entry
+                    .code
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c == '.' || c == '_'),
+                "{} must stay lowercase ascii",
+                entry.code
+            );
+        }
+    }
+
+    // A rename that reuses a live code as an alias would make lookup ambiguous
+    // and silently reroute someone's saved query.
+    #[test]
+    fn aliases_never_collide_with_live_codes() {
+        let live: HashSet<&str> = CATALOG.iter().map(|entry| entry.code).collect();
+        let mut seen_aliases = HashSet::new();
+        for entry in CATALOG {
+            for alias in entry.aliases {
+                assert!(
+                    !live.contains(alias),
+                    "{alias} is both a live code and an alias of {}",
+                    entry.code
+                );
+                assert!(seen_aliases.insert(*alias), "duplicate alias {alias}");
+            }
+        }
+    }
+
+    #[test]
+    fn every_entry_documents_meaning_and_action() {
+        for entry in CATALOG {
+            assert!(!entry.meaning.is_empty(), "{} has no meaning", entry.code);
+            assert!(!entry.action.is_empty(), "{} has no action", entry.code);
+        }
+    }
+
+    // Field names land verbatim in the JSONL, where consumers index them.
+    #[test]
+    fn field_names_are_camel_case_and_unique_per_code() {
+        for entry in CATALOG {
+            let mut seen = HashSet::new();
+            for field in entry.required.iter().chain(entry.optional.iter()) {
+                assert!(
+                    seen.insert(field.name),
+                    "{} declares {} twice",
+                    entry.code,
+                    field.name
+                );
+                assert!(
+                    !field.name.contains('_') && !field.name.contains('-'),
+                    "{} field {} must be camelCase",
+                    entry.code,
+                    field.name
+                );
+                assert!(
+                    field
+                        .name
+                        .starts_with(|c: char| c.is_ascii_lowercase() || c == '_'),
+                    "{} field {} must start lowercase",
+                    entry.code,
+                    field.name
+                );
+            }
+        }
+    }
+
+    // `durMs`, `outcome`, `platform`-as-a-column and friends are record
+    // columns; redeclaring one as a field would produce two spellings of the
+    // same thing in the same line.
+    #[test]
+    fn fields_never_shadow_record_columns() {
+        const COLUMNS: [&str; 8] = [
+            "schemaVersion",
+            "tsMs",
+            "level",
+            "code",
+            "source",
+            "msg",
+            "runId",
+            "opId",
+        ];
+        for entry in CATALOG {
+            for field in entry.required.iter().chain(entry.optional.iter()) {
+                assert!(
+                    !COLUMNS.contains(&field.name),
+                    "{} field {} shadows a record column",
+                    entry.code,
+                    field.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn lookup_resolves_codes_and_aliases() {
+        assert_eq!(lookup("log.rotated").unwrap().code, "log.rotated");
+        assert!(lookup("does.not.exist").is_none());
+        for entry in CATALOG {
+            for alias in entry.aliases {
+                assert_eq!(lookup(alias).unwrap().code, entry.code);
+            }
+        }
+    }
+
+    #[test]
+    fn json_export_is_sorted_and_complete() {
+        let exported = to_json();
+        let events = exported["events"].as_array().expect("events array");
+        assert_eq!(events.len(), CATALOG.len());
+        let codes: Vec<&str> = events
+            .iter()
+            .map(|entry| entry["code"].as_str().expect("code"))
+            .collect();
+        let mut sorted = codes.clone();
+        sorted.sort_unstable();
+        assert_eq!(codes, sorted, "export must be stable across builds");
+    }
+}

--- a/crates/accshift-core/src/diagnostics/event.rs
+++ b/crates/accshift-core/src/diagnostics/event.rs
@@ -1,0 +1,596 @@
+//! The versioned record and the only way to write one.
+//!
+//! A record is a flat object with fixed columns plus a typed `fields` bag:
+//!
+//! ```json
+//! {"schemaVersion":2,"tsMs":1754000000000,"level":"error","code":"platform.switch.failed",
+//!  "source":"platform.steam","msg":"Steam refused to exit","fields":{"platform":"steam","stage":"shutdown"},
+//!  "runId":"run-4f2a1c9d8b70","opId":"op-91c2ab77de10","durMs":4211,"outcome":"failure","errKind":"client_running"}
+//! ```
+//!
+//! `fields` replaces the free-text `details` of the legacy line: everything in
+//! it is declared in the catalog, so it can be filtered on instead of grepped.
+//! Every string it contains, keys included, goes through the same redaction as
+//! the message, recursively and with no opt-out.
+
+use super::catalog::{EventCode, FieldSpec};
+use super::{levels, redact};
+use crate::context::AppContext;
+use serde_json::{json, Map, Value};
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Bumped when the record shape changes in a way a reader must know about.
+/// Version 1 is the legacy `{tsMs, level, source, message, details}` line that
+/// [`crate::logging::append_app_log`] still writes and that readers still parse.
+pub const SCHEMA_VERSION: u32 = 2;
+
+/// Caps, in bytes. A single pathological record must not be able to eat the
+/// whole retention budget.
+pub const MAX_MESSAGE_BYTES: usize = 512;
+pub const MAX_FIELD_STRING_BYTES: usize = 1_024;
+pub const MAX_FIELDS_BYTES: usize = 16_384;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Level {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl Level {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Level::Trace => "trace",
+            Level::Debug => "debug",
+            Level::Info => "info",
+            Level::Warn => "warn",
+            Level::Error => "error",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "trace" => Some(Level::Trace),
+            "debug" => Some(Level::Debug),
+            "info" => Some(Level::Info),
+            // "warning" is what the legacy lines and most humans write.
+            "warn" | "warning" => Some(Level::Warn),
+            "error" => Some(Level::Error),
+            _ => None,
+        }
+    }
+
+    pub const ALL: [Level; 5] = [
+        Level::Trace,
+        Level::Debug,
+        Level::Info,
+        Level::Warn,
+        Level::Error,
+    ];
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    Success,
+    Failure,
+    Cancelled,
+}
+
+impl Outcome {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Outcome::Success => "success",
+            Outcome::Failure => "failure",
+            Outcome::Cancelled => "cancelled",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "success" => Some(Outcome::Success),
+            "failure" => Some(Outcome::Failure),
+            "cancelled" | "canceled" => Some(Outcome::Cancelled),
+            _ => None,
+        }
+    }
+}
+
+/// Identifier of this process' logging session. Every record carries it, so a
+/// file holding several launches still splits cleanly per run.
+pub fn run_id() -> &'static str {
+    static RUN_ID: OnceLock<String> = OnceLock::new();
+    RUN_ID.get_or_init(|| short_id("run"))
+}
+
+/// Fresh operation identifier. Prefixed and 12 hex chars wide on purpose: a
+/// bare 32-hex or dashed-UUID shape would be eaten by the UUID redaction the
+/// moment someone interpolated it into a message.
+pub fn new_op_id() -> String {
+    short_id("op")
+}
+
+fn short_id(prefix: &str) -> String {
+    let raw = uuid::Uuid::new_v4().simple().to_string();
+    format!("{prefix}-{}", &raw[..12])
+}
+
+pub fn now_unix_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+/// Start building a record. The argument is a catalog constant, which is what
+/// makes an undeclared code a compile error.
+pub fn event(code: &'static EventCode) -> EventBuilder {
+    EventBuilder {
+        code,
+        level: code.level,
+        source: None,
+        msg: None,
+        fields: Map::new(),
+        op_id: None,
+        dur_ms: None,
+        outcome: None,
+        err_kind: None,
+    }
+}
+
+pub struct EventBuilder {
+    code: &'static EventCode,
+    level: Level,
+    source: Option<String>,
+    msg: Option<String>,
+    fields: Map<String, Value>,
+    op_id: Option<String>,
+    dur_ms: Option<u64>,
+    outcome: Option<Outcome>,
+    err_kind: Option<String>,
+}
+
+impl EventBuilder {
+    /// Override the catalog severity. Same event, worse day.
+    pub fn level(mut self, level: Level) -> Self {
+        self.level = level;
+        self
+    }
+
+    /// Module this came from, e.g. `platform.steam`. Drives the per-module
+    /// level filter. Defaults to the code's own area.
+    pub fn source(mut self, source: impl Into<String>) -> Self {
+        self.source = Some(source.into());
+        self
+    }
+
+    pub fn msg(mut self, msg: impl Into<String>) -> Self {
+        self.msg = Some(msg.into());
+        self
+    }
+
+    pub fn field(mut self, name: &str, value: impl Into<Value>) -> Self {
+        self.fields.insert(name.to_string(), value.into());
+        self
+    }
+
+    /// Attach this record to an operation. Everything sharing the id replays
+    /// as one sequence.
+    pub fn op(mut self, op_id: impl Into<String>) -> Self {
+        self.op_id = Some(op_id.into());
+        self
+    }
+
+    pub fn dur_ms(mut self, dur_ms: u64) -> Self {
+        self.dur_ms = Some(dur_ms);
+        self
+    }
+
+    pub fn outcome(mut self, outcome: Outcome) -> Self {
+        self.outcome = Some(outcome);
+        self
+    }
+
+    /// Machine-readable error family, e.g. `client_running`. Free-form text
+    /// belongs in `msg`, never here.
+    pub fn err_kind(mut self, err_kind: impl Into<String>) -> Self {
+        self.err_kind = Some(err_kind.into());
+        self
+    }
+
+    /// Serialize the record: validate against the catalog, redact, cap, encode.
+    /// No level filtering and no IO, so it is also the test entry point.
+    pub fn render(self) -> String {
+        self.render_parts().0
+    }
+
+    /// The line, plus whatever the catalog says is wrong with it. Only
+    /// [`EventBuilder::emit`] needs the second half, to report a broken call
+    /// site under its own code.
+    fn render_parts(self) -> (String, Vec<String>) {
+        let defects = validate(self.code, &self.fields);
+        // A debug build turns a malformed call site into a failing test rather
+        // than a line nobody reads. Release keeps the record and says so.
+        debug_assert!(
+            defects.is_empty(),
+            "event {} is malformed: {}",
+            self.code.code,
+            defects.join(", ")
+        );
+
+        let source = self
+            .source
+            .unwrap_or_else(|| default_source(self.code.code).to_string());
+
+        let mut record = Map::new();
+        record.insert("schemaVersion".into(), json!(SCHEMA_VERSION));
+        record.insert("tsMs".into(), json!(now_unix_ms()));
+        record.insert("level".into(), json!(self.level.as_str()));
+        record.insert("code".into(), json!(self.code.code));
+        record.insert(
+            "source".into(),
+            json!(redact::trim_text(&redact::sanitize_log_text(&source), 128)),
+        );
+        if let Some(msg) = self.msg {
+            record.insert(
+                "msg".into(),
+                json!(redact::trim_text(
+                    &redact::sanitize_log_text(&msg),
+                    MAX_MESSAGE_BYTES
+                )),
+            );
+        }
+        record.insert(
+            "fields".into(),
+            Value::Object(prepare_fields(self.code, self.fields, &defects)),
+        );
+        record.insert("runId".into(), json!(run_id()));
+        if let Some(op_id) = self.op_id {
+            record.insert("opId".into(), json!(op_id));
+        }
+        if let Some(dur_ms) = self.dur_ms {
+            record.insert("durMs".into(), json!(dur_ms));
+        }
+        if let Some(outcome) = self.outcome {
+            record.insert("outcome".into(), json!(outcome.as_str()));
+        }
+        if let Some(err_kind) = self.err_kind {
+            record.insert(
+                "errKind".into(),
+                json!(redact::trim_text(&redact::sanitize_log_text(&err_kind), 64)),
+            );
+        }
+
+        (Value::Object(record).to_string(), defects)
+    }
+
+    /// Write the record, unless the effective level for its source filters it
+    /// out. Best effort: logging never becomes a failure path for a caller.
+    pub fn emit(self, app_handle: &dyn AppContext) {
+        let source = self
+            .source
+            .clone()
+            .unwrap_or_else(|| default_source(self.code.code).to_string());
+        if self.level < levels::effective_level(app_handle, &source) {
+            return;
+        }
+
+        let code = self.code.code;
+        let (line, defects) = self.render_parts();
+        let _ = crate::logging::write_line(app_handle, &line);
+
+        if !defects.is_empty() {
+            // Debug builds already panicked in `render_parts`, so this only
+            // ever ships in release. A broken call site gets its own code so
+            // it is findable, instead of hiding in one record's `_defects`.
+            let report = event(&super::catalog::DIAGNOSTICS_EVENT_INVALID)
+                .source("diagnostics")
+                .msg("An event was emitted without satisfying its own declaration")
+                .field("offendingCode", code)
+                .field(
+                    "defects",
+                    Value::Array(defects.iter().map(|defect| json!(defect)).collect()),
+                )
+                .render();
+            let _ = crate::logging::write_line(app_handle, &report);
+        }
+    }
+}
+
+/// `platform.switch.failed` belongs to the `platform` module unless the call
+/// site says something more precise.
+fn default_source(code: &str) -> &str {
+    code.split('.').next().unwrap_or(code)
+}
+
+fn validate(code: &'static EventCode, fields: &Map<String, Value>) -> Vec<String> {
+    let mut defects = Vec::new();
+
+    for spec in code.required {
+        match fields.get(spec.name) {
+            None => defects.push(format!("missing required field `{}`", spec.name)),
+            Some(value) if !spec.ty.matches(value) => {
+                defects.push(format!(
+                    "field `{}` must be {}",
+                    spec.name,
+                    spec.ty.as_str()
+                ));
+            }
+            Some(_) => {}
+        }
+    }
+
+    for (name, value) in fields {
+        let declared: Option<&FieldSpec> = code
+            .required
+            .iter()
+            .chain(code.optional.iter())
+            .find(|spec| spec.name == name);
+        match declared {
+            None => defects.push(format!("undeclared field `{name}`")),
+            Some(spec) if !spec.ty.matches(value) => {
+                defects.push(format!("field `{name}` must be {}", spec.ty.as_str()));
+            }
+            Some(_) => {}
+        }
+    }
+
+    defects.sort();
+    defects.dedup();
+    defects
+}
+
+/// Redact, cap each string, then cap the whole bag. Optional fields are
+/// dropped before required ones: an oversized record still has to answer the
+/// question its code promises to answer.
+fn prepare_fields(
+    code: &'static EventCode,
+    fields: Map<String, Value>,
+    defects: &[String],
+) -> Map<String, Value> {
+    let mut prepared = Map::with_capacity(fields.len());
+    for (name, value) in fields {
+        prepared.insert(name, cap_strings(&redact::sanitize_value(&value)));
+    }
+
+    if !defects.is_empty() {
+        // Release builds keep the record and admit it is malformed, which is
+        // strictly more useful than dropping the only trace of the incident.
+        prepared.insert(
+            "_defects".into(),
+            Value::Array(defects.iter().map(|d| json!(d)).collect()),
+        );
+    }
+
+    let mut serialized = Value::Object(prepared.clone()).to_string().len();
+    if serialized <= MAX_FIELDS_BYTES {
+        return prepared;
+    }
+
+    let required: Vec<&str> = code.required.iter().map(|spec| spec.name).collect();
+    let droppable: Vec<String> = prepared
+        .keys()
+        .filter(|name| !required.contains(&name.as_str()) && name.as_str() != "_defects")
+        .cloned()
+        .collect();
+    let mut lost = 0usize;
+    for name in droppable {
+        if serialized <= MAX_FIELDS_BYTES {
+            break;
+        }
+        prepared.remove(&name);
+        lost += 1;
+        serialized = Value::Object(prepared.clone()).to_string().len();
+    }
+
+    if serialized > MAX_FIELDS_BYTES {
+        // The mandatory fields alone still overflow. Never drop one of those:
+        // the code promises they are there. Replace the bulky values with a
+        // marker instead, so the record keeps answering what it exists for.
+        // A collection replaced this way stops matching its declared type,
+        // which is why `_truncatedFields` is on the line to say so.
+        let names: Vec<String> = prepared.keys().cloned().collect();
+        for name in names {
+            let too_big = prepared
+                .get(&name)
+                .map(|value| value.to_string().len() > TRUNCATE_VALUE_ABOVE_BYTES)
+                .unwrap_or(false);
+            if too_big {
+                prepared.insert(name, json!("<truncated>"));
+                lost += 1;
+            }
+        }
+    }
+
+    prepared.insert("_truncatedFields".into(), json!(lost));
+    prepared
+}
+
+/// Above this, a single field value is replaced by a marker once the whole
+/// bag has already overflowed its budget.
+const TRUNCATE_VALUE_ABOVE_BYTES: usize = 256;
+
+fn cap_strings(value: &Value) -> Value {
+    match value {
+        Value::String(text) => Value::String(redact::trim_text(text, MAX_FIELD_STRING_BYTES)),
+        Value::Array(items) => Value::Array(items.iter().map(cap_strings).collect()),
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .map(|(key, item)| (key.clone(), cap_strings(item)))
+                .collect(),
+        ),
+        other => other.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diagnostics::catalog;
+
+    fn parse(line: &str) -> Value {
+        serde_json::from_str(line).expect("record must be valid JSON")
+    }
+
+    #[test]
+    fn record_carries_the_versioned_columns() {
+        let line = event(&catalog::LOG_ROTATED)
+            .msg("size cap reached")
+            .field("reason", "size")
+            .field("bytes", 2_097_152u64)
+            .field("keptFiles", 5u64)
+            .op("op-abc123abc123")
+            .dur_ms(12)
+            .outcome(Outcome::Success)
+            .render();
+        let record = parse(&line);
+
+        assert_eq!(record["schemaVersion"], json!(SCHEMA_VERSION));
+        assert_eq!(record["code"], json!("log.rotated"));
+        assert_eq!(record["level"], json!("info"));
+        assert_eq!(record["source"], json!("log"));
+        assert_eq!(record["msg"], json!("size cap reached"));
+        assert_eq!(record["fields"]["reason"], json!("size"));
+        assert_eq!(record["opId"], json!("op-abc123abc123"));
+        assert_eq!(record["durMs"], json!(12));
+        assert_eq!(record["outcome"], json!("success"));
+        assert_eq!(record["runId"], json!(run_id()));
+        assert!(record["tsMs"].as_u64().expect("tsMs") > 0);
+    }
+
+    // The whole point of a catalog: a field that the code declares mandatory
+    // cannot be forgotten silently.
+    #[test]
+    fn missing_required_field_is_a_defect() {
+        let defects = validate(&catalog::HEALTH_PATH_MISSING, &Map::new());
+        assert!(defects.iter().any(|d| d.contains("`path`")), "{defects:?}");
+        assert!(
+            defects.iter().any(|d| d.contains("`purpose`")),
+            "{defects:?}"
+        );
+    }
+
+    #[test]
+    fn mistyped_and_undeclared_fields_are_defects() {
+        let mut fields = Map::new();
+        fields.insert("path".into(), json!("C:/x"));
+        fields.insert("purpose".into(), json!(42));
+        fields.insert("surprise".into(), json!(true));
+
+        let defects = validate(&catalog::HEALTH_PATH_MISSING, &fields);
+
+        assert!(
+            defects
+                .iter()
+                .any(|d| d == "field `purpose` must be string"),
+            "{defects:?}"
+        );
+        assert!(
+            defects.iter().any(|d| d == "undeclared field `surprise`"),
+            "{defects:?}"
+        );
+    }
+
+    #[test]
+    fn a_correct_call_site_has_no_defect() {
+        let mut fields = Map::new();
+        fields.insert("path".into(), json!("C:/x"));
+        fields.insert("purpose".into(), json!("steam userdata"));
+        fields.insert("platform".into(), json!("steam"));
+        assert!(validate(&catalog::HEALTH_PATH_MISSING, &fields).is_empty());
+    }
+
+    // Redaction is not a policy the structured layer gets to opt out of.
+    #[test]
+    fn fields_are_redacted_recursively() {
+        let line = event(&catalog::HEALTH_PROFILE_CORRUPT)
+            .field("path", "C:/Users/x/mail user@example.com")
+            .field("reason", "expected value at line 1")
+            .field("platform", "riot")
+            .render();
+        let record = parse(&line);
+        assert_eq!(
+            record["fields"]["path"],
+            json!("C:/Users/x/mail <email>"),
+            "field strings must be scrubbed like the message"
+        );
+    }
+
+    #[test]
+    fn message_and_field_strings_are_capped() {
+        let long = "a".repeat(4_000);
+        let line = event(&catalog::HEALTH_PROFILE_CORRUPT)
+            .msg(long.clone())
+            .field("path", long.clone())
+            .field("reason", "x")
+            .render();
+        let record = parse(&line);
+
+        assert_eq!(
+            record["msg"].as_str().expect("msg").len(),
+            MAX_MESSAGE_BYTES
+        );
+        assert_eq!(
+            record["fields"]["path"].as_str().expect("path").len(),
+            MAX_FIELD_STRING_BYTES
+        );
+    }
+
+    #[test]
+    fn oversized_fields_drop_optional_entries_and_never_required_ones() {
+        let bulky: Vec<Value> = (0..40)
+            .map(|i| json!(format!("{}{}", "x".repeat(900), i)))
+            .collect();
+        let record = parse(
+            &event(&catalog::DIAGNOSTICS_DEBUG_ENABLED)
+                .field("durationMs", 60_000u64)
+                .field("newLevel", "debug")
+                // `modules` is optional on this code, so it goes first.
+                .field("modules", Value::Array(bulky))
+                .render(),
+        );
+
+        assert_eq!(record["fields"]["durationMs"], json!(60_000));
+        assert_eq!(record["fields"]["newLevel"], json!("debug"));
+        assert!(record["fields"]["modules"].is_null());
+        assert_eq!(record["fields"]["_truncatedFields"], json!(1));
+        assert!(record["fields"].to_string().len() <= MAX_FIELDS_BYTES);
+    }
+
+    #[test]
+    fn a_mandatory_field_is_marked_rather_than_dropped() {
+        let bulky: Vec<Value> = (0..40)
+            .map(|i| json!(format!("{}{}", "x".repeat(900), i)))
+            .collect();
+        let record = parse(
+            &event(&catalog::HEALTH_LAUNCHER_RUNNING)
+                .field("platform", "steam")
+                .field("processes", Value::Array(bulky))
+                .render(),
+        );
+
+        assert_eq!(record["fields"]["platform"], json!("steam"));
+        assert_eq!(record["fields"]["processes"], json!("<truncated>"));
+        assert_eq!(record["fields"]["_truncatedFields"], json!(1));
+    }
+
+    #[test]
+    fn level_parses_the_spellings_that_exist_on_disk() {
+        assert_eq!(Level::parse("WARN"), Some(Level::Warn));
+        assert_eq!(Level::parse("warning"), Some(Level::Warn));
+        assert_eq!(Level::parse("nope"), None);
+        assert!(Level::Error > Level::Warn && Level::Warn > Level::Info);
+    }
+
+    // Op and run ids travel through message text too; a UUID-shaped id would
+    // be redacted into `<uuid>` and the whole trace would lose its key.
+    #[test]
+    fn ids_survive_redaction() {
+        let op_id = new_op_id();
+        assert_eq!(redact::sanitize_log_text(&op_id), op_id);
+        assert_eq!(redact::sanitize_log_text(run_id()), run_id());
+        assert!(op_id.starts_with("op-"));
+    }
+}

--- a/crates/accshift-core/src/diagnostics/health.rs
+++ b/crates/accshift-core/src/diagnostics/health.rs
@@ -1,0 +1,767 @@
+//! Health invariants: the checks that name a problem before it becomes a
+//! failed switch.
+//!
+//! Every invariant has its own catalog code, and every code carries the action
+//! that fixes it. A check that passes is not silent either, it is recorded at
+//! debug level, so a clean preflight is provable instead of assumed.
+//!
+//! Nothing here knows anything about a specific platform. A caller describes
+//! what its operation needs as a [`Preflight`], the runner turns that into
+//! results and events. That keeps the invariants usable while the platform
+//! layer is being rewritten, and keeps them honest afterwards: a new platform
+//! gets the checks for free by declaring its requirements.
+
+use super::event::now_unix_ms;
+use super::{catalog, event, query};
+use crate::context::AppContext;
+use serde_json::{json, Map, Value};
+use std::fs::OpenOptions;
+use std::path::{Path, PathBuf};
+
+use fs4::{FileExt, TryLockError};
+
+/// A clock that moved backwards by less than this is ordinary drift and NTP
+/// resynchronisation, not something to warn a user about.
+const CLOCK_SKEW_TOLERANCE_MS: u128 = 60_000;
+
+/// Free space the log alone wants: the announced budget plus room to rotate.
+pub const LOG_DISK_REQUIREMENT_BYTES: u64 = 32 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    Pass,
+    /// Works, but the operation is likely to be degraded or to fail later.
+    Warn,
+    /// The operation cannot succeed in this state.
+    Fail,
+}
+
+impl Status {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Status::Pass => "pass",
+            Status::Warn => "warn",
+            Status::Fail => "fail",
+        }
+    }
+}
+
+/// The verdict of one invariant, in a shape both the report and the UI can use.
+#[derive(Debug, Clone)]
+pub struct CheckResult {
+    /// Short name of the invariant, stable across releases: `path`, `disk`.
+    pub check: &'static str,
+    pub status: Status,
+    /// Catalog code that was emitted. `None` when the check passed.
+    pub code: Option<&'static str>,
+    pub detail: String,
+    /// Copied from the catalog, so a reader never has to look the code up.
+    pub action: &'static str,
+    pub fields: Map<String, Value>,
+}
+
+impl CheckResult {
+    fn pass(check: &'static str, detail: impl Into<String>) -> Self {
+        CheckResult {
+            check,
+            status: Status::Pass,
+            code: None,
+            detail: detail.into(),
+            action: "",
+            fields: Map::new(),
+        }
+    }
+
+    fn from_code(
+        check: &'static str,
+        status: Status,
+        code: &'static catalog::EventCode,
+        detail: impl Into<String>,
+        fields: Map<String, Value>,
+    ) -> Self {
+        CheckResult {
+            check,
+            status,
+            code: Some(code.code),
+            detail: detail.into(),
+            action: code.action,
+            fields,
+        }
+    }
+
+    pub fn to_json(&self) -> Value {
+        json!({
+            "check": self.check,
+            "status": self.status.as_str(),
+            "code": self.code,
+            "detail": self.detail,
+            "action": self.action,
+            "fields": Value::Object(self.fields.clone()),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Report {
+    pub results: Vec<CheckResult>,
+}
+
+impl Report {
+    /// True when nothing failed. Warnings do not block an operation.
+    pub fn ok(&self) -> bool {
+        !self.results.iter().any(|r| r.status == Status::Fail)
+    }
+
+    pub fn failures(&self) -> impl Iterator<Item = &CheckResult> {
+        self.results.iter().filter(|r| r.status == Status::Fail)
+    }
+
+    pub fn warnings(&self) -> impl Iterator<Item = &CheckResult> {
+        self.results.iter().filter(|r| r.status == Status::Warn)
+    }
+
+    /// First blocking reason, in the order the checks were declared.
+    pub fn blocking_reason(&self) -> Option<String> {
+        self.failures()
+            .next()
+            .map(|failure| format!("{} ({})", failure.detail, failure.action))
+    }
+
+    pub fn to_json(&self) -> Value {
+        json!({
+            "ok": self.ok(),
+            "failed": self.failures().count(),
+            "warned": self.warnings().count(),
+            "checks": self.results.iter().map(CheckResult::to_json).collect::<Vec<_>>(),
+        })
+    }
+}
+
+/// What a path is needed for, and whether the operation has to write into it.
+#[derive(Debug, Clone)]
+pub struct RequiredPath {
+    pub path: PathBuf,
+    /// Human words, ends up in the record: "steam userdata", "riot config".
+    pub purpose: String,
+    pub writable: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct DiskRequirement {
+    pub path: PathBuf,
+    pub required_bytes: u64,
+}
+
+/// What an operation needs before it is safe to start.
+///
+/// Deliberately data, not behaviour: the caller declares, the runner decides.
+#[derive(Debug, Clone, Default)]
+pub struct Preflight {
+    pub platform: Option<String>,
+    pub paths: Vec<RequiredPath>,
+    /// Files that must be rewritable right now, checked with a real lock.
+    pub unlocked_files: Vec<PathBuf>,
+    /// Launcher processes that must not be running.
+    pub stopped_processes: Vec<String>,
+    /// Files that must still parse as JSON.
+    pub valid_json: Vec<PathBuf>,
+    pub disk: Option<DiskRequirement>,
+    /// Also verify the system clock against what is already on disk.
+    pub check_clock: bool,
+}
+
+impl Preflight {
+    pub fn new() -> Self {
+        Preflight::default()
+    }
+
+    pub fn platform(mut self, platform: impl Into<String>) -> Self {
+        self.platform = Some(platform.into());
+        self
+    }
+
+    pub fn require_path(mut self, path: impl Into<PathBuf>, purpose: impl Into<String>) -> Self {
+        self.paths.push(RequiredPath {
+            path: path.into(),
+            purpose: purpose.into(),
+            writable: false,
+        });
+        self
+    }
+
+    pub fn require_writable_path(
+        mut self,
+        path: impl Into<PathBuf>,
+        purpose: impl Into<String>,
+    ) -> Self {
+        self.paths.push(RequiredPath {
+            path: path.into(),
+            purpose: purpose.into(),
+            writable: true,
+        });
+        self
+    }
+
+    pub fn require_unlocked_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.unlocked_files.push(path.into());
+        self
+    }
+
+    pub fn require_stopped(mut self, processes: &[&str]) -> Self {
+        self.stopped_processes
+            .extend(processes.iter().map(|name| (*name).to_string()));
+        self
+    }
+
+    pub fn require_valid_json(mut self, path: impl Into<PathBuf>) -> Self {
+        self.valid_json.push(path.into());
+        self
+    }
+
+    pub fn require_free_space(mut self, path: impl Into<PathBuf>, required_bytes: u64) -> Self {
+        self.disk = Some(DiskRequirement {
+            path: path.into(),
+            required_bytes,
+        });
+        self
+    }
+
+    pub fn check_clock(mut self) -> Self {
+        self.check_clock = true;
+        self
+    }
+
+    /// Run every declared invariant. Nothing is mutated, nothing is retried.
+    pub fn run(&self, app_handle: &dyn AppContext) -> Report {
+        let mut report = Report::default();
+        let platform = self.platform.as_deref();
+
+        for required in &self.paths {
+            report.results.push(check_path(required, platform));
+        }
+        for path in &self.unlocked_files {
+            report.results.push(check_file_unlocked(path, platform));
+        }
+        if !self.stopped_processes.is_empty() {
+            report
+                .results
+                .push(check_processes_stopped(&self.stopped_processes, platform));
+        }
+        for path in &self.valid_json {
+            report.results.push(check_valid_json(path, platform));
+        }
+        if let Some(disk) = &self.disk {
+            report.results.push(check_disk(disk));
+        }
+        if self.check_clock {
+            report.results.push(check_clock_skew(app_handle));
+        }
+
+        report
+    }
+
+    /// Run and log. `op_id` attaches every finding to a running operation, so
+    /// the preflight replays with the rest of the attempt.
+    pub fn run_and_emit(&self, app_handle: &dyn AppContext, op_id: Option<&str>) -> Report {
+        let report = self.run(app_handle);
+        emit(app_handle, &report, op_id, self.platform.as_deref());
+        report
+    }
+}
+
+/// Turn a report into records: one per finding, one debug line per pass.
+pub fn emit(
+    app_handle: &dyn AppContext,
+    report: &Report,
+    op_id: Option<&str>,
+    source_hint: Option<&str>,
+) {
+    let source = match source_hint {
+        Some(platform) => format!("health.{platform}"),
+        None => "health".to_string(),
+    };
+
+    for result in &report.results {
+        let mut builder = match result.code.and_then(catalog::lookup) {
+            Some(code) => event::event(code),
+            // A pass has no code of its own: it is the same statement for
+            // every invariant, and only its name changes.
+            None => event::event(&catalog::HEALTH_CHECK_PASSED).field("check", result.check),
+        };
+        builder = builder.source(source.clone()).msg(result.detail.clone());
+        for (name, value) in &result.fields {
+            builder = builder.field(name, value.clone());
+        }
+        if let Some(op_id) = op_id {
+            builder = builder.op(op_id);
+        }
+        builder.emit(app_handle);
+    }
+}
+
+fn fields(pairs: &[(&str, Value)]) -> Map<String, Value> {
+    pairs
+        .iter()
+        .map(|(name, value)| ((*name).to_string(), value.clone()))
+        .collect()
+}
+
+fn with_platform(mut map: Map<String, Value>, platform: Option<&str>) -> Map<String, Value> {
+    if let Some(platform) = platform {
+        map.insert("platform".into(), json!(platform));
+    }
+    map
+}
+
+fn display(path: &Path) -> String {
+    path.display().to_string()
+}
+
+// ---------------------------------------------------------------------------
+// The invariants themselves
+// ---------------------------------------------------------------------------
+
+pub fn check_path(required: &RequiredPath, platform: Option<&str>) -> CheckResult {
+    let path = &required.path;
+    let base = fields(&[
+        ("path", json!(display(path))),
+        ("purpose", json!(required.purpose.clone())),
+    ]);
+
+    if !path.exists() {
+        return CheckResult::from_code(
+            "path",
+            Status::Fail,
+            &catalog::HEALTH_PATH_MISSING,
+            format!("{} is missing ({})", display(path), required.purpose),
+            with_platform(base, platform),
+        );
+    }
+
+    if required.writable {
+        if let Err(reason) = probe_writable(path) {
+            let mut denied = with_platform(base, platform);
+            denied.insert("reason".into(), json!(reason));
+            return CheckResult::from_code(
+                "path.writable",
+                Status::Fail,
+                &catalog::HEALTH_PATH_PERMISSION_DENIED,
+                format!("{} is not writable ({})", display(path), required.purpose),
+                denied,
+            );
+        }
+    }
+
+    CheckResult::pass("path", format!("{} is available", display(path)))
+}
+
+/// Write access is only knowable by trying. A read-only flag says nothing
+/// about an ACL, and an ACL says nothing about an antivirus holding the file.
+fn probe_writable(path: &Path) -> Result<(), String> {
+    if path.is_dir() {
+        let probe = path.join(format!(".accshift-write-probe-{}", std::process::id()));
+        match std::fs::write(&probe, b"") {
+            Ok(()) => {
+                let _ = std::fs::remove_file(&probe);
+                Ok(())
+            }
+            Err(reason) => Err(reason.to_string()),
+        }
+    } else {
+        OpenOptions::new()
+            .append(true)
+            .open(path)
+            .map(|_| ())
+            .map_err(|reason| reason.to_string())
+    }
+}
+
+/// A file another process is holding is the single most common reason a switch
+/// half-succeeds: the snapshot is read, the write is refused, the launcher
+/// starts on the previous account.
+pub fn check_file_unlocked(path: &Path, platform: Option<&str>) -> CheckResult {
+    let base = with_platform(fields(&[("path", json!(display(path)))]), platform);
+
+    if !path.exists() {
+        // Not this check's problem: `require_path` is what reports a missing
+        // file, and reporting it twice would double every incident.
+        return CheckResult::pass(
+            "file.locked",
+            format!("{} does not exist yet", display(path)),
+        );
+    }
+
+    let file = match OpenOptions::new().read(true).write(true).open(path) {
+        Ok(file) => file,
+        Err(reason) => {
+            let mut held = base;
+            held.insert("holder".into(), json!(reason.to_string()));
+            return CheckResult::from_code(
+                "file.locked",
+                Status::Fail,
+                &catalog::HEALTH_FILE_LOCKED,
+                format!("{} cannot be opened for writing", display(path)),
+                held,
+            );
+        }
+    };
+
+    // fs4 maps "someone else holds it" to WouldBlock, and keeps Error for a
+    // real I/O failure. Reporting the second as contention would send a user
+    // hunting for a process that does not exist.
+    match FileExt::try_lock(&file) {
+        Ok(()) => {
+            let _ = FileExt::unlock(&file);
+            CheckResult::pass("file.locked", format!("{} is free", display(path)))
+        }
+        Err(TryLockError::WouldBlock) => CheckResult::from_code(
+            "file.locked",
+            Status::Fail,
+            &catalog::HEALTH_FILE_LOCKED,
+            format!("{} is locked by another process", display(path)),
+            base,
+        ),
+        Err(TryLockError::Error(reason)) => {
+            let mut held = base;
+            held.insert("holder".into(), json!(reason.to_string()));
+            CheckResult::from_code(
+                "file.locked",
+                Status::Warn,
+                &catalog::HEALTH_FILE_LOCKED,
+                format!("{} could not be tested for locks", display(path)),
+                held,
+            )
+        }
+    }
+}
+
+pub fn check_processes_stopped(processes: &[String], platform: Option<&str>) -> CheckResult {
+    let names: Vec<&str> = processes.iter().map(String::as_str).collect();
+    launcher_result(&crate::os::running_process_names(&names), platform)
+}
+
+/// Split from the process-table lookup so the verdict is testable without
+/// depending on what happens to be running on the machine.
+fn launcher_result(running: &[&str], platform: Option<&str>) -> CheckResult {
+    if running.is_empty() {
+        return CheckResult::pass("launcher.running", "no launcher process is running");
+    }
+
+    let mut found = fields(&[(
+        "processes",
+        json!(running.iter().map(|name| json!(name)).collect::<Vec<_>>()),
+    )]);
+    // This code makes the platform mandatory: without it the record cannot say
+    // whose launcher is in the way.
+    found.insert(
+        "platform".into(),
+        json!(platform.unwrap_or("unknown").to_string()),
+    );
+
+    CheckResult::from_code(
+        "launcher.running",
+        Status::Fail,
+        &catalog::HEALTH_LAUNCHER_RUNNING,
+        format!("still running: {}", running.join(", ")),
+        found,
+    )
+}
+
+pub fn check_valid_json(path: &Path, platform: Option<&str>) -> CheckResult {
+    if !path.exists() {
+        return CheckResult::pass(
+            "profile.json",
+            format!("{} does not exist yet", display(path)),
+        );
+    }
+
+    let reason = match std::fs::read_to_string(path) {
+        Err(reason) => reason.to_string(),
+        Ok(text) => match serde_json::from_str::<Value>(&text) {
+            Ok(_) => return CheckResult::pass("profile.json", format!("{} parses", display(path))),
+            Err(reason) => reason.to_string(),
+        },
+    };
+
+    let mut broken = with_platform(fields(&[("path", json!(display(path)))]), platform);
+    broken.insert("reason".into(), json!(reason.clone()));
+    CheckResult::from_code(
+        "profile.json",
+        Status::Fail,
+        &catalog::HEALTH_PROFILE_CORRUPT,
+        format!("{} is not valid JSON: {reason}", display(path)),
+        broken,
+    )
+}
+
+pub fn check_disk(requirement: &DiskRequirement) -> CheckResult {
+    // Walk up until an existing ancestor: the volume is what is being measured,
+    // and the leaf often does not exist yet.
+    let mut probe = requirement.path.as_path();
+    while !probe.exists() {
+        match probe.parent() {
+            Some(parent) => probe = parent,
+            None => break,
+        }
+    }
+
+    let available = match fs4::available_space(probe) {
+        Ok(available) => available,
+        Err(reason) => {
+            return CheckResult::pass(
+                "disk",
+                format!("free space is unknown on {}: {reason}", display(probe)),
+            )
+        }
+    };
+
+    if available >= requirement.required_bytes {
+        return CheckResult::pass(
+            "disk",
+            format!("{available} bytes free on {}", display(probe)),
+        );
+    }
+
+    CheckResult::from_code(
+        "disk",
+        Status::Fail,
+        &catalog::HEALTH_DISK_LOW,
+        format!(
+            "only {available} bytes free on {}, {} needed",
+            display(probe),
+            requirement.required_bytes
+        ),
+        fields(&[
+            ("path", json!(display(probe))),
+            ("availableBytes", json!(available)),
+            ("requiredBytes", json!(requirement.required_bytes)),
+        ]),
+    )
+}
+
+/// A clock that jumped backwards makes every timestamp comparison lie, which
+/// is worth knowing before someone concludes an event never happened.
+pub fn check_clock_skew(app_handle: &dyn AppContext) -> CheckResult {
+    let latest = query::search(
+        app_handle,
+        &query::Filter {
+            limit: Some(1),
+            ..Default::default()
+        },
+    )
+    .ok()
+    .and_then(|result| result.entries.last().map(|entry| entry.ts_ms));
+
+    let Some(latest) = latest else {
+        return CheckResult::pass("clock", "no earlier record to compare against");
+    };
+
+    let now = now_unix_ms();
+    if now + CLOCK_SKEW_TOLERANCE_MS >= latest {
+        return CheckResult::pass("clock", "system clock is consistent with the log");
+    }
+
+    let skew = latest - now;
+    CheckResult::from_code(
+        "clock",
+        Status::Warn,
+        &catalog::HEALTH_CLOCK_SKEW,
+        format!("the clock is {skew} ms behind the newest record on disk"),
+        fields(&[("skewMs", json!(skew.min(u128::from(u64::MAX)) as u64))]),
+    )
+}
+
+/// Invariants that hold for the app itself, whatever the platform: can it log
+/// at all, and is there room to keep logging.
+pub fn startup_report(app_handle: &dyn AppContext) -> Report {
+    let log_root = match crate::storage::app_log_root(app_handle) {
+        Ok(root) => root,
+        Err(reason) => {
+            let mut report = Report::default();
+            report.results.push(CheckResult::from_code(
+                "path.writable",
+                Status::Fail,
+                &catalog::HEALTH_PATH_PERMISSION_DENIED,
+                format!("the log directory cannot be resolved: {reason}"),
+                fields(&[
+                    ("path", json!("<unresolved>")),
+                    ("purpose", json!("application log")),
+                ]),
+            ));
+            return report;
+        }
+    };
+    let _ = std::fs::create_dir_all(&log_root);
+
+    Preflight::new()
+        .require_writable_path(log_root.clone(), "application log")
+        .require_free_space(log_root, LOG_DISK_REQUIREMENT_BYTES)
+        .check_clock()
+        .run(app_handle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diagnostics::test_support::TestCtx;
+
+    #[test]
+    fn a_missing_path_fails_with_its_action() {
+        let ctx = TestCtx::new("health-missing");
+        let missing = ctx.root().join("nope").join("userdata");
+        let report = Preflight::new()
+            .platform("steam")
+            .require_path(&missing, "steam userdata")
+            .run(&ctx);
+
+        assert!(!report.ok());
+        let failure = report.failures().next().expect("one failure");
+        assert_eq!(failure.code, Some("health.path.missing"));
+        assert!(
+            !failure.action.is_empty(),
+            "a finding without an action is a dead end"
+        );
+        assert_eq!(failure.fields["platform"], json!("steam"));
+    }
+
+    #[test]
+    fn an_existing_writable_directory_passes() {
+        let ctx = TestCtx::new("health-writable");
+        let report = Preflight::new()
+            .require_writable_path(ctx.root(), "test root")
+            .run(&ctx);
+        assert!(report.ok(), "{:?}", report.results);
+    }
+
+    #[test]
+    fn a_locked_file_is_detected() {
+        let ctx = TestCtx::new("health-locked");
+        let path = ctx.root().join("loginusers.vdf");
+        std::fs::write(&path, "{}").expect("seed");
+
+        let free = Preflight::new().require_unlocked_file(&path).run(&ctx);
+        assert!(free.ok(), "an untouched file must not look locked");
+
+        let holder = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .expect("open");
+        FileExt::lock(&holder).expect("lock");
+
+        let locked = Preflight::new()
+            .platform("steam")
+            .require_unlocked_file(&path)
+            .run(&ctx);
+        let _ = FileExt::unlock(&holder);
+
+        assert!(!locked.ok());
+        assert_eq!(
+            locked.failures().next().expect("failure").code,
+            Some("health.file.locked")
+        );
+    }
+
+    #[test]
+    fn a_corrupt_profile_is_detected_and_names_the_reason() {
+        let ctx = TestCtx::new("health-corrupt");
+        let path = ctx.root().join("profile.json");
+        std::fs::write(&path, "{ this is not json").expect("seed");
+
+        let report = Preflight::new()
+            .platform("riot")
+            .require_valid_json(&path)
+            .run(&ctx);
+
+        let failure = report.failures().next().expect("failure");
+        assert_eq!(failure.code, Some("health.profile.corrupt"));
+        assert!(failure.fields["reason"]
+            .as_str()
+            .is_some_and(|r| !r.is_empty()));
+    }
+
+    #[test]
+    fn a_disk_that_cannot_hold_the_request_fails() {
+        let ctx = TestCtx::new("health-disk");
+        let low = check_disk(&DiskRequirement {
+            path: ctx.root().to_path_buf(),
+            // No volume this app runs on has an exabyte free.
+            required_bytes: u64::MAX / 2,
+        });
+        assert_eq!(low.status, Status::Fail);
+        assert_eq!(low.code, Some("health.disk.low"));
+        assert!(low.fields["availableBytes"].as_u64().is_some());
+
+        let plenty = check_disk(&DiskRequirement {
+            path: ctx.root().to_path_buf(),
+            required_bytes: 1,
+        });
+        assert_eq!(plenty.status, Status::Pass);
+    }
+
+    #[test]
+    fn a_running_launcher_fails_and_names_the_platform() {
+        let result = launcher_result(&["steam.exe", "steamwebhelper.exe"], Some("steam"));
+
+        assert_eq!(result.status, Status::Fail);
+        assert_eq!(result.code, Some("health.launcher.running"));
+        assert_eq!(result.fields["platform"], json!("steam"));
+        assert_eq!(
+            result.fields["processes"],
+            json!(["steam.exe", "steamwebhelper.exe"])
+        );
+        // The code demands a platform, so a caller that forgot one still gets
+        // a valid record rather than a defect.
+        assert_eq!(
+            launcher_result(&["steam.exe"], None).fields["platform"],
+            json!("unknown")
+        );
+    }
+
+    #[test]
+    fn a_process_that_cannot_be_running_passes() {
+        let result = check_processes_stopped(
+            &["accshift-no-such-process-9c1f.exe".to_string()],
+            Some("steam"),
+        );
+        assert_eq!(result.status, Status::Pass);
+    }
+
+    // The findings have to reach the log with the operation attached, or the
+    // preflight is invisible in the replay of the failure it predicted.
+    #[test]
+    fn findings_are_emitted_against_the_operation() {
+        let ctx = TestCtx::ctx("health-emitted");
+        let missing = crate::storage::app_log_root(&*ctx)
+            .expect("root")
+            .join("absent");
+
+        Preflight::new()
+            .platform("steam")
+            .require_path(&missing, "steam userdata")
+            .run_and_emit(&*ctx, Some("op-deadbeef1234"));
+
+        let found = query::search(
+            &*ctx,
+            &query::Filter {
+                op_id: Some("op-deadbeef1234".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("query");
+        assert_eq!(found.entries.len(), 1);
+        assert_eq!(found.entries[0].code, "health.path.missing");
+        assert_eq!(found.entries[0].source, "health.steam");
+    }
+
+    #[test]
+    fn the_startup_report_runs_on_a_real_directory() {
+        let ctx = TestCtx::ctx("health-startup");
+        let report = startup_report(&*ctx);
+        assert!(report.ok(), "{:?}", report.results);
+        assert!(report
+            .results
+            .iter()
+            .any(|result| result.check == "disk" || result.check == "path"));
+    }
+}

--- a/crates/accshift-core/src/diagnostics/health.rs
+++ b/crates/accshift-core/src/diagnostics/health.rs
@@ -89,15 +89,19 @@ impl CheckResult {
         }
     }
 
+    /// Redacted, like everything else that can be read by someone other than
+    /// the machine that produced it. A check result quotes real paths, and
+    /// this value is what the diagnostic report and the UI display: the
+    /// redaction on the way to the log file would not cover either of them.
     pub fn to_json(&self) -> Value {
-        json!({
+        super::redact::sanitize_value(&json!({
             "check": self.check,
             "status": self.status.as_str(),
             "code": self.code,
             "detail": self.detail,
             "action": self.action,
             "fields": Value::Object(self.fields.clone()),
-        })
+        }))
     }
 }
 
@@ -120,11 +124,13 @@ impl Report {
         self.results.iter().filter(|r| r.status == Status::Warn)
     }
 
-    /// First blocking reason, in the order the checks were declared.
+    /// First blocking reason, in the order the checks were declared. Redacted:
+    /// this string is handed back to the caller as an error, and an error
+    /// message is the thing users paste.
     pub fn blocking_reason(&self) -> Option<String> {
-        self.failures()
-            .next()
-            .map(|failure| format!("{} ({})", failure.detail, failure.action))
+        self.failures().next().map(|failure| {
+            super::redact::sanitize_log_text(&format!("{} ({})", failure.detail, failure.action))
+        })
     }
 
     pub fn to_json(&self) -> Value {
@@ -622,6 +628,34 @@ mod tests {
             "a finding without an action is a dead end"
         );
         assert_eq!(failure.fields["platform"], json!("steam"));
+    }
+
+    // A check result quotes real paths, and the diagnostic report prints it
+    // verbatim. The redaction on the way to the log file does not cover that
+    // road, so the serialized form has to scrub on its own.
+    #[test]
+    fn a_serialized_check_result_is_redacted() {
+        let result = CheckResult::from_code(
+            "path",
+            Status::Fail,
+            &catalog::HEALTH_PATH_MISSING,
+            "missing for player@example.com at 3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+            Map::new(),
+        );
+
+        let detail = result.to_json()["detail"]
+            .as_str()
+            .expect("detail")
+            .to_string();
+        assert!(!detail.contains("player@example.com"), "{detail}");
+        assert!(!detail.contains("3f2504e0"), "{detail}");
+
+        let report = Report {
+            results: vec![result],
+        };
+        let reason = report.blocking_reason().expect("a blocking reason");
+        assert!(!reason.contains("player@example.com"), "{reason}");
+        assert!(!reason.contains("3f2504e0"), "{reason}");
     }
 
     #[test]

--- a/crates/accshift-core/src/diagnostics/levels.rs
+++ b/crates/accshift-core/src/diagnostics/levels.rs
@@ -1,0 +1,466 @@
+//! Per-module log levels, and a verbose mode that expires on its own.
+//!
+//! Two constraints shaped this. The user must never have to edit a file to
+//! raise the level, so the state lives next to the log and is driven by a
+//! command. And the verbose mode has to switch itself back off: a debug level
+//! left on by accident is how a 2 MiB log budget turns into ten minutes of
+//! retention.
+//!
+//! The GUI and the CLI are separate processes reading the same file, so the
+//! in-process cache is deliberately short-lived: a level raised from the CLI
+//! reaches a running GUI within [`CACHE_TTL`].
+
+use super::event::{now_unix_ms, Level};
+use crate::context::AppContext;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+pub const LEVELS_FILE_NAME: &str = "log-levels.json";
+const CACHE_TTL: Duration = Duration::from_secs(2);
+const DEFAULT_LEVEL: Level = Level::Info;
+/// Ceiling for a temporary debug window. Long enough to reproduce a switch,
+/// short enough that a forgotten one cannot eat the retention budget.
+pub const MAX_TEMPORARY_DEBUG_MS: u64 = 60 * 60 * 1000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TemporaryDebug {
+    pub level: Level,
+    /// Empty means every module.
+    pub modules: Vec<String>,
+    pub until_ms: u128,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LevelConfig {
+    pub default: Level,
+    pub modules: BTreeMap<String, Level>,
+    pub temporary: Option<TemporaryDebug>,
+}
+
+impl Default for LevelConfig {
+    fn default() -> Self {
+        Self {
+            default: DEFAULT_LEVEL,
+            modules: BTreeMap::new(),
+            temporary: None,
+        }
+    }
+}
+
+impl LevelConfig {
+    /// Level a record from `source` must reach to be written.
+    ///
+    /// The most specific module prefix wins (`platform.steam` beats
+    /// `platform`), and an active temporary window can only ever make it more
+    /// verbose, never less.
+    pub fn effective_for(&self, source: &str, now_ms: u128) -> Level {
+        let mut level = self
+            .modules
+            .iter()
+            .filter(|(module, _)| matches_module(module, source))
+            .max_by_key(|(module, _)| module.len())
+            .map(|(_, level)| *level)
+            .unwrap_or(self.default);
+
+        if let Some(temporary) = &self.temporary {
+            let active = temporary.until_ms > now_ms
+                && (temporary.modules.is_empty()
+                    || temporary
+                        .modules
+                        .iter()
+                        .any(|module| matches_module(module, source)));
+            if active && temporary.level < level {
+                level = temporary.level;
+            }
+        }
+
+        level
+    }
+
+    /// Whether a temporary window is still open at `now_ms`.
+    pub fn temporary_active(&self, now_ms: u128) -> bool {
+        self.temporary
+            .as_ref()
+            .is_some_and(|temporary| temporary.until_ms > now_ms)
+    }
+
+    pub fn to_json(&self, now_ms: u128) -> Value {
+        json!({
+            "default": self.default.as_str(),
+            "modules": self
+                .modules
+                .iter()
+                .map(|(module, level)| (module.clone(), json!(level.as_str())))
+                .collect::<serde_json::Map<String, Value>>(),
+            "temporaryDebug": self.temporary.as_ref().filter(|t| t.until_ms > now_ms).map(|t| json!({
+                "level": t.level.as_str(),
+                "modules": t.modules,
+                "untilMs": t.until_ms as u64,
+                "remainingMs": (t.until_ms - now_ms) as u64,
+            })),
+        })
+    }
+}
+
+/// `platform` covers `platform.steam`; `*` covers everything.
+fn matches_module(module: &str, source: &str) -> bool {
+    if module == "*" {
+        return true;
+    }
+    source == module
+        || (source.starts_with(module) && source.as_bytes().get(module.len()) == Some(&b'.'))
+}
+
+// ---------------------------------------------------------------------------
+// On-disk shape
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+struct RawLevelConfig {
+    default: Option<String>,
+    modules: BTreeMap<String, String>,
+    temporary_debug: Option<RawTemporaryDebug>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+struct RawTemporaryDebug {
+    level: Option<String>,
+    modules: Vec<String>,
+    until_ms: u64,
+}
+
+impl From<RawLevelConfig> for LevelConfig {
+    fn from(raw: RawLevelConfig) -> Self {
+        LevelConfig {
+            default: raw
+                .default
+                .as_deref()
+                .and_then(Level::parse)
+                .unwrap_or(DEFAULT_LEVEL),
+            modules: raw
+                .modules
+                .into_iter()
+                .filter_map(|(module, level)| Level::parse(&level).map(|level| (module, level)))
+                .collect(),
+            temporary: raw.temporary_debug.and_then(|temporary| {
+                let level = temporary.level.as_deref().and_then(Level::parse)?;
+                Some(TemporaryDebug {
+                    level,
+                    modules: temporary.modules,
+                    until_ms: u128::from(temporary.until_ms),
+                })
+            }),
+        }
+    }
+}
+
+impl LevelConfig {
+    fn to_raw(&self, now_ms: u128) -> RawLevelConfig {
+        RawLevelConfig {
+            default: Some(self.default.as_str().to_string()),
+            modules: self
+                .modules
+                .iter()
+                .map(|(module, level)| (module.clone(), level.as_str().to_string()))
+                .collect(),
+            // An expired window is dropped on the next write rather than kept
+            // as dead state nobody can explain later.
+            temporary_debug: self
+                .temporary
+                .as_ref()
+                .filter(|temporary| temporary.until_ms > now_ms)
+                .map(|temporary| RawTemporaryDebug {
+                    level: Some(temporary.level.as_str().to_string()),
+                    modules: temporary.modules.clone(),
+                    until_ms: temporary.until_ms.min(u128::from(u64::MAX)) as u64,
+                }),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Access
+// ---------------------------------------------------------------------------
+
+static CACHE: Mutex<Option<(PathBuf, Instant, LevelConfig)>> = Mutex::new(None);
+
+pub fn levels_file_path(app_handle: &dyn AppContext) -> Result<PathBuf, String> {
+    Ok(crate::storage::app_log_root(app_handle)?.join(LEVELS_FILE_NAME))
+}
+
+/// Read the level configuration, from a short-lived cache when possible.
+pub fn load(app_handle: &dyn AppContext) -> LevelConfig {
+    let Ok(path) = levels_file_path(app_handle) else {
+        return LevelConfig::default();
+    };
+
+    {
+        let cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some((cached_path, loaded_at, config)) = cache.as_ref() {
+            if cached_path == &path && loaded_at.elapsed() < CACHE_TTL {
+                return config.clone();
+            }
+        }
+    }
+
+    let config = read_from_disk(&path);
+    let mut cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    *cache = Some((path, Instant::now(), config.clone()));
+    config
+}
+
+fn read_from_disk(path: &std::path::Path) -> LevelConfig {
+    // A missing or unreadable file is the normal case (nobody ever changed a
+    // level), and a corrupt one must not silence logging: both fall back to
+    // the defaults.
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|text| serde_json::from_str::<RawLevelConfig>(&text).ok())
+        .map(LevelConfig::from)
+        .unwrap_or_default()
+}
+
+/// Effective level for `source`, the single question the emit path asks.
+pub fn effective_level(app_handle: &dyn AppContext, source: &str) -> Level {
+    load(app_handle).effective_for(source, now_unix_ms())
+}
+
+fn store(app_handle: &dyn AppContext, config: &LevelConfig) -> Result<(), String> {
+    let path = levels_file_path(app_handle)?;
+    let raw = config.to_raw(now_unix_ms());
+    let payload = serde_json::to_vec_pretty(&raw)
+        .map_err(|reason| format!("Could not serialize log levels: {reason}"))?;
+    super::write_atomic(&path, &payload)?;
+    invalidate_cache();
+    Ok(())
+}
+
+/// Forget the cached configuration. Called by every writer so the change is
+/// visible to this process immediately instead of within [`CACHE_TTL`].
+pub fn invalidate_cache() {
+    let mut cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    *cache = None;
+}
+
+/// Set (or clear, with `None`) the level of one module. `module` = `None`
+/// targets the default level.
+pub fn set_level(
+    app_handle: &dyn AppContext,
+    module: Option<&str>,
+    level: Option<Level>,
+) -> Result<LevelConfig, String> {
+    let mut config = load(app_handle);
+    match (module, level) {
+        (None, Some(level)) => config.default = level,
+        (None, None) => config.default = DEFAULT_LEVEL,
+        (Some(module), Some(level)) => {
+            config.modules.insert(module.to_string(), level);
+        }
+        (Some(module), None) => {
+            config.modules.remove(module);
+        }
+    }
+    store(app_handle, &config)?;
+
+    super::event::event(&super::catalog::DIAGNOSTICS_LEVEL_CHANGED)
+        .source("diagnostics.levels")
+        .field("module", module.unwrap_or("*"))
+        .field("newLevel", level.map(Level::as_str).unwrap_or("default"))
+        .emit(app_handle);
+
+    Ok(config)
+}
+
+/// Open a verbose window that closes itself after `duration_ms`.
+pub fn start_temporary_debug(
+    app_handle: &dyn AppContext,
+    level: Level,
+    modules: Vec<String>,
+    duration_ms: u64,
+) -> Result<LevelConfig, String> {
+    let duration_ms = duration_ms.clamp(1_000, MAX_TEMPORARY_DEBUG_MS);
+    let mut config = load(app_handle);
+    config.temporary = Some(TemporaryDebug {
+        level,
+        modules: modules.clone(),
+        until_ms: now_unix_ms() + u128::from(duration_ms),
+    });
+    store(app_handle, &config)?;
+
+    super::event::event(&super::catalog::DIAGNOSTICS_DEBUG_ENABLED)
+        .source("diagnostics.levels")
+        .field("durationMs", duration_ms)
+        .field("newLevel", level.as_str())
+        .field(
+            "modules",
+            Value::Array(modules.iter().map(|m| json!(m)).collect()),
+        )
+        .emit(app_handle);
+
+    Ok(config)
+}
+
+/// Close the verbose window early.
+pub fn stop_temporary_debug(app_handle: &dyn AppContext) -> Result<LevelConfig, String> {
+    let mut config = load(app_handle);
+    let was_active = config.temporary_active(now_unix_ms());
+    config.temporary = None;
+    store(app_handle, &config)?;
+    if was_active {
+        super::event::event(&super::catalog::DIAGNOSTICS_DEBUG_EXPIRED)
+            .source("diagnostics.levels")
+            .emit(app_handle);
+    }
+    Ok(config)
+}
+
+/// Drop an expired window from the file. Called at session start so the state
+/// on disk matches what the app actually does.
+pub fn expire_temporary_debug(app_handle: &dyn AppContext) {
+    let config = load(app_handle);
+    let now = now_unix_ms();
+    if config.temporary.is_some() && !config.temporary_active(now) {
+        let mut cleaned = config;
+        cleaned.temporary = None;
+        let _ = store(app_handle, &cleaned);
+        super::event::event(&super::catalog::DIAGNOSTICS_DEBUG_EXPIRED)
+            .source("diagnostics.levels")
+            .emit(app_handle);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diagnostics::test_support::TestCtx;
+
+    #[test]
+    fn default_level_hides_debug_and_keeps_info() {
+        let config = LevelConfig::default();
+        assert_eq!(config.effective_for("platform.steam", 0), Level::Info);
+    }
+
+    #[test]
+    fn most_specific_module_prefix_wins() {
+        let mut config = LevelConfig::default();
+        config.modules.insert("platform".into(), Level::Warn);
+        config.modules.insert("platform.steam".into(), Level::Debug);
+
+        assert_eq!(config.effective_for("platform.steam", 0), Level::Debug);
+        assert_eq!(config.effective_for("platform.riot", 0), Level::Warn);
+        assert_eq!(config.effective_for("storage", 0), Level::Info);
+    }
+
+    // A prefix must match on a dot boundary, otherwise `platform` would also
+    // configure a hypothetical `platformer` module.
+    #[test]
+    fn module_prefixes_match_on_dot_boundaries() {
+        assert!(matches_module("platform", "platform.steam"));
+        assert!(matches_module("platform", "platform"));
+        assert!(!matches_module("platform", "platforms.steam"));
+        assert!(matches_module("*", "anything"));
+    }
+
+    #[test]
+    fn temporary_window_only_makes_logging_more_verbose() {
+        let mut config = LevelConfig::default();
+        config.modules.insert("platform".into(), Level::Error);
+        config.temporary = Some(TemporaryDebug {
+            level: Level::Debug,
+            modules: vec![],
+            until_ms: 1_000,
+        });
+
+        assert_eq!(config.effective_for("platform.steam", 500), Level::Debug);
+        // A window asking for less than the module already emits changes
+        // nothing.
+        config.temporary = Some(TemporaryDebug {
+            level: Level::Warn,
+            modules: vec![],
+            until_ms: 1_000,
+        });
+        assert_eq!(config.effective_for("storage", 500), Level::Info);
+    }
+
+    #[test]
+    fn temporary_window_reverts_on_its_own() {
+        let mut config = LevelConfig::default();
+        config.temporary = Some(TemporaryDebug {
+            level: Level::Trace,
+            modules: vec![],
+            until_ms: 1_000,
+        });
+
+        assert_eq!(config.effective_for("platform", 999), Level::Trace);
+        // One millisecond past the deadline the normal level is back, with no
+        // command, no restart and no file edit.
+        assert_eq!(config.effective_for("platform", 1_000), Level::Info);
+        assert!(!config.temporary_active(1_000));
+    }
+
+    #[test]
+    fn temporary_window_can_target_one_module() {
+        let mut config = LevelConfig::default();
+        config.temporary = Some(TemporaryDebug {
+            level: Level::Debug,
+            modules: vec!["platform.riot".into()],
+            until_ms: 1_000,
+        });
+
+        assert_eq!(config.effective_for("platform.riot", 0), Level::Debug);
+        assert_eq!(config.effective_for("platform.steam", 0), Level::Info);
+    }
+
+    #[test]
+    fn levels_round_trip_through_the_file() {
+        let ctx = TestCtx::new("levels-roundtrip");
+
+        set_level(&ctx, Some("platform.steam"), Some(Level::Debug)).expect("set module level");
+        set_level(&ctx, None, Some(Level::Warn)).expect("set default level");
+
+        let reloaded = read_from_disk(&levels_file_path(&ctx).expect("path"));
+        assert_eq!(reloaded.default, Level::Warn);
+        assert_eq!(
+            reloaded.modules.get("platform.steam").copied(),
+            Some(Level::Debug)
+        );
+
+        set_level(&ctx, Some("platform.steam"), None).expect("clear module level");
+        let cleared = read_from_disk(&levels_file_path(&ctx).expect("path"));
+        assert!(cleared.modules.is_empty());
+    }
+
+    #[test]
+    fn temporary_debug_is_clamped_and_persisted() {
+        let ctx = TestCtx::new("levels-temporary");
+
+        start_temporary_debug(&ctx, Level::Trace, vec![], u64::MAX).expect("start");
+        let stored = read_from_disk(&levels_file_path(&ctx).expect("path"));
+        let temporary = stored.temporary.expect("temporary window");
+        assert_eq!(temporary.level, Level::Trace);
+        assert!(temporary.until_ms <= now_unix_ms() + u128::from(MAX_TEMPORARY_DEBUG_MS));
+
+        stop_temporary_debug(&ctx).expect("stop");
+        assert!(read_from_disk(&levels_file_path(&ctx).expect("path"))
+            .temporary
+            .is_none());
+    }
+
+    // A file someone hand-edited into nonsense must not take logging down
+    // with it.
+    #[test]
+    fn corrupt_file_falls_back_to_defaults() {
+        let ctx = TestCtx::new("levels-corrupt");
+        let path = levels_file_path(&ctx).expect("path");
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&path, "{ not json").expect("write");
+
+        assert_eq!(read_from_disk(&path), LevelConfig::default());
+    }
+}

--- a/crates/accshift-core/src/diagnostics/mod.rs
+++ b/crates/accshift-core/src/diagnostics/mod.rs
@@ -33,15 +33,27 @@ pub use event::{event, new_op_id, run_id, EventBuilder, Level, Outcome, SCHEMA_V
 pub use ops::{with_operation, Op};
 pub use redact::sanitize_log_text;
 
-use std::fs;
-use std::path::Path;
+use fs4::FileExt;
+use std::fs::{self, OpenOptions};
+use std::path::{Path, PathBuf};
+
+fn atomic_lock_path(path: &Path) -> PathBuf {
+    let mut name = path
+        .file_name()
+        .map(|name| name.to_os_string())
+        .unwrap_or_else(|| std::ffi::OsString::from("file"));
+    name.push(".lock");
+    path.with_file_name(name)
+}
 
 /// Write through a sibling temporary file and rename over the target.
 ///
 /// The state files here (levels, anomaly counters) are read by another process
 /// while this one writes them. A partial write would be read as corrupt, and
 /// corrupt means the defaults come back, which silently loses whatever the
-/// user just set.
+/// user just set. The GUI and the CLI share the same `*.tmp` name, so the
+/// write and the rename sit under an exclusive sidecar lock, same shape as
+/// [`anomaly::with_state`].
 pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> Result<(), String> {
     let parent = path
         .parent()
@@ -49,14 +61,33 @@ pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> Result<(), String> {
     fs::create_dir_all(parent)
         .map_err(|reason| format!("Could not create {}: {reason}", parent.display()))?;
 
+    let lock_path = atomic_lock_path(path);
+    let lock_file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .map_err(|reason| format!("Could not open {}: {reason}", lock_path.display()))?;
+    // Best effort, same as the log sink and the anomaly counters: a lock that
+    // cannot be taken must not turn a settings write into a hard failure.
+    let locked = FileExt::lock(&lock_file).is_ok();
+
     let temp = path.with_extension("tmp");
-    fs::write(&temp, bytes)
-        .map_err(|reason| format!("Could not write {}: {reason}", temp.display()))?;
-    // Rename replaces the target on both platforms this ships on.
-    fs::rename(&temp, path).map_err(|reason| {
-        let _ = fs::remove_file(&temp);
-        format!("Could not replace {}: {reason}", path.display())
-    })
+    let outcome = fs::write(&temp, bytes)
+        .map_err(|reason| format!("Could not write {}: {reason}", temp.display()))
+        .and_then(|()| {
+            // Rename replaces the target on both platforms this ships on.
+            fs::rename(&temp, path).map_err(|reason| {
+                let _ = fs::remove_file(&temp);
+                format!("Could not replace {}: {reason}", path.display())
+            })
+        });
+
+    if locked {
+        let _ = FileExt::unlock(&lock_file);
+    }
+    outcome
 }
 
 #[cfg(test)]
@@ -141,5 +172,36 @@ mod tests {
             !path.with_extension("tmp").exists(),
             "the temporary file must not survive"
         );
+        assert!(
+            atomic_lock_path(&path).exists(),
+            "the sidecar lock file is how two processes serialize"
+        );
+    }
+
+    #[test]
+    fn write_atomic_never_leaves_a_mixed_payload() {
+        let dir = std::env::temp_dir()
+            .join("accshift-diagnostics-tests")
+            .join(format!("atomic-race-{}", std::process::id()));
+        let path = dir.join("state.json");
+        let payloads: Vec<Vec<u8>> = (0..8)
+            .map(|index| format!("payload-{index:02}-{}", "x".repeat(512)).into_bytes())
+            .collect();
+
+        std::thread::scope(|scope| {
+            for payload in &payloads {
+                let path = path.clone();
+                scope.spawn(move || {
+                    write_atomic(&path, payload).expect("write");
+                });
+            }
+        });
+
+        let written = fs::read(&path).expect("read");
+        assert!(
+            payloads.iter().any(|payload| payload == &written),
+            "the file must be one complete payload, not a mix"
+        );
+        assert!(!path.with_extension("tmp").exists());
     }
 }

--- a/crates/accshift-core/src/diagnostics/mod.rs
+++ b/crates/accshift-core/src/diagnostics/mod.rs
@@ -1,0 +1,145 @@
+//! Diagnostics: the structured half of the log.
+//!
+//! [`crate::logging`] owns the file, the lock and the rotation. This module
+//! owns what goes in it and what can be got back out:
+//!
+//! - [`catalog`] declares every event code, its severity, its fields, what it
+//!   means and what to do about it. It is the single source of truth, and an
+//!   undeclared code is a compile error.
+//! - [`event`] builds the versioned record and is the only writing path.
+//! - [`levels`] decides what is verbose enough to keep, per module, including
+//!   a temporary debug window that turns itself off.
+//! - [`ops`] gives one identifier to a whole user action, so a failure replays
+//!   as a sequence.
+//! - [`health`] checks the invariants that predict a failure before it happens.
+//! - [`anomaly`] counts what only means something over several runs.
+//! - [`query`] reads it all back with filters.
+//! - [`bundle`] packs one pasteable local file out of the lot.
+//! - [`redact`] scrubs everything above, with no opt-out.
+
+pub mod anomaly;
+pub mod bundle;
+pub mod catalog;
+pub mod event;
+pub mod health;
+pub mod levels;
+pub mod ops;
+pub mod query;
+pub mod redact;
+pub mod schema;
+
+pub use catalog::{lookup, EventCode, CATALOG};
+pub use event::{event, new_op_id, run_id, EventBuilder, Level, Outcome, SCHEMA_VERSION};
+pub use ops::{with_operation, Op};
+pub use redact::sanitize_log_text;
+
+use std::fs;
+use std::path::Path;
+
+/// Write through a sibling temporary file and rename over the target.
+///
+/// The state files here (levels, anomaly counters) are read by another process
+/// while this one writes them. A partial write would be read as corrupt, and
+/// corrupt means the defaults come back, which silently loses whatever the
+/// user just set.
+pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("{} has no parent directory", path.display()))?;
+    fs::create_dir_all(parent)
+        .map_err(|reason| format!("Could not create {}: {reason}", parent.display()))?;
+
+    let temp = path.with_extension("tmp");
+    fs::write(&temp, bytes)
+        .map_err(|reason| format!("Could not write {}: {reason}", temp.display()))?;
+    // Rename replaces the target on both platforms this ships on.
+    fs::rename(&temp, path).map_err(|reason| {
+        let _ = fs::remove_file(&temp);
+        format!("Could not replace {}: {reason}", path.display())
+    })
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use crate::context::{AppContext, AppCtx};
+    use std::collections::HashSet;
+    use std::path::{Path, PathBuf};
+    use std::sync::{Arc, Mutex, OnceLock};
+
+    /// An [`AppContext`] rooted in a throwaway directory, one per test.
+    ///
+    /// Tests share a process, and the log sink is process-global and keyed by
+    /// path, so two tests must never share a tag.
+    pub struct TestCtx {
+        root: PathBuf,
+    }
+
+    fn created() -> &'static Mutex<HashSet<PathBuf>> {
+        static CREATED: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
+        CREATED.get_or_init(|| Mutex::new(HashSet::new()))
+    }
+
+    impl TestCtx {
+        pub fn new(tag: &str) -> Self {
+            let root = std::env::temp_dir()
+                .join("accshift-diagnostics-tests")
+                .join(format!("{tag}-{}", std::process::id()));
+
+            // Wipe once per process: a test that builds its context twice must
+            // not lose what it already logged, but a rerun must not inherit
+            // the previous run's file either.
+            let mut created = created().lock().unwrap_or_else(|e| e.into_inner());
+            if created.insert(root.clone()) {
+                let _ = std::fs::remove_dir_all(&root);
+            }
+            let _ = std::fs::create_dir_all(&root);
+
+            TestCtx { root }
+        }
+
+        /// Shorthand for the common case: a context, ready to log into.
+        pub fn ctx(tag: &str) -> AppCtx {
+            Arc::new(TestCtx::new(tag))
+        }
+
+        pub fn root(&self) -> &Path {
+            &self.root
+        }
+    }
+
+    impl AppContext for TestCtx {
+        fn app_config_dir(&self) -> Result<PathBuf, String> {
+            Ok(self.root.clone())
+        }
+        fn app_data_dir(&self) -> Result<PathBuf, String> {
+            Ok(self.root.clone())
+        }
+        fn app_local_data_dir(&self) -> Result<PathBuf, String> {
+            Ok(self.root.clone())
+        }
+        fn app_cache_dir(&self) -> Result<PathBuf, String> {
+            Ok(self.root.clone())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_atomic_replaces_an_existing_file() {
+        let dir = std::env::temp_dir()
+            .join("accshift-diagnostics-tests")
+            .join(format!("atomic-{}", std::process::id()));
+        let path = dir.join("state.json");
+        write_atomic(&path, b"first").expect("first write");
+        write_atomic(&path, b"second").expect("second write");
+
+        assert_eq!(fs::read_to_string(&path).expect("read"), "second");
+        assert!(
+            !path.with_extension("tmp").exists(),
+            "the temporary file must not survive"
+        );
+    }
+}

--- a/crates/accshift-core/src/diagnostics/ops.rs
+++ b/crates/accshift-core/src/diagnostics/ops.rs
@@ -1,0 +1,358 @@
+//! Operation tracing: one identifier per user action, propagated all the way
+//! down, so a failed attempt reads as a sequence instead of a handful of
+//! unrelated lines.
+//!
+//! ```ignore
+//! let op = ops::start(&ctx, "platform.switch").platform("steam").begin();
+//! op.step("kill-launcher");
+//! op.event(&catalog::HEALTH_LAUNCHER_RUNNING)
+//!     .field("platform", "steam")
+//!     .field("processes", json!(["steam.exe"]))
+//!     .emit(&*op.ctx());
+//! op.fail("client_running", "Steam refused to exit");
+//! ```
+//!
+//! Everything above shares one `opId`, and `accshift diag logs --op <id>`
+//! replays it in order with the duration and the outcome on the closing line.
+
+use super::catalog::{self, EventCode};
+use super::event::{self, EventBuilder, Outcome};
+use crate::context::AppCtx;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Instant;
+
+/// Builder so the opening record can carry context without a five-argument
+/// `start`.
+pub struct OpStart<'a> {
+    ctx: &'a AppCtx,
+    name: &'static str,
+    platform: Option<String>,
+    trigger: Option<String>,
+}
+
+/// Open an operation. `name` is a static string on purpose: operation names
+/// are a closed vocabulary, not user input.
+pub fn start<'a>(ctx: &'a AppCtx, name: &'static str) -> OpStart<'a> {
+    OpStart {
+        ctx,
+        name,
+        platform: None,
+        trigger: None,
+    }
+}
+
+impl OpStart<'_> {
+    pub fn platform(mut self, platform: impl Into<String>) -> Self {
+        self.platform = Some(platform.into());
+        self
+    }
+
+    /// What asked for this: `gui`, `cli`, `deep-link`, `startup`.
+    pub fn trigger(mut self, trigger: impl Into<String>) -> Self {
+        self.trigger = Some(trigger.into());
+        self
+    }
+
+    pub fn begin(self) -> Op {
+        let op = Op {
+            ctx: self.ctx.clone(),
+            id: event::new_op_id(),
+            name: self.name,
+            platform: self.platform.clone(),
+            started: Instant::now(),
+            steps: AtomicU64::new(0),
+            finished: AtomicBool::new(false),
+        };
+
+        let mut builder = event::event(&catalog::OP_STARTED)
+            .source(self.name)
+            .op(op.id.clone())
+            .field("op", self.name);
+        if let Some(platform) = self.platform {
+            builder = builder.field("platform", platform);
+        }
+        if let Some(trigger) = self.trigger {
+            builder = builder.field("trigger", trigger);
+        }
+        builder.emit(&*op.ctx);
+
+        op
+    }
+}
+
+/// A live operation. Dropping one without an explicit outcome closes it as
+/// cancelled, so an early `return` or a panic still leaves a closing line.
+pub struct Op {
+    ctx: AppCtx,
+    id: String,
+    name: &'static str,
+    platform: Option<String>,
+    started: Instant,
+    steps: AtomicU64,
+    finished: AtomicBool,
+}
+
+impl Op {
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    pub fn platform(&self) -> Option<&str> {
+        self.platform.as_deref()
+    }
+
+    /// The context this operation was opened with, for callees that need to
+    /// log on their own.
+    pub fn ctx(&self) -> &AppCtx {
+        &self.ctx
+    }
+
+    pub fn elapsed_ms(&self) -> u64 {
+        self.started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64
+    }
+
+    /// An event attached to this operation: same `opId`, same source, so a
+    /// callee only has to add its own fields.
+    pub fn event(&self, code: &'static EventCode) -> EventBuilder {
+        event::event(code).source(self.name).op(self.id.clone())
+    }
+
+    /// Record a named step. The last step before a failure is where a reader
+    /// starts.
+    pub fn step(&self, step: &str) {
+        self.step_with_detail(step, None);
+    }
+
+    pub fn step_with_detail(&self, step: &str, detail: Option<&str>) {
+        self.steps.fetch_add(1, Ordering::Relaxed);
+        let mut builder = self
+            .event(&catalog::OP_STEP)
+            .field("op", self.name)
+            .field("step", step);
+        if let Some(platform) = &self.platform {
+            builder = builder.field("platform", platform.clone());
+        }
+        if let Some(detail) = detail {
+            builder = builder.field("detail", detail);
+        }
+        builder.emit(&*self.ctx);
+    }
+
+    pub fn succeed(self) {
+        self.close(Outcome::Success, None, None);
+    }
+
+    pub fn fail(self, err_kind: &str, message: &str) {
+        self.close(Outcome::Failure, Some(err_kind), Some(message));
+    }
+
+    pub fn cancel(self, reason: &str) {
+        self.close(Outcome::Cancelled, None, Some(reason));
+    }
+
+    /// Close with an outcome computed by the caller.
+    pub fn finish(self, outcome: Outcome, err_kind: Option<&str>, message: Option<&str>) {
+        self.close(outcome, err_kind, message);
+    }
+
+    fn close(&self, outcome: Outcome, err_kind: Option<&str>, message: Option<&str>) {
+        if self.finished.swap(true, Ordering::SeqCst) {
+            return;
+        }
+
+        let mut builder = self
+            .event(&catalog::OP_FINISHED)
+            .field("op", self.name)
+            .field("steps", self.steps.load(Ordering::Relaxed))
+            .dur_ms(self.elapsed_ms())
+            .outcome(outcome);
+        if let Some(platform) = &self.platform {
+            builder = builder.field("platform", platform.clone());
+        }
+        if let Some(err_kind) = err_kind {
+            builder = builder.err_kind(err_kind);
+        }
+        if let Some(message) = message {
+            builder = builder.msg(message);
+        }
+        if matches!(outcome, Outcome::Failure) {
+            // A failure is worth reading even when the module is quiet.
+            builder = builder.level(event::Level::Error);
+        }
+        builder.emit(&*self.ctx);
+
+        super::anomaly::record_operation(
+            &self.ctx,
+            self.platform.as_deref(),
+            self.name,
+            outcome,
+            self.elapsed_ms(),
+        );
+    }
+}
+
+impl Drop for Op {
+    fn drop(&mut self) {
+        // An operation that vanished without a verdict is itself a finding:
+        // an early return, a `?` on an untyped error, or a panic unwinding
+        // through the call stack.
+        self.close(
+            Outcome::Cancelled,
+            None,
+            Some("Operation dropped without an explicit outcome"),
+        );
+    }
+}
+
+/// Run `body` inside an operation and close it from the `Result`.
+///
+/// `err_kind` maps the error to the closed vocabulary that lands in the
+/// `errKind` column, which is what makes failures groupable.
+pub fn with_operation<T, E, F, K>(
+    ctx: &AppCtx,
+    name: &'static str,
+    platform: Option<&str>,
+    err_kind: K,
+    body: F,
+) -> Result<T, E>
+where
+    F: FnOnce(&Op) -> Result<T, E>,
+    K: FnOnce(&E) -> String,
+    E: std::fmt::Display,
+{
+    let mut starter = start(ctx, name);
+    if let Some(platform) = platform {
+        starter = starter.platform(platform);
+    }
+    let op = starter.begin();
+
+    match body(&op) {
+        Ok(value) => {
+            op.succeed();
+            Ok(value)
+        }
+        Err(error) => {
+            let kind = err_kind(&error);
+            op.fail(&kind, &error.to_string());
+            Err(error)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diagnostics::query;
+    use crate::diagnostics::test_support::TestCtx;
+    use crate::diagnostics::{catalog, levels};
+    use serde_json::json;
+
+    fn read_ops(ctx: &AppCtx, op_id: &str) -> Vec<serde_json::Value> {
+        let filter = query::Filter {
+            op_id: Some(op_id.to_string()),
+            ..Default::default()
+        };
+        query::search(&**ctx, &filter)
+            .expect("query")
+            .entries
+            .into_iter()
+            .map(|entry| entry.raw)
+            .collect()
+    }
+
+    // The acceptance test of the whole tracing layer: one failed attempt has
+    // to read back as an ordered sequence from a single identifier.
+    #[test]
+    fn a_failed_operation_replays_from_its_op_id_alone() {
+        let ctx = TestCtx::ctx("ops-replay");
+        // Steps are debug-level, so the trace is only complete once the module
+        // is turned up. That is exactly what the temporary debug mode is for.
+        levels::set_level(&*ctx, Some("platform.switch"), Some(event::Level::Debug))
+            .expect("raise level");
+
+        let op = start(&ctx, "platform.switch")
+            .platform("steam")
+            .trigger("cli")
+            .begin();
+        let op_id = op.id().to_string();
+        op.step("preflight");
+        op.event(&catalog::HEALTH_LAUNCHER_RUNNING)
+            .field("platform", "steam")
+            .field("processes", json!(["steam.exe"]))
+            .emit(&**op.ctx());
+        op.step("kill-launcher");
+        op.fail("client_running", "Steam refused to exit");
+
+        let entries = read_ops(&ctx, &op_id);
+        let codes: Vec<&str> = entries
+            .iter()
+            .map(|entry| entry["code"].as_str().unwrap_or_default())
+            .collect();
+        assert_eq!(
+            codes,
+            [
+                "op.started",
+                "op.step",
+                "health.launcher.running",
+                "op.step",
+                "op.finished"
+            ],
+            "the whole attempt must come back in order from one opId"
+        );
+
+        let closing = entries.last().expect("closing record");
+        assert_eq!(closing["outcome"], json!("failure"));
+        assert_eq!(closing["errKind"], json!("client_running"));
+        assert_eq!(closing["fields"]["steps"], json!(2));
+        assert!(closing["durMs"].as_u64().is_some());
+        // Every record carries the run, so a file holding several launches
+        // still splits per run.
+        assert!(entries
+            .iter()
+            .all(|entry| entry["runId"] == json!(event::run_id())));
+    }
+
+    #[test]
+    fn a_dropped_operation_still_closes() {
+        let ctx = TestCtx::ctx("ops-dropped");
+        let op_id = {
+            let op = start(&ctx, "platform.snapshot").begin();
+            op.id().to_string()
+        };
+
+        let entries = read_ops(&ctx, &op_id);
+        let closing = entries.last().expect("closing record");
+        assert_eq!(closing["code"], json!("op.finished"));
+        assert_eq!(closing["outcome"], json!("cancelled"));
+    }
+
+    #[test]
+    fn with_operation_closes_from_the_result() {
+        let ctx = TestCtx::ctx("ops-with");
+        let outcome: Result<u8, String> = with_operation(
+            &ctx,
+            "diagnostics.selftest",
+            Some("steam"),
+            |_| "io".to_string(),
+            |op| {
+                op.step("work");
+                Err("disk on fire".to_string())
+            },
+        );
+        assert!(outcome.is_err());
+
+        let filter = query::Filter {
+            codes: vec!["op.finished".to_string()],
+            ..Default::default()
+        };
+        let entries = query::search(&*ctx, &filter).expect("query").entries;
+        let closing = entries.last().expect("closing record");
+        assert_eq!(closing.raw["outcome"], json!("failure"));
+        assert_eq!(closing.raw["errKind"], json!("io"));
+        assert_eq!(closing.raw["fields"]["platform"], json!("steam"));
+    }
+}

--- a/crates/accshift-core/src/diagnostics/query.rs
+++ b/crates/accshift-core/src/diagnostics/query.rs
@@ -1,0 +1,509 @@
+//! Reading the log back.
+//!
+//! A log nobody can query is a log nobody reads. This is the other half of the
+//! structured record: filters on the columns the writer promised, over the
+//! whole retained chain, oldest file first, in one call.
+//!
+//! Readers never take the log lock. A record is a whole line, so the worst a
+//! concurrent writer can do is leave a half-written last line, which fails to
+//! parse and is skipped.
+
+use super::catalog;
+use super::event::{Level, Outcome};
+use crate::context::AppContext;
+use crate::logging;
+use serde_json::{json, Value};
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+/// What a reader asks for. Everything is optional and combines with AND.
+#[derive(Debug, Clone, Default)]
+pub struct Filter {
+    /// Exact codes. Aliases are resolved, so an old code still finds its
+    /// records.
+    pub codes: Vec<String>,
+    /// Keep records at this level or above.
+    pub min_level: Option<Level>,
+    pub op_id: Option<String>,
+    pub run_id: Option<String>,
+    /// Matches the `platform` field, whatever the code.
+    pub platform: Option<String>,
+    /// Module prefix, dot-bounded: `platform` matches `platform.steam`.
+    pub source: Option<String>,
+    pub outcome: Option<Outcome>,
+    pub since_ms: Option<u128>,
+    pub until_ms: Option<u128>,
+    /// Substring, case-insensitive, over the message and the fields.
+    pub contains: Option<String>,
+    /// Keep only the last N matches. `None` keeps everything retained.
+    pub limit: Option<usize>,
+}
+
+/// One record, plus where it came from.
+#[derive(Debug, Clone)]
+pub struct Entry {
+    /// File name only: the directory is the log root and never interesting.
+    pub file: String,
+    pub line: usize,
+    pub schema_version: u32,
+    pub ts_ms: u128,
+    pub level: Level,
+    /// `legacy.record` for a schema-1 line, which has no code of its own.
+    pub code: String,
+    pub source: String,
+    pub msg: String,
+    pub op_id: Option<String>,
+    pub outcome: Option<String>,
+    pub dur_ms: Option<u64>,
+    pub err_kind: Option<String>,
+    /// The record exactly as it sits on disk.
+    pub raw: Value,
+}
+
+pub const LEGACY_CODE: &str = "legacy.record";
+
+#[derive(Debug, Clone, Default)]
+pub struct SearchResult {
+    pub entries: Vec<Entry>,
+    /// Lines read, matching or not. The ratio says whether a filter is useful.
+    pub scanned: usize,
+    /// Lines that were not valid JSON: a torn tail, or something else writing
+    /// into the file.
+    pub unparsable: usize,
+    /// Matches dropped because `limit` kept only the tail.
+    pub dropped_by_limit: usize,
+    pub files: Vec<String>,
+}
+
+/// Retained files, oldest first, so a scan reads in chronological order.
+pub fn retained_files(app_handle: &dyn AppContext) -> Result<Vec<PathBuf>, String> {
+    let current = logging::log_file_path(app_handle)?;
+    let mut files: Vec<PathBuf> = Vec::new();
+
+    for index in (1..=logging::ROTATED_FILES_KEPT).rev() {
+        let path = logging::rotated_log_file_path(app_handle, index)?;
+        if path.exists() {
+            files.push(path);
+        }
+    }
+    // A file left by a build older than the numbered rotation.
+    let legacy = current.with_file_name(logging::LEGACY_PREVIOUS_LOG_FILE_NAME);
+    if legacy.exists() {
+        files.push(legacy);
+    }
+    if current.exists() {
+        files.push(current);
+    }
+
+    Ok(files)
+}
+
+pub fn search(app_handle: &dyn AppContext, filter: &Filter) -> Result<SearchResult, String> {
+    let wanted_codes = resolve_codes(&filter.codes);
+    let mut result = SearchResult::default();
+
+    for path in retained_files(app_handle)? {
+        let name = path
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let Ok(file) = File::open(&path) else {
+            continue;
+        };
+        result.files.push(name.clone());
+
+        for (index, line) in BufReader::new(file).lines().enumerate() {
+            let Ok(line) = line else {
+                break;
+            };
+            if line.trim().is_empty() {
+                continue;
+            }
+            result.scanned += 1;
+
+            let Ok(raw) = serde_json::from_str::<Value>(&line) else {
+                result.unparsable += 1;
+                continue;
+            };
+            let entry = Entry::from_raw(name.clone(), index + 1, raw);
+            if !entry.matches(filter, &wanted_codes) {
+                continue;
+            }
+
+            result.entries.push(entry);
+            if let Some(limit) = filter.limit {
+                // Keep the tail: the newest records are the ones anyone wants.
+                if result.entries.len() > limit {
+                    result.entries.remove(0);
+                    result.dropped_by_limit += 1;
+                }
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+/// Resolve every asked-for code through the catalog so an alias finds the
+/// records written under the current name and vice versa.
+fn resolve_codes(codes: &[String]) -> Vec<String> {
+    let mut wanted = Vec::new();
+    for code in codes {
+        let code = code.trim();
+        if code.is_empty() {
+            continue;
+        }
+        match catalog::lookup(code) {
+            Some(entry) => {
+                wanted.push(entry.code.to_string());
+                wanted.extend(entry.aliases.iter().map(|alias| alias.to_string()));
+            }
+            // Unknown to the catalog: match it literally rather than returning
+            // nothing, so a typo is visibly empty instead of silently wrong.
+            None => wanted.push(code.to_string()),
+        }
+    }
+    wanted
+}
+
+impl Entry {
+    fn from_raw(file: String, line: usize, raw: Value) -> Self {
+        let schema_version = raw["schemaVersion"].as_u64().unwrap_or(1) as u32;
+        // Schema 1 called it `message` and had no code.
+        let msg = raw["msg"]
+            .as_str()
+            .or_else(|| raw["message"].as_str())
+            .unwrap_or_default()
+            .to_string();
+
+        Entry {
+            file,
+            line,
+            schema_version,
+            ts_ms: raw["tsMs"].as_u64().map(u128::from).unwrap_or_default(),
+            level: raw["level"]
+                .as_str()
+                .and_then(Level::parse)
+                .unwrap_or(Level::Info),
+            code: raw["code"].as_str().unwrap_or(LEGACY_CODE).to_string(),
+            source: raw["source"].as_str().unwrap_or_default().to_string(),
+            msg,
+            op_id: raw["opId"].as_str().map(|value| value.to_string()),
+            outcome: raw["outcome"].as_str().map(|value| value.to_string()),
+            dur_ms: raw["durMs"].as_u64(),
+            err_kind: raw["errKind"].as_str().map(|value| value.to_string()),
+            raw,
+        }
+    }
+
+    fn matches(&self, filter: &Filter, wanted_codes: &[String]) -> bool {
+        if !wanted_codes.is_empty() && !wanted_codes.contains(&self.code) {
+            return false;
+        }
+        if let Some(min_level) = filter.min_level {
+            if self.level < min_level {
+                return false;
+            }
+        }
+        if let Some(op_id) = &filter.op_id {
+            if self.op_id.as_deref() != Some(op_id.as_str()) {
+                return false;
+            }
+        }
+        if let Some(run_id) = &filter.run_id {
+            if self.raw["runId"].as_str() != Some(run_id.as_str()) {
+                return false;
+            }
+        }
+        if let Some(outcome) = filter.outcome {
+            if self.outcome.as_deref() != Some(outcome.as_str()) {
+                return false;
+            }
+        }
+        if let Some(source) = &filter.source {
+            if !prefix_matches(&self.source, source) {
+                return false;
+            }
+        }
+        if let Some(platform) = &filter.platform {
+            let recorded = self.raw["fields"]["platform"].as_str();
+            if recorded != Some(platform.as_str()) {
+                return false;
+            }
+        }
+        if let Some(since) = filter.since_ms {
+            if self.ts_ms < since {
+                return false;
+            }
+        }
+        if let Some(until) = filter.until_ms {
+            if self.ts_ms > until {
+                return false;
+            }
+        }
+        if let Some(needle) = &filter.contains {
+            let needle = needle.to_lowercase();
+            let haystack = format!("{} {}", self.msg, self.raw["fields"]).to_lowercase();
+            if !haystack.contains(&needle) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// One line for a human: the shape a terminal shows.
+    pub fn to_line(&self) -> String {
+        let mut line = format!(
+            "{} {:<5} {} {}",
+            format_ts(self.ts_ms),
+            self.level.as_str(),
+            self.code,
+            self.msg
+        );
+        if let Some(op_id) = &self.op_id {
+            line.push_str(&format!(" [{op_id}]"));
+        }
+        if let Some(outcome) = &self.outcome {
+            line.push_str(&format!(" {outcome}"));
+        }
+        if let Some(dur_ms) = self.dur_ms {
+            line.push_str(&format!(" {dur_ms}ms"));
+        }
+        if let Some(err_kind) = &self.err_kind {
+            line.push_str(&format!(" ({err_kind})"));
+        }
+        let fields = &self.raw["fields"];
+        if fields.as_object().is_some_and(|map| !map.is_empty()) {
+            line.push_str(&format!(" {fields}"));
+        }
+        line
+    }
+}
+
+/// `platform` matches `platform.steam` but not `platforms`.
+fn prefix_matches(source: &str, prefix: &str) -> bool {
+    source == prefix
+        || (source.starts_with(prefix) && source.as_bytes().get(prefix.len()) == Some(&b'.'))
+}
+
+/// UTC, second resolution, no dependency: enough to correlate with a user's
+/// "it broke around 14:30".
+pub fn format_ts(ts_ms: u128) -> String {
+    let secs = (ts_ms / 1000) as i64;
+    let days = secs.div_euclid(86_400);
+    let time = secs.rem_euclid(86_400);
+    let (year, month, day) = civil_from_days(days);
+    format!(
+        "{year:04}-{month:02}-{day:02}T{:02}:{:02}:{:02}Z",
+        time / 3600,
+        (time % 3600) / 60,
+        time % 60
+    )
+}
+
+/// Howard Hinnant's `civil_from_days`, the standard shift-to-March algorithm.
+fn civil_from_days(days: i64) -> (i64, u32, u32) {
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let year = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let month = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    (if month <= 2 { year + 1 } else { year }, month, day)
+}
+
+/// The catalog entry behind a code, for `diag explain`.
+pub fn explain(code: &str) -> Option<Value> {
+    let entry = catalog::lookup(code)?;
+    Some(entry.to_json())
+}
+
+/// Everything the log can currently say, for an agent that has never seen this
+/// codebase: the codes, and what is actually in the files right now.
+pub fn summary(app_handle: &dyn AppContext) -> Result<Value, String> {
+    let result = search(
+        app_handle,
+        &Filter {
+            ..Default::default()
+        },
+    )?;
+
+    let mut per_code: std::collections::BTreeMap<String, u64> = std::collections::BTreeMap::new();
+    let mut per_level: std::collections::BTreeMap<String, u64> = std::collections::BTreeMap::new();
+    let mut first_ts = u128::MAX;
+    let mut last_ts = 0u128;
+    for entry in &result.entries {
+        *per_code.entry(entry.code.clone()).or_default() += 1;
+        *per_level
+            .entry(entry.level.as_str().to_string())
+            .or_default() += 1;
+        first_ts = first_ts.min(entry.ts_ms);
+        last_ts = last_ts.max(entry.ts_ms);
+    }
+
+    Ok(json!({
+        "records": result.entries.len(),
+        "unparsable": result.unparsable,
+        "files": result.files,
+        "firstTsMs": if first_ts == u128::MAX { 0 } else { first_ts },
+        "lastTsMs": last_ts,
+        "perCode": per_code,
+        "perLevel": per_level,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diagnostics::test_support::TestCtx;
+    use crate::diagnostics::{catalog, event};
+
+    fn seed(ctx: &crate::context::AppCtx) {
+        event::event(&catalog::HEALTH_PATH_MISSING)
+            .field("path", "C:/steam/config")
+            .field("purpose", "steam config")
+            .field("platform", "steam")
+            .msg("Steam config folder is gone")
+            .emit(&**ctx);
+        event::event(&catalog::HEALTH_DISK_LOW)
+            .field("path", "C:/")
+            .field("availableBytes", 1_000u64)
+            .field("requiredBytes", 50_000u64)
+            .msg("Almost no free space")
+            .emit(&**ctx);
+    }
+
+    #[test]
+    fn filters_narrow_by_code_level_and_platform() {
+        let ctx = TestCtx::ctx("query-filters");
+        seed(&ctx);
+
+        let by_code = search(
+            &*ctx,
+            &Filter {
+                codes: vec!["health.path.missing".to_string()],
+                ..Default::default()
+            },
+        )
+        .expect("query");
+        assert_eq!(by_code.entries.len(), 1);
+        assert_eq!(by_code.entries[0].code, "health.path.missing");
+
+        let by_platform = search(
+            &*ctx,
+            &Filter {
+                platform: Some("steam".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("query");
+        assert_eq!(by_platform.entries.len(), 1);
+
+        let by_level = search(
+            &*ctx,
+            &Filter {
+                min_level: Some(Level::Error),
+                ..Default::default()
+            },
+        )
+        .expect("query");
+        assert_eq!(
+            by_level.entries.len(),
+            1,
+            "the missing path is an error, the low disk is only a warning"
+        );
+    }
+
+    #[test]
+    fn limit_keeps_the_newest_matches() {
+        let ctx = TestCtx::ctx("query-limit");
+        for index in 0..5 {
+            event::event(&catalog::HEALTH_PATH_MISSING)
+                .field("path", format!("C:/p{index}"))
+                .field("purpose", "test")
+                .emit(&*ctx);
+        }
+
+        let result = search(
+            &*ctx,
+            &Filter {
+                limit: Some(2),
+                ..Default::default()
+            },
+        )
+        .expect("query");
+        assert_eq!(result.entries.len(), 2);
+        assert_eq!(result.dropped_by_limit, 3);
+        assert_eq!(result.entries[1].raw["fields"]["path"], json!("C:/p4"));
+    }
+
+    // The legacy facade keeps writing schema-1 lines until the 38 existing call
+    // sites migrate. A reader that choked on them would be useless today.
+    #[test]
+    fn legacy_lines_are_readable_alongside_structured_ones() {
+        let ctx = TestCtx::ctx("query-legacy");
+        crate::logging::append_app_log(&*ctx, "warning", "steam.switch", "old style", Some("d"))
+            .expect("legacy write");
+        seed(&ctx);
+
+        let all = search(&*ctx, &Filter::default()).expect("query");
+        assert_eq!(all.entries.len(), 3);
+        let legacy = &all.entries[0];
+        assert_eq!(legacy.code, LEGACY_CODE);
+        assert_eq!(legacy.schema_version, 1);
+        assert_eq!(legacy.msg, "old style");
+        assert_eq!(legacy.level, Level::Warn);
+    }
+
+    #[test]
+    fn a_torn_last_line_is_counted_not_fatal() {
+        let ctx = TestCtx::ctx("query-torn");
+        seed(&ctx);
+        let path = crate::logging::log_file_path(&*ctx).expect("path");
+        let mut text = std::fs::read_to_string(&path).expect("read");
+        text.push_str("{\"schemaVersion\":2,\"code\":\"trunc");
+        std::fs::write(&path, text).expect("write");
+
+        let all = search(&*ctx, &Filter::default()).expect("query");
+        assert_eq!(all.entries.len(), 2);
+        assert_eq!(all.unparsable, 1);
+    }
+
+    #[test]
+    fn an_alias_finds_the_records_of_its_current_code() {
+        // Aliases only exist once a code is renamed; the resolution itself is
+        // what has to keep working, so exercise it through a known code.
+        let resolved = resolve_codes(&["health.path.missing".to_string()]);
+        assert!(resolved.contains(&"health.path.missing".to_string()));
+
+        let unknown = resolve_codes(&["not.a.code".to_string()]);
+        assert_eq!(unknown, vec!["not.a.code".to_string()]);
+    }
+
+    #[test]
+    fn source_prefix_stops_at_a_dot() {
+        assert!(prefix_matches("platform.steam", "platform"));
+        assert!(prefix_matches("platform", "platform"));
+        assert!(!prefix_matches("platforms.steam", "platform"));
+    }
+
+    #[test]
+    fn timestamps_render_as_utc() {
+        // 2024-02-29T12:34:56Z, a leap day, because that is where date maths
+        // usually breaks.
+        assert_eq!(format_ts(1_709_210_096_000), "2024-02-29T12:34:56Z");
+        assert_eq!(format_ts(0), "1970-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn explain_renders_the_catalog_entry() {
+        let entry = explain("health.disk.low").expect("known code");
+        assert_eq!(entry["code"], json!("health.disk.low"));
+        assert!(entry["action"].as_str().is_some_and(|a| !a.is_empty()));
+        assert!(explain("nope.not.here").is_none());
+    }
+}

--- a/crates/accshift-core/src/diagnostics/redact.rs
+++ b/crates/accshift-core/src/diagnostics/redact.rs
@@ -1,0 +1,723 @@
+//! Redaction applied to everything that reaches the log file.
+//!
+//! Moved out of `logging.rs` when the structured event layer landed: the
+//! legacy facade and the new event pipeline must scrub identically, and the
+//! new pipeline needs a recursive walk over `fields` that the string-only
+//! entry point could not express.
+//!
+//! The rule this module encodes: a log line never carries a token, a
+//! password, a cookie, a `.maFile` body, or a filesystem path that still
+//! contains the OS account name. What it cannot recognise by shape (Steam
+//! login names, persona names) is kept out at the call sites instead, which
+//! is why nothing here tries to guess free-form words.
+
+use serde_json::{Map, Value};
+
+/// Redact every string reachable from `value`, keys included.
+///
+/// Object keys are scrubbed too: a field can carry a map whose keys are
+/// user data (a path -> status map, for instance), and "recursively, without
+/// exception" has to mean exactly that.
+pub fn sanitize_value(value: &Value) -> Value {
+    match value {
+        Value::String(text) => Value::String(sanitize_log_text(text)),
+        Value::Array(items) => Value::Array(items.iter().map(sanitize_value).collect()),
+        Value::Object(map) => {
+            let mut out = Map::with_capacity(map.len());
+            for (key, item) in map {
+                out.insert(sanitize_log_text(key), sanitize_value(item));
+            }
+            Value::Object(out)
+        }
+        other => other.clone(),
+    }
+}
+
+pub fn sanitize_log_text(value: &str) -> String {
+    // Order matters: collapse emails first (they can contain digits/hex), then
+    // BattleTags, then UUID/PUUID. We deliberately do NOT try to redact Steam
+    // login names or persona names here: they're free-form words with no stable
+    // shape, so any heuristic broad enough to catch them would also redact
+    // ordinary log text (verbs, product names). Steam account identifiers stay
+    // out of the log layer and are handled at the call sites instead.
+    let mut sanitized = redact_email_like_tokens(value);
+    sanitized = redact_battletags(&sanitized);
+    sanitized = redact_uuid_like_tokens(&sanitized);
+
+    for (path, placeholder) in resolved_env_scrub_pairs() {
+        sanitized = replace_case_insensitive(&sanitized, &path, placeholder);
+    }
+
+    sanitized
+}
+
+/// Truncate `value` to `max_bytes`, never splitting a UTF-8 char.
+pub fn trim_text(value: &str, max_bytes: usize) -> String {
+    if value.len() <= max_bytes {
+        return value.to_string();
+    }
+
+    let mut end = max_bytes;
+    while !value.is_char_boundary(end) && end > 0 {
+        end -= 1;
+    }
+    value[..end].to_string()
+}
+
+fn replace_case_insensitive(haystack: &str, needle: &str, replacement: &str) -> String {
+    if needle.is_empty() {
+        return haystack.to_string();
+    }
+
+    // Unicode-aware case fold so accented usernames (C:\Users\Jérôme) match a
+    // differently-cased log path. `to_lowercase` can change byte length (and
+    // even char count) versus the original, so we can't index the original
+    // with offsets taken from the lowercased strings. Build a per-char map
+    // from each lowercased-byte offset back to the original byte offset, then
+    // copy spans out of the original.
+    let lower_haystack = haystack.to_lowercase();
+    let lower_needle = needle.to_lowercase();
+
+    // Nothing to replace: skip the offset map entirely. It costs 8 bytes per
+    // lowercased byte and the loop below would just copy `haystack` verbatim.
+    let Some(first_match) = lower_haystack.find(&lower_needle) else {
+        return haystack.to_string();
+    };
+
+    // For every byte offset in `lower_haystack` that starts a char, record the
+    // matching byte offset in `haystack`. `to_lowercase` maps each source char
+    // to one or more chars without reordering, so the char streams stay
+    // aligned: the i-th lowercased char comes from the i-th original char.
+    let mut orig_starts: Vec<usize> = Vec::with_capacity(lower_haystack.len() + 1);
+    {
+        let mut orig_chars = haystack.char_indices();
+        let mut pending_orig = orig_chars.next();
+        // How many lowercased chars the current original char expands into.
+        let mut remaining_in_current = 0usize;
+        let mut current_orig_offset = 0usize;
+        for (lower_offset, _) in lower_haystack.char_indices() {
+            while remaining_in_current == 0 {
+                if let Some((offset, ch)) = pending_orig.take() {
+                    current_orig_offset = offset;
+                    remaining_in_current = ch.to_lowercase().count();
+                    pending_orig = orig_chars.next();
+                } else {
+                    break;
+                }
+            }
+            // Pad the lookup table for byte offsets inside this lowercased char.
+            while orig_starts.len() <= lower_offset {
+                orig_starts.push(current_orig_offset);
+            }
+            remaining_in_current = remaining_in_current.saturating_sub(1);
+        }
+        // Terminal entry maps the end of the lowercased string to the end of
+        // the original, so a match that runs to the tail copies correctly.
+        while orig_starts.len() <= lower_haystack.len() {
+            orig_starts.push(haystack.len());
+        }
+    }
+
+    let mut out = String::with_capacity(haystack.len());
+    let mut search_start = 0usize;
+    let mut copied_orig = 0usize;
+    let mut relative_match = Some(first_match);
+
+    while let Some(relative_index) = relative_match {
+        let lower_start = search_start + relative_index;
+        let lower_end = lower_start + lower_needle.len();
+        let orig_start = orig_starts[lower_start];
+        let orig_end = orig_starts[lower_end];
+        out.push_str(&haystack[copied_orig..orig_start]);
+        out.push_str(replacement);
+        copied_orig = orig_end;
+        search_start = lower_end;
+        relative_match = lower_haystack[search_start..].find(&lower_needle);
+    }
+
+    out.push_str(&haystack[copied_orig..]);
+    out
+}
+
+fn redact_email_like_tokens(value: &str) -> String {
+    // No `@`, no email: skip the char vector and the rewind table.
+    if !value.contains('@') {
+        return value.to_string();
+    }
+
+    let chars: Vec<char> = value.chars().collect();
+    let mut out = String::with_capacity(value.len());
+    // `out_len_at[i]` is the byte length of `out` right before the char at
+    // index `i` was emitted. We push an entry every time we copy a char into
+    // `out`, so on an email match we can rewind `out` to where the local part
+    // began (`left`) and drop the already-written name.
+    let mut out_len_at: Vec<usize> = Vec::with_capacity(chars.len());
+    let mut cursor = 0usize;
+
+    while cursor < chars.len() {
+        if chars[cursor] != '@' {
+            out_len_at.push(out.len());
+            out.push(chars[cursor]);
+            cursor += 1;
+            continue;
+        }
+
+        let mut left = cursor;
+        while left > 0 {
+            let ch = chars[left - 1];
+            // `is_alphanumeric` (not `is_ascii_alphanumeric`) so IDN / SMTPUTF8
+            // locals (accented or non-Latin) match in full instead of stopping
+            // at the first non-ASCII char and leaking the rest.
+            if ch.is_alphanumeric() || matches!(ch, '.' | '_' | '%' | '+' | '-') {
+                left -= 1;
+            } else {
+                break;
+            }
+        }
+
+        let mut right = cursor + 1;
+        let mut saw_domain_dot = false;
+        while right < chars.len() {
+            let ch = chars[right];
+            // Same widening for the domain so an accented TLD/host is consumed
+            // and redacted rather than left in clear after the placeholder.
+            if ch.is_alphanumeric() || matches!(ch, '.' | '-') {
+                if ch == '.' {
+                    saw_domain_dot = true;
+                }
+                right += 1;
+            } else {
+                break;
+            }
+        }
+
+        let local_len = cursor.saturating_sub(left);
+        let domain_len = right.saturating_sub(cursor + 1);
+        if local_len == 0 || domain_len < 3 || !saw_domain_dot {
+            out_len_at.push(out.len());
+            out.push(chars[cursor]);
+            cursor += 1;
+            continue;
+        }
+
+        // The local part was already copied into `out` char-by-char in earlier
+        // iterations. Rewind to where it began so the whole local@domain span
+        // collapses to a single placeholder instead of leaking the name.
+        let local_start_len = out_len_at.get(left).copied().unwrap_or(out.len());
+        out.truncate(local_start_len);
+        out_len_at.truncate(left);
+
+        out.push_str("<email>");
+        // Keep `out_len_at` indexed by original char position so a later email
+        // in the same string still rewinds to the right spot: chars `left`
+        // through `right - 1` (local@domain) all collapse into the placeholder,
+        // each mapping to the byte where the placeholder started.
+        for _ in left..right {
+            out_len_at.push(local_start_len);
+        }
+        cursor = right;
+    }
+
+    out
+}
+
+/// Redact Battle.net BattleTags (`Name#1234`). The discriminator is the part
+/// that ties a tag to a specific account, so the whole `Name#1234` collapses
+/// to `<battletag>`. A BattleTag name is 3-12 chars (letters, digits, and on
+/// some locales accented letters) followed by `#` and 4-5 digits; we match
+/// that shape and ignore other `#` uses (e.g. `#define`, `channel #42`).
+fn redact_battletags(value: &str) -> String {
+    // A BattleTag always carries a `#`; without one the loop just copies.
+    if !value.contains('#') {
+        return value.to_string();
+    }
+
+    let chars: Vec<char> = value.chars().collect();
+    let mut out = String::with_capacity(value.len());
+    let mut i = 0usize;
+
+    while i < chars.len() {
+        if chars[i] != '#' {
+            out.push(chars[i]);
+            i += 1;
+            continue;
+        }
+
+        // Walk back over the name part.
+        let mut name_start = i;
+        while name_start > 0 {
+            let ch = chars[name_start - 1];
+            if ch.is_alphanumeric() {
+                name_start -= 1;
+            } else {
+                break;
+            }
+        }
+
+        // Walk forward over the digit discriminator.
+        let mut digits_end = i + 1;
+        while digits_end < chars.len() && chars[digits_end].is_ascii_digit() {
+            digits_end += 1;
+        }
+
+        let name_len = i - name_start;
+        let digit_len = digits_end - (i + 1);
+        // Blizzard names are 3-12 chars; the discriminator is 4-5 digits. A
+        // following alphanumeric run would mean we clipped a longer token, so
+        // bail and leave the `#` alone.
+        let trailing_ok = digits_end >= chars.len() || !chars[digits_end].is_alphanumeric();
+        if (3..=12).contains(&name_len) && (4..=5).contains(&digit_len) && trailing_ok {
+            // The name was already copied char-by-char; drop it before the tag.
+            for _ in 0..name_len {
+                out.pop();
+            }
+            out.push_str("<battletag>");
+            i = digits_end;
+        } else {
+            out.push(chars[i]);
+            i += 1;
+        }
+    }
+
+    out
+}
+
+/// Redact UUID / Riot PUUID tokens: canonical 8-4-4-4-12 hex with dashes, and
+/// bare 32-hex strings (PUUIDs are often logged dashless). Word boundaries are
+/// approximated by requiring the surrounding chars to be non-hex / non-dash so
+/// we don't clip a longer hex blob (hashes, keys) mid-stream.
+fn redact_uuid_like_tokens(value: &str) -> String {
+    // Both forms need at least 8 consecutive hex digits (first dashed group is
+    // 8, the bare form is 32). ASCII hex digits are single bytes, so a byte
+    // scan is equivalent to a char scan and avoids the char vector.
+    let mut hex_run = 0usize;
+    let mut has_hex_run = false;
+    for byte in value.bytes() {
+        if byte.is_ascii_hexdigit() {
+            hex_run += 1;
+            if hex_run >= 8 {
+                has_hex_run = true;
+                break;
+            }
+        } else {
+            hex_run = 0;
+        }
+    }
+    if !has_hex_run {
+        return value.to_string();
+    }
+
+    let chars: Vec<char> = value.chars().collect();
+    let mut out = String::with_capacity(value.len());
+    let mut i = 0usize;
+
+    let is_hex = |c: char| c.is_ascii_hexdigit();
+    let is_boundary_char = |c: char| !(c.is_ascii_hexdigit() || c == '-');
+
+    while i < chars.len() {
+        // Only consider a token start at a boundary (start of string or after a
+        // non-hex, non-dash char).
+        let at_boundary = i == 0 || is_boundary_char(chars[i - 1]);
+        if !at_boundary || !is_hex(chars[i]) {
+            out.push(chars[i]);
+            i += 1;
+            continue;
+        }
+
+        // Canonical 8-4-4-4-12 dashed form.
+        if let Some(end) = match_dashed_uuid(&chars, i) {
+            let trailing_ok = end >= chars.len() || is_boundary_char(chars[end]);
+            if trailing_ok {
+                out.push_str("<uuid>");
+                i = end;
+                continue;
+            }
+        }
+
+        // Bare 32-hex form (dashless PUUID).
+        let mut run_end = i;
+        while run_end < chars.len() && is_hex(chars[run_end]) {
+            run_end += 1;
+        }
+        let run_len = run_end - i;
+        let trailing_ok = run_end >= chars.len() || is_boundary_char(chars[run_end]);
+        if run_len == 32 && trailing_ok {
+            out.push_str("<uuid>");
+            i = run_end;
+            continue;
+        }
+
+        out.push(chars[i]);
+        i += 1;
+    }
+
+    out
+}
+
+/// Match a canonical 8-4-4-4-12 hex UUID starting at char index `start`.
+/// Returns the exclusive end char index on success.
+fn match_dashed_uuid(chars: &[char], start: usize) -> Option<usize> {
+    const GROUPS: [usize; 5] = [8, 4, 4, 4, 12];
+    let mut i = start;
+    for (group_idx, &group_len) in GROUPS.iter().enumerate() {
+        for _ in 0..group_len {
+            if i >= chars.len() || !chars[i].is_ascii_hexdigit() {
+                return None;
+            }
+            i += 1;
+        }
+        if group_idx < GROUPS.len() - 1 {
+            if i >= chars.len() || chars[i] != '-' {
+                return None;
+            }
+            i += 1;
+        }
+    }
+    Some(i)
+}
+
+// Env vars whose values are user-identifying paths, with the placeholder that
+// replaces them. Order matters and is preserved by the resolver below:
+// USERPROFILE first, HOME before the XDG dirs.
+const ENV_SCRUB_KEYS: [(&str, &str); 10] = [
+    ("USERPROFILE", "%USERPROFILE%"),
+    ("OneDrive", "%ONEDRIVE%"),
+    ("APPDATA", "%APPDATA%"),
+    ("LOCALAPPDATA", "%LOCALAPPDATA%"),
+    ("PROGRAMDATA", "%PROGRAMDATA%"),
+    ("TEMP", "%TEMP%"),
+    ("TMP", "%TEMP%"),
+    // Linux/macOS: AppContext::app_data_dir()/app_local_data_dir() resolve
+    // under $HOME (and under XDG_DATA_HOME/XDG_CONFIG_HOME when those are
+    // set), which embeds the OS account name. Without these, paths logged
+    // from config.rs's save_config_unlocked (portable/local config paths)
+    // leak the username on every successful config save.
+    ("HOME", "%HOME%"),
+    ("XDG_DATA_HOME", "%XDG_DATA_HOME%"),
+    ("XDG_CONFIG_HOME", "%XDG_CONFIG_HOME%"),
+];
+
+fn resolve_env_scrub_pairs() -> Vec<(String, &'static str)> {
+    ENV_SCRUB_KEYS
+        .iter()
+        .filter_map(|(env_key, placeholder)| {
+            std::env::var(env_key).ok().map(|path| (path, *placeholder))
+        })
+        .collect()
+}
+
+// These values are fixed for the process lifetime, so resolve them once
+// instead of paying 10 env lookups per sanitized field (4 fields per record).
+#[cfg(not(test))]
+fn resolved_env_scrub_pairs() -> Vec<(String, &'static str)> {
+    static ENV_SCRUB_CACHE: std::sync::OnceLock<Vec<(String, &'static str)>> =
+        std::sync::OnceLock::new();
+    ENV_SCRUB_CACHE.get_or_init(resolve_env_scrub_pairs).clone()
+}
+
+// Tests mutate HOME / XDG_* at runtime, so they need a fresh read per call.
+#[cfg(test)]
+fn resolved_env_scrub_pairs() -> Vec<(String, &'static str)> {
+    resolve_env_scrub_pairs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // Serializes the tests that mutate process-global HOME / XDG_* env vars.
+    // sanitize_log_text reads them at call time, so two of these running
+    // concurrently under cargo's parallel runner would clobber each other's
+    // setup (one test's HOME/XDG leaking into the other's assertion).
+    static ENV_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn trim_text_shorter_than_max() {
+        assert_eq!(trim_text("hello", 10), "hello");
+    }
+
+    #[test]
+    fn trim_text_exact_max() {
+        assert_eq!(trim_text("hello", 5), "hello");
+    }
+
+    #[test]
+    fn trim_text_truncates_at_boundary() {
+        assert_eq!(trim_text("hello world", 5), "hello");
+    }
+
+    #[test]
+    fn trim_text_respects_utf8_boundary() {
+        // é is 2 bytes in UTF-8, max_bytes=3 should not split it
+        let result = trim_text("héllo", 2);
+        assert_eq!(result, "h");
+    }
+
+    #[test]
+    fn trim_text_empty_string() {
+        assert_eq!(trim_text("", 10), "");
+    }
+
+    #[test]
+    fn replace_case_insensitive_basic() {
+        assert_eq!(
+            replace_case_insensitive("Hello WORLD", "world", "earth"),
+            "Hello earth"
+        );
+    }
+
+    #[test]
+    fn replace_case_insensitive_multiple() {
+        assert_eq!(replace_case_insensitive("aAbBaA", "aa", "X"), "XbBX");
+    }
+
+    #[test]
+    fn replace_case_insensitive_empty_needle() {
+        assert_eq!(replace_case_insensitive("hello", "", "X"), "hello");
+    }
+
+    #[test]
+    fn replace_case_insensitive_no_match() {
+        assert_eq!(replace_case_insensitive("hello", "xyz", "X"), "hello");
+    }
+
+    #[test]
+    fn replace_case_insensitive_accented_username() {
+        // The log path lowercases the accented username differently than the
+        // env var; Unicode-aware folding must still match it.
+        assert_eq!(
+            replace_case_insensitive(
+                r"C:\Users\Jérôme\AppData",
+                r"C:\Users\JÉRÔME",
+                "%USERPROFILE%"
+            ),
+            r"%USERPROFILE%\AppData"
+        );
+    }
+
+    #[test]
+    fn replace_case_insensitive_accented_changes_length() {
+        // German ß lowercases to itself but uppercases to "SS": folding must
+        // not desync the offset map between lowercased and original.
+        assert_eq!(
+            replace_case_insensitive("straße end", "STRASSE", "X"),
+            "straße end"
+        );
+        assert_eq!(replace_case_insensitive("STRAßE x", "straße", "Y"), "Y x");
+    }
+
+    #[test]
+    fn redact_email_basic() {
+        // The whole local@domain collapses; the local part must not leak.
+        assert_eq!(redact_email_like_tokens("user@example.com"), "<email>");
+    }
+
+    #[test]
+    fn redact_email_drops_local_part_with_name() {
+        // Regression: previously left "jean.dupont<email>", leaking the name.
+        assert_eq!(
+            redact_email_like_tokens("jean.dupont@example.com"),
+            "<email>"
+        );
+    }
+
+    #[test]
+    fn redact_email_multiple() {
+        assert_eq!(
+            redact_email_like_tokens("a@b.co and c@d.com"),
+            "<email> and <email>"
+        );
+    }
+
+    #[test]
+    fn redact_email_no_email() {
+        assert_eq!(redact_email_like_tokens("hello world"), "hello world");
+    }
+
+    #[test]
+    fn redact_email_at_without_domain() {
+        assert_eq!(redact_email_like_tokens("just @ sign"), "just @ sign");
+    }
+
+    #[test]
+    fn redact_email_preserves_surrounding_text() {
+        assert_eq!(
+            redact_email_like_tokens("logged in as test@mail.com successfully"),
+            "logged in as <email> successfully"
+        );
+    }
+
+    #[test]
+    fn redact_email_accented_local_part() {
+        // Multibyte local part: the accented name must be dropped whole, not
+        // truncated at the first non-ASCII byte. The truncate-on-match rewinds
+        // `out` by recorded byte offsets, so the 2-byte `é` can't desync it.
+        assert_eq!(redact_email_like_tokens("jérôme@example.com"), "<email>");
+        assert_eq!(
+            redact_email_like_tokens("connecté en tant que jérôme@example.com ok"),
+            "connecté en tant que <email> ok"
+        );
+    }
+
+    #[test]
+    fn redact_email_accented_domain() {
+        // Non-ASCII tail in the domain must be consumed by the match instead of
+        // being left in clear after the placeholder.
+        assert_eq!(redact_email_like_tokens("john@domain.café"), "<email>");
+        assert_eq!(
+            redact_email_like_tokens("ping müller@firma.köln now"),
+            "ping <email> now"
+        );
+    }
+
+    #[test]
+    fn redact_battletag_basic() {
+        assert_eq!(
+            redact_battletags("playing as Hero#1234 now"),
+            "playing as <battletag> now"
+        );
+    }
+
+    #[test]
+    fn redact_battletag_five_digit_discriminator() {
+        assert_eq!(redact_battletags("Tag#12345"), "<battletag>");
+    }
+
+    #[test]
+    fn redact_battletag_ignores_non_tag_hashes() {
+        // Too few discriminator digits, or a name that's too short.
+        assert_eq!(redact_battletags("see channel #42"), "see channel #42");
+        assert_eq!(redact_battletags("#define FOO 1"), "#define FOO 1");
+        assert_eq!(redact_battletags("ab#1234"), "ab#1234");
+    }
+
+    #[test]
+    fn redact_uuid_dashed() {
+        assert_eq!(
+            redact_uuid_like_tokens("id=550e8400-e29b-41d4-a716-446655440000 done"),
+            "id=<uuid> done"
+        );
+    }
+
+    #[test]
+    fn redact_uuid_bare_32_hex() {
+        // Dashless PUUID form.
+        assert_eq!(
+            redact_uuid_like_tokens("puuid 550e8400e29b41d4a716446655440000 ok"),
+            "puuid <uuid> ok"
+        );
+    }
+
+    #[test]
+    fn redact_uuid_ignores_short_or_long_hex() {
+        // Not 32 hex chars, not a dashed UUID: left alone.
+        assert_eq!(redact_uuid_like_tokens("deadbeef"), "deadbeef");
+        assert_eq!(
+            redact_uuid_like_tokens("abc123def4567890abc123def4567890ab"),
+            "abc123def4567890abc123def4567890ab"
+        );
+    }
+
+    #[test]
+    fn sanitize_log_text_combines_redactions() {
+        let input = "user jean@mail.com Hero#1234 550e8400-e29b-41d4-a716-446655440000";
+        assert_eq!(sanitize_log_text(input), "user <email> <battletag> <uuid>");
+    }
+
+    // Regression: sanitize_log_text's env-var scrub list used to only cover
+    // Windows vars (USERPROFILE, APPDATA, ...), so a Linux/macOS path under
+    // $HOME (e.g. the portable/local config paths logged by
+    // config.rs's save_config_unlocked) leaked the OS account name into
+    // app.log, where it could later be exposed if the user shared the file,
+    // on every save.
+    #[test]
+    fn sanitize_log_text_scrubs_home_dir_path() {
+        let _env = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        let previous = std::env::var("HOME").ok();
+        std::env::set_var("HOME", "/home/alice");
+
+        let result = sanitize_log_text(
+            "Saved split app config /home/alice/.local/share/accshift/state/portable-config.json",
+        );
+
+        match previous {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
+
+        assert_eq!(
+            result,
+            "Saved split app config %HOME%/.local/share/accshift/state/portable-config.json"
+        );
+    }
+
+    #[test]
+    fn sanitize_log_text_scrubs_xdg_dirs() {
+        let _env = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        // Also pin HOME to a value that shares no substring with the XDG
+        // paths below: on a machine where HOME happens to already be set
+        // (e.g. Git Bash on Windows), the HOME substitution runs first in
+        // sanitize_log_text's loop and would otherwise eat part of the XDG
+        // path before the XDG substitution gets a chance to match it.
+        let previous_home = std::env::var("HOME").ok();
+        let previous_data = std::env::var("XDG_DATA_HOME").ok();
+        let previous_config = std::env::var("XDG_CONFIG_HOME").ok();
+        std::env::set_var("HOME", "/home/unrelated-sentinel");
+        std::env::set_var("XDG_DATA_HOME", "/home/alice/.local/share");
+        std::env::set_var("XDG_CONFIG_HOME", "/home/alice/.config");
+
+        let result = sanitize_log_text(
+            "paths /home/alice/.local/share/accshift and /home/alice/.config/accshift",
+        );
+
+        match previous_home {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
+        match previous_data {
+            Some(value) => std::env::set_var("XDG_DATA_HOME", value),
+            None => std::env::remove_var("XDG_DATA_HOME"),
+        }
+        match previous_config {
+            Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
+
+        assert_eq!(
+            result,
+            "paths %XDG_DATA_HOME%/accshift and %XDG_CONFIG_HOME%/accshift"
+        );
+    }
+
+    // The whole point of the structured layer: `fields` is data, not prose,
+    // so nothing in it may escape the scrub the message string already got.
+    #[test]
+    fn sanitize_value_walks_nested_structures() {
+        let input = json!({
+            "account": "player@mail.com",
+            "tags": ["Hero#1234", "plain"],
+            "nested": { "puuid": "550e8400e29b41d4a716446655440000" },
+            "count": 3,
+            "ok": true,
+        });
+
+        let output = sanitize_value(&input);
+
+        assert_eq!(output["account"], json!("<email>"));
+        assert_eq!(output["tags"], json!(["<battletag>", "plain"]));
+        assert_eq!(output["nested"]["puuid"], json!("<uuid>"));
+        // Non-string leaves pass through untouched.
+        assert_eq!(output["count"], json!(3));
+        assert_eq!(output["ok"], json!(true));
+    }
+
+    // A map keyed by user data (path -> status, tag -> count) would otherwise
+    // leak through the key half of every entry.
+    #[test]
+    fn sanitize_value_scrubs_object_keys() {
+        let input = json!({ "Hero#1234": "ok", "user@mail.com": 1 });
+        let output = sanitize_value(&input);
+        assert_eq!(output, json!({ "<battletag>": "ok", "<email>": 1 }));
+    }
+}

--- a/crates/accshift-core/src/diagnostics/schema.rs
+++ b/crates/accshift-core/src/diagnostics/schema.rs
@@ -1,0 +1,207 @@
+//! The record schema, published as JSON.
+//!
+//! `docs/log-schema.json` and `docs/log-catalog.json` are generated from the
+//! same declarations the writer uses, and a test fails when they drift. A
+//! reader that has never seen this codebase can therefore trust them, which is
+//! the whole point of publishing them.
+
+use super::event::{Level, Outcome, SCHEMA_VERSION};
+use super::{catalog, event};
+use serde_json::{json, Value};
+use std::path::Path;
+
+pub const SCHEMA_FILE_NAME: &str = "log-schema.json";
+pub const CATALOG_FILE_NAME: &str = "log-catalog.json";
+
+/// JSON Schema (draft 2020-12) of one line of `app.log`.
+pub fn record_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://accshift.app/schemas/log-record.json",
+        "title": "accshift log record",
+        "description": "One line of app.log. The file is JSONL: one record per line, never pretty-printed.",
+        "type": "object",
+        "required": ["schemaVersion", "tsMs", "level", "code", "source", "runId", "fields"],
+        "additionalProperties": false,
+        "properties": {
+            "schemaVersion": {
+                "const": SCHEMA_VERSION,
+                "description": "Version of this record shape. Version 1 is the legacy line: {tsMs, level, source, message, details}, no code and no fields.",
+            },
+            "tsMs": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Unix milliseconds when the record was built.",
+            },
+            "level": {
+                "enum": Level::ALL.iter().map(|level| level.as_str()).collect::<Vec<_>>(),
+                "description": "Severity. May be raised above the catalog default by the call site.",
+            },
+            "code": {
+                "type": "string",
+                "description": "Catalog code. Every possible value is in log-catalog.json.",
+            },
+            "source": {
+                "type": "string",
+                "description": "Dotted module the record came from, e.g. platform.steam. Drives the per-module level filter.",
+            },
+            "msg": {
+                "type": "string",
+                "description": "Human sentence. Never parse this: parse fields.",
+            },
+            "fields": {
+                "type": "object",
+                "description": "Typed payload declared by the code. `_defects` lists validation failures, `_truncatedFields` counts values dropped or marked to fit the size budget.",
+            },
+            "runId": {
+                "type": "string",
+                "pattern": "^run-[0-9a-f]{12}$",
+                "description": "One per process launch. Scopes everything to a single session.",
+            },
+            "opId": {
+                "type": "string",
+                "pattern": "^op-[0-9a-f]{12}$",
+                "description": "One per user-visible operation. Shared by every record of that attempt.",
+            },
+            "durMs": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Duration of the operation, on its closing record.",
+            },
+            "outcome": {
+                "enum": [Outcome::Success.as_str(), Outcome::Failure.as_str(), Outcome::Cancelled.as_str()],
+                "description": "How an operation ended. Absent on records that do not close one.",
+            },
+            "errKind": {
+                "type": "string",
+                "description": "Machine-readable error family, so failures group without parsing msg.",
+            },
+        },
+    })
+}
+
+/// Everything a reader needs, in one value: the schema, the catalog, and the
+/// retention policy that bounds what is still on disk.
+pub fn to_json() -> Value {
+    json!({
+        "schemaVersion": SCHEMA_VERSION,
+        "record": record_schema(),
+        "catalog": catalog::to_json(),
+        "retention": crate::logging::retention_policy(),
+    })
+}
+
+fn render(value: &Value) -> String {
+    let mut text = serde_json::to_string_pretty(value).unwrap_or_default();
+    text.push('\n');
+    text
+}
+
+/// Write the two generated files into `docs/`. Used by the test that keeps
+/// them honest, and by the CLI so a contributor can regenerate them.
+pub fn write_docs(docs_dir: &Path) -> Result<Vec<String>, String> {
+    let mut written = Vec::new();
+    for (name, value) in [
+        (SCHEMA_FILE_NAME, record_schema()),
+        (CATALOG_FILE_NAME, catalog::to_json()),
+    ] {
+        let path = docs_dir.join(name);
+        std::fs::write(&path, render(&value))
+            .map_err(|reason| format!("Could not write {}: {reason}", path.display()))?;
+        written.push(name.to_string());
+    }
+    Ok(written)
+}
+
+/// A single record, described for whoever has to read one. Kept next to the
+/// schema so the example cannot drift from the shape it illustrates.
+pub fn example_record() -> String {
+    event::event(&catalog::OP_FINISHED)
+        .source("platform.steam")
+        .msg("Steam refused to exit")
+        .field("op", "platform.switch")
+        .field("platform", "steam")
+        .field("steps", 4u64)
+        .op("op-91c2ab77de10")
+        .dur_ms(4_211)
+        .outcome(Outcome::Failure)
+        .err_kind("client_running")
+        .render()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn docs_dir() -> std::path::PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("docs")
+    }
+
+    /// The generated files are committed, so a code change that forgets them
+    /// leaves the documentation lying. This is the test that refuses.
+    ///
+    /// `ACCSHIFT_UPDATE_DOCS=1 cargo test -p accshift-core` regenerates them
+    /// instead of failing, which is the same trick as a snapshot test.
+    ///
+    /// The comparison is on the parsed value, not on the bytes: the repository
+    /// formatter owns the layout of every JSON file and disagrees with
+    /// `serde_json` about where short arrays wrap. Comparing text would make
+    /// the two tools undo each other forever, and layout is not what this test
+    /// is about.
+    #[test]
+    fn generated_docs_are_up_to_date() {
+        if std::env::var("ACCSHIFT_UPDATE_DOCS").as_deref() == Ok("1") {
+            write_docs(&docs_dir()).expect("regenerate the published schema");
+            return;
+        }
+
+        for (name, value) in [
+            (SCHEMA_FILE_NAME, record_schema()),
+            (CATALOG_FILE_NAME, catalog::to_json()),
+        ] {
+            let path = docs_dir().join(name);
+            let on_disk: Value = std::fs::read_to_string(&path)
+                .ok()
+                .and_then(|text| serde_json::from_str(&text).ok())
+                .unwrap_or(Value::Null);
+            assert_eq!(
+                on_disk, value,
+                "{name} is stale. Regenerate it with `accshift diag schema --write`, \
+                 or `ACCSHIFT_UPDATE_DOCS=1 cargo test -p accshift-core`.",
+            );
+        }
+    }
+
+    #[test]
+    fn the_schema_accepts_the_columns_the_writer_produces() {
+        let record: Value = serde_json::from_str(&example_record()).expect("valid JSON");
+        let schema = record_schema();
+        let properties = schema["properties"].as_object().expect("properties");
+
+        for key in record.as_object().expect("object").keys() {
+            assert!(
+                properties.contains_key(key),
+                "the writer emits `{key}` and the schema does not declare it"
+            );
+        }
+        for required in schema["required"].as_array().expect("required") {
+            let name = required.as_str().expect("name");
+            assert!(
+                record.get(name).is_some(),
+                "the schema demands `{name}` and the example does not have it"
+            );
+        }
+    }
+
+    #[test]
+    fn the_bundle_of_everything_carries_the_retention_policy() {
+        let everything = to_json();
+        assert!(everything["retention"]["diskBudgetBytes"]
+            .as_u64()
+            .is_some_and(|budget| budget > 0));
+        assert_eq!(everything["schemaVersion"], json!(SCHEMA_VERSION));
+    }
+}

--- a/crates/accshift-core/src/lib.rs
+++ b/crates/accshift-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod context;
+pub mod diagnostics;
 pub mod error;
 pub mod fs_utils;
 pub mod lock;

--- a/crates/accshift-core/src/logging.rs
+++ b/crates/accshift-core/src/logging.rs
@@ -27,6 +27,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 const LOG_FILE_NAME: &str = "app.log";
 const LOG_LOCK_FILE_NAME: &str = "app.log.lock";
+/// Live file, taken aside before the numbered chain is touched.
+const ROTATING_LOG_FILE_NAME: &str = "app.log.rotating";
 
 /// Written by builds that rotated on session start only. Migrated into the
 /// numbered chain the first time this code rotates, and still readable in the
@@ -229,6 +231,23 @@ fn rotated_path(current: &Path, index: u32) -> PathBuf {
     current.with_file_name(format!("app.{index}.log"))
 }
 
+fn rotating_path(current: &Path) -> PathBuf {
+    current.with_file_name(ROTATING_LOG_FILE_NAME)
+}
+
+/// Drop the oldest slot, then shift `app.1.log` through `app.3.log` up by one.
+/// The live file is already aside: this must not run until that rename worked.
+fn shift_rotated_files(current: &Path) {
+    let oldest = rotated_path(current, ROTATED_FILES_KEPT);
+    let _ = fs::remove_file(&oldest);
+    for index in (1..ROTATED_FILES_KEPT).rev() {
+        let from = rotated_path(current, index);
+        if from.exists() {
+            let _ = fs::rename(&from, rotated_path(current, index + 1));
+        }
+    }
+}
+
 pub fn log_lock_file_path(app_handle: &dyn AppContext) -> Result<PathBuf, String> {
     Ok(log_file_path(app_handle)?.with_file_name(LOG_LOCK_FILE_NAME))
 }
@@ -245,20 +264,38 @@ pub fn log_lock_file_path(app_handle: &dyn AppContext) -> Result<PathBuf, String
 fn rotate(path: &Path, sink: &mut Sink, reason: &str) -> Result<(), String> {
     let rotated_bytes = sink.size;
 
-    // Windows refuses to rename an open file.
+    // Windows refuses to rename an open file. Close our handle first; another
+    // process can still hold `app.log` without FILE_SHARE_DELETE (the GUI
+    // append handle, or a reader that used File::open).
     sink.file = None;
 
-    let oldest = rotated_path(path, ROTATED_FILES_KEPT);
-    let _ = fs::remove_file(&oldest);
-    for index in (1..ROTATED_FILES_KEPT).rev() {
-        let from = rotated_path(path, index);
-        if from.exists() {
-            let _ = fs::rename(&from, rotated_path(path, index + 1));
-        }
+    if !path.exists() {
+        sink.open_if_needed(path)?;
+        return Ok(());
     }
-    if path.exists() {
-        fs::rename(path, rotated_path(path, 1))
-            .map_err(|error| format!("Could not rotate log file {}: {error}", path.display()))?;
+
+    let staging = rotating_path(path);
+    // A leftover file from a crash would block the next rename on Windows.
+    // A directory left here is a test (or a user) blocking rotation on purpose.
+    if staging.is_file() {
+        let _ = fs::remove_file(&staging);
+    }
+    if fs::rename(path, &staging).is_err() {
+        // Live file did not move. Keep appending; do not touch the chain.
+        sink.open_if_needed(path)?;
+        return Ok(());
+    }
+
+    shift_rotated_files(path);
+    if let Err(error) = fs::rename(&staging, rotated_path(path, 1)) {
+        // Put the live file back. The chain has already moved; losing that
+        // slot is better than deleting the records we just took aside.
+        let _ = fs::rename(&staging, path);
+        sink.open_if_needed(path)?;
+        return Err(format!(
+            "Could not rotate log file {}: {error}",
+            path.display()
+        ));
     }
 
     // Every writer of this file has to learn that its open handle is stale.
@@ -541,6 +578,10 @@ mod tests {
             !rotated_path(&path, ROTATED_FILES_KEPT + 1).exists(),
             "nothing may survive past the last kept slot"
         );
+        assert!(
+            !rotating_path(&path).exists(),
+            "the staging name must not survive a finished rotation"
+        );
     }
 
     #[test]
@@ -581,6 +622,56 @@ mod tests {
                 .any(|record| record["code"] == serde_json::json!("app.session.started")),
             "a session must be able to say when it started"
         );
+    }
+
+    // Staging rename fails (a non-empty directory occupies the temp name, the
+    // same outcome as another process holding app.log without FILE_SHARE_DELETE
+    // on Windows). The oldest slot must still be there, and writes must work.
+    #[test]
+    fn a_failed_rotation_does_not_delete_the_chain() {
+        let ctx = TestCtx::ctx("logging-rotate-fail");
+        let path = log_file_path(&*ctx).expect("path");
+        ensure_parent(&path).expect("parent");
+
+        append_app_log(&*ctx, "info", "test", "active", None).expect("seed live");
+        for index in 1..=ROTATED_FILES_KEPT {
+            fs::write(
+                rotated_path(&path, index),
+                format!("{{\"tsMs\":{index},\"message\":\"slot{index}\"}}\n"),
+            )
+            .expect("seed slot");
+        }
+
+        let staging = rotating_path(&path);
+        fs::create_dir_all(&staging).expect("staging dir");
+        fs::write(staging.join("blocker"), b"x").expect("block rename");
+
+        begin_log_session(&*ctx).expect("session must keep writing");
+
+        let oldest = rotated_path(&path, ROTATED_FILES_KEPT);
+        assert!(
+            oldest.exists(),
+            "a failed live rename must not drop the oldest file"
+        );
+        assert_eq!(
+            fs::read_to_string(&oldest).expect("read oldest"),
+            format!("{{\"tsMs\":{ROTATED_FILES_KEPT},\"message\":\"slot{ROTATED_FILES_KEPT}\"}}\n")
+        );
+        let newest_rotated = fs::read_to_string(rotated_path(&path, 1)).expect("read .1");
+        assert!(
+            newest_rotated.contains("slot1"),
+            "the numbered chain must stay where it was: {newest_rotated}"
+        );
+
+        append_app_log(&*ctx, "info", "test", "after-failed-rotate", None)
+            .expect("app.log must still accept writes");
+        let current = fs::read_to_string(&path).expect("read live");
+        assert!(
+            current.contains("after-failed-rotate"),
+            "writes after a failed rotate land in the live file: {current}"
+        );
+
+        let _ = fs::remove_dir_all(&staging);
     }
 
     // An empty file is not worth a rotation slot: the CLI runs often and would

--- a/crates/accshift-core/src/logging.rs
+++ b/crates/accshift-core/src/logging.rs
@@ -1,495 +1,206 @@
+//! The log file: one sink, one lock, a bounded amount of disk.
+//!
+//! This module owns the plumbing and nothing else. What a record contains, and
+//! how it is read back, lives in [`crate::diagnostics`].
+//!
+//! Two processes write this file. The GUI and the CLI are separate binaries
+//! pointing at the same `app.log`, so every mutation (append, rotate, purge)
+//! happens under an OS advisory lock on an `app.log.lock` sidecar, and the
+//! sidecar also carries a rotation generation counter. A process that finds a
+//! generation newer than its own knows the file it holds open has been renamed
+//! out from under it and reopens instead of appending into a rotated file.
+//!
+//! Retention is announced rather than implicit: at most
+//! [`MAX_LOG_FILE_BYTES`] per file, [`ROTATED_FILES_KEPT`] rotated files kept
+//! beside the active one, nothing older than [`RETENTION_DAYS`] days. That is
+//! [`disk_budget_bytes`], and `docs/logging.md` states the same number.
+
 use crate::context::AppContext;
+use crate::diagnostics::redact::{sanitize_log_text, trim_text};
 use fs4::FileExt;
+use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const LOG_FILE_NAME: &str = "app.log";
-const PREVIOUS_LOG_FILE_NAME: &str = "app.previous.log";
 const LOG_LOCK_FILE_NAME: &str = "app.log.lock";
+
+/// Written by builds that rotated on session start only. Migrated into the
+/// numbered chain the first time this code rotates, and still readable in the
+/// meantime.
+pub const LEGACY_PREVIOUS_LOG_FILE_NAME: &str = "app.previous.log";
+
+/// Size at which the active file is rotated.
+pub const MAX_LOG_FILE_BYTES: u64 = 2 * 1024 * 1024;
+/// Rotated files kept beside the active one: `app.1.log` to `app.4.log`.
+pub const ROTATED_FILES_KEPT: u32 = 4;
+/// Nothing rotated survives longer than this, however small the chain is.
+pub const RETENTION_DAYS: u64 = 14;
+
 const MAX_MESSAGE_BYTES: usize = 512;
 const MAX_DETAILS_BYTES: usize = 16_384;
 
-// Open append handle kept for the whole session. Opening the file on every
-// record costs a few syscalls per log line (plus antivirus re-scans on
-// Windows); the mutex also serializes writers, so it doubles as the old
-// LOG_LOCK.
-static LOG_SINK: OnceLock<Mutex<Option<File>>> = OnceLock::new();
-
-fn log_sink() -> &'static Mutex<Option<File>> {
-    LOG_SINK.get_or_init(|| Mutex::new(None))
+/// Worst case on disk, the number `docs/logging.md` announces to the user.
+pub const fn disk_budget_bytes() -> u64 {
+    MAX_LOG_FILE_BYTES * (ROTATED_FILES_KEPT as u64 + 1)
 }
 
-// Sidecar file used purely as a cross-process advisory lock. The in-process
-// `LOG_SINK` mutex only serializes threads within one binary; the GUI and CLI
-// are separate processes that append the same app.log, so a rotation rename in
-// one can race an append in the other. An OS advisory lock on this sidecar
-// serializes the two processes. Kept open for the whole session to avoid
-// re-opening it on every write.
-static LOG_LOCK_FILE: OnceLock<Mutex<Option<File>>> = OnceLock::new();
-
-fn log_lock_file_handle() -> &'static Mutex<Option<File>> {
-    LOG_LOCK_FILE.get_or_init(|| Mutex::new(None))
+/// Retention as data, for the diagnostic report and the docs test.
+pub fn retention_policy() -> serde_json::Value {
+    serde_json::json!({
+        "maxFileBytes": MAX_LOG_FILE_BYTES,
+        "rotatedFilesKept": ROTATED_FILES_KEPT,
+        "retentionDays": RETENTION_DAYS,
+        "diskBudgetBytes": disk_budget_bytes(),
+    })
 }
 
-/// Holds the OS-level exclusive lock on the log sidecar for as long as it is
-/// alive; releases on drop. Acquisition is best-effort: if the sidecar can't be
-/// opened or locked we proceed without it rather than dropping log records,
-/// since logging must not become a hard failure path. `Some` means the lock is
-/// held on the canonical cached handle, whose mutex stays held for the
-/// guard's lifetime so the unlock targets that same handle.
-struct CrossProcessLogGuard {
-    guard: Option<std::sync::MutexGuard<'static, Option<File>>>,
+/// Everything one log file needs, kept open for the session.
+///
+/// Opening the file per record costs syscalls and, on Windows, an antivirus
+/// re-scan each time. The map is keyed by path because a process can hold more
+/// than one context (the test suite does; the app does not).
+#[derive(Default)]
+struct Sink {
+    file: Option<File>,
+    lock: Option<File>,
+    /// Rotation generation this process last saw. Compared against the sidecar
+    /// on every acquire.
+    generation: u64,
+    /// Bytes in the open file, tracked incrementally so a write does not need
+    /// a stat.
+    size: u64,
 }
 
-impl CrossProcessLogGuard {
-    fn acquire(app_handle: &dyn AppContext) -> Self {
-        let mut guard = log_lock_file_handle()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+fn sinks() -> &'static Mutex<HashMap<PathBuf, Sink>> {
+    static SINKS: OnceLock<Mutex<HashMap<PathBuf, Sink>>> = OnceLock::new();
+    SINKS.get_or_init(|| Mutex::new(HashMap::new()))
+}
 
-        if guard.is_none() {
-            if let Ok(lock_path) = log_lock_file_path(app_handle) {
-                if ensure_log_parent(&lock_path).is_ok() {
-                    if let Ok(file) = OpenOptions::new()
-                        .create(true)
-                        .read(true)
-                        .write(true)
-                        .truncate(false)
-                        .open(&lock_path)
-                    {
-                        *guard = Some(file);
-                    }
-                }
-            }
+impl Sink {
+    fn ensure_lock_file(&mut self, path: &Path) {
+        if self.lock.is_some() {
+            return;
         }
+        let lock_path = path.with_file_name(LOG_LOCK_FILE_NAME);
+        if ensure_parent(&lock_path).is_err() {
+            return;
+        }
+        self.lock = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&lock_path)
+            .ok();
+    }
 
-        // Blocking acquire on the canonical handle, taken while still holding
-        // the in-process mutex. That wait can't stall a sibling thread: every
-        // acquire site takes the `log_sink` mutex first and keeps it for the
-        // guard's lifetime (lock order log_sink -> LOG_LOCK_FILE everywhere),
-        // so siblings are already serialized before reaching this point.
-        // Best-effort: if the sidecar can't be opened or locked we drop the
-        // mutex and proceed unlocked rather than failing the log write, and
-        // the open is retried on the next call.
-        let locked = match guard.as_ref() {
-            Some(file) => FileExt::lock(file).is_ok(),
-            None => false,
+    /// Generation stored in the sidecar, or 0 when there is none yet.
+    fn stored_generation(&self) -> u64 {
+        let Some(lock) = self.lock.as_ref() else {
+            return self.generation;
         };
-
-        CrossProcessLogGuard {
-            guard: locked.then_some(guard),
+        let mut buffer = [0u8; 8];
+        let mut handle = lock;
+        if handle.seek(SeekFrom::Start(0)).is_err() {
+            return self.generation;
+        }
+        match handle.read_exact(&mut buffer) {
+            Ok(()) => u64::from_le_bytes(buffer),
+            // No counter yet: a fresh sidecar, or one written by an older build.
+            Err(_) => 0,
         }
     }
-}
 
-impl Drop for CrossProcessLogGuard {
-    fn drop(&mut self) {
-        if let Some(guard) = self.guard.take() {
-            if let Some(file) = guard.as_ref() {
-                let _ = FileExt::unlock(file);
-            }
+    fn store_generation(&mut self, generation: u64) {
+        self.generation = generation;
+        let Some(lock) = self.lock.as_ref() else {
+            return;
+        };
+        let mut handle = lock;
+        if handle.seek(SeekFrom::Start(0)).is_ok() {
+            let _ = handle.write_all(&generation.to_le_bytes());
+            let _ = handle.flush();
         }
     }
-}
 
-fn open_append_handle(path: &Path) -> Result<File, String> {
-    OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .map_err(|reason| format!("Could not open log file {}: {reason}", path.display()))
-}
-
-fn trim_text(value: &str, max_bytes: usize) -> String {
-    if value.len() <= max_bytes {
-        return value.to_string();
+    fn open_if_needed(&mut self, path: &Path) -> Result<(), String> {
+        if self.file.is_some() {
+            return Ok(());
+        }
+        ensure_parent(path)?;
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .map_err(|reason| format!("Could not open log file {}: {reason}", path.display()))?;
+        self.size = file.metadata().map(|meta| meta.len()).unwrap_or(0);
+        self.file = Some(file);
+        Ok(())
     }
 
-    let mut end = max_bytes;
-    while !value.is_char_boundary(end) && end > 0 {
-        end -= 1;
+    fn append(&mut self, path: &Path, line: &str) -> Result<(), String> {
+        let Some(file) = self.file.as_mut() else {
+            return Err("log sink is not open".to_string());
+        };
+        if let Err(reason) = writeln!(file, "{line}") {
+            // Drop the dead handle so the next record reopens the file.
+            self.file = None;
+            return Err(format!(
+                "Could not write log file {}: {reason}",
+                path.display()
+            ));
+        }
+        self.size += line.len() as u64 + 1;
+        Ok(())
     }
-    value[..end].to_string()
 }
 
-fn replace_case_insensitive(haystack: &str, needle: &str, replacement: &str) -> String {
-    if needle.is_empty() {
-        return haystack.to_string();
-    }
+/// Run `job` with the sink for this context open and locked.
+///
+/// Lock order is always in-process mutex, then OS lock, and `job` must never
+/// re-enter this function: the mutex is not reentrant, and the record types
+/// that would want to (a rotation notice) are written by `job` itself.
+fn with_sink<T>(
+    app_handle: &dyn AppContext,
+    job: impl FnOnce(&Path, &mut Sink) -> Result<T, String>,
+) -> Result<T, String> {
+    let path = log_file_path(app_handle)?;
+    let mut map = sinks().lock().unwrap_or_else(|error| error.into_inner());
+    let sink = map.entry(path.clone()).or_default();
 
-    // Unicode-aware case fold so accented usernames (C:\Users\Jérôme) match a
-    // differently-cased log path. `to_lowercase` can change byte length (and
-    // even char count) versus the original, so we can't index the original
-    // with offsets taken from the lowercased strings. Build a per-char map
-    // from each lowercased-byte offset back to the original byte offset, then
-    // copy spans out of the original.
-    let lower_haystack = haystack.to_lowercase();
-    let lower_needle = needle.to_lowercase();
-
-    // Nothing to replace: skip the offset map entirely. It costs 8 bytes per
-    // lowercased byte and the loop below would just copy `haystack` verbatim.
-    let Some(first_match) = lower_haystack.find(&lower_needle) else {
-        return haystack.to_string();
+    sink.ensure_lock_file(&path);
+    // Best effort, as before: a sidecar that cannot be opened or locked must
+    // not turn logging into a failure path. The window it leaves is a rotation
+    // racing an append between two processes, which costs at most the records
+    // written in that instant.
+    let locked = match sink.lock.as_ref() {
+        Some(lock) => FileExt::lock(lock).is_ok(),
+        None => false,
     };
 
-    // For every byte offset in `lower_haystack` that starts a char, record the
-    // matching byte offset in `haystack`. `to_lowercase` maps each source char
-    // to one or more chars without reordering, so the char streams stay
-    // aligned: the i-th lowercased char comes from the i-th original char.
-    let mut orig_starts: Vec<usize> = Vec::with_capacity(lower_haystack.len() + 1);
-    {
-        let mut orig_chars = haystack.char_indices();
-        let mut pending_orig = orig_chars.next();
-        // How many lowercased chars the current original char expands into.
-        let mut remaining_in_current = 0usize;
-        let mut current_orig_offset = 0usize;
-        for (lower_offset, _) in lower_haystack.char_indices() {
-            while remaining_in_current == 0 {
-                if let Some((offset, ch)) = pending_orig.take() {
-                    current_orig_offset = offset;
-                    remaining_in_current = ch.to_lowercase().count();
-                    pending_orig = orig_chars.next();
-                } else {
-                    break;
-                }
-            }
-            // Pad the lookup table for byte offsets inside this lowercased char.
-            while orig_starts.len() <= lower_offset {
-                orig_starts.push(current_orig_offset);
-            }
-            remaining_in_current = remaining_in_current.saturating_sub(1);
-        }
-        // Terminal entry maps the end of the lowercased string to the end of
-        // the original, so a match that runs to the tail copies correctly.
-        while orig_starts.len() <= lower_haystack.len() {
-            orig_starts.push(haystack.len());
-        }
+    // Another process may have rotated while we were not holding the lock. The
+    // handle we keep open would then point at the renamed file.
+    let stored = sink.stored_generation();
+    if stored != sink.generation {
+        sink.generation = stored;
+        sink.file = None;
     }
 
-    let mut out = String::with_capacity(haystack.len());
-    let mut search_start = 0usize;
-    let mut copied_orig = 0usize;
-    let mut relative_match = Some(first_match);
+    let outcome = job(&path, sink);
 
-    while let Some(relative_index) = relative_match {
-        let lower_start = search_start + relative_index;
-        let lower_end = lower_start + lower_needle.len();
-        let orig_start = orig_starts[lower_start];
-        let orig_end = orig_starts[lower_end];
-        out.push_str(&haystack[copied_orig..orig_start]);
-        out.push_str(replacement);
-        copied_orig = orig_end;
-        search_start = lower_end;
-        relative_match = lower_haystack[search_start..].find(&lower_needle);
+    if locked {
+        if let Some(lock) = sink.lock.as_ref() {
+            let _ = FileExt::unlock(lock);
+        }
     }
-
-    out.push_str(&haystack[copied_orig..]);
-    out
+    outcome
 }
 
-fn redact_email_like_tokens(value: &str) -> String {
-    // No `@`, no email: skip the char vector and the rewind table.
-    if !value.contains('@') {
-        return value.to_string();
-    }
-
-    let chars: Vec<char> = value.chars().collect();
-    let mut out = String::with_capacity(value.len());
-    // `out_len_at[i]` is the byte length of `out` right before the char at
-    // index `i` was emitted. We push an entry every time we copy a char into
-    // `out`, so on an email match we can rewind `out` to where the local part
-    // began (`left`) and drop the already-written name.
-    let mut out_len_at: Vec<usize> = Vec::with_capacity(chars.len());
-    let mut cursor = 0usize;
-
-    while cursor < chars.len() {
-        if chars[cursor] != '@' {
-            out_len_at.push(out.len());
-            out.push(chars[cursor]);
-            cursor += 1;
-            continue;
-        }
-
-        let mut left = cursor;
-        while left > 0 {
-            let ch = chars[left - 1];
-            // `is_alphanumeric` (not `is_ascii_alphanumeric`) so IDN / SMTPUTF8
-            // locals (accented or non-Latin) match in full instead of stopping
-            // at the first non-ASCII char and leaking the rest.
-            if ch.is_alphanumeric() || matches!(ch, '.' | '_' | '%' | '+' | '-') {
-                left -= 1;
-            } else {
-                break;
-            }
-        }
-
-        let mut right = cursor + 1;
-        let mut saw_domain_dot = false;
-        while right < chars.len() {
-            let ch = chars[right];
-            // Same widening for the domain so an accented TLD/host is consumed
-            // and redacted rather than left in clear after the placeholder.
-            if ch.is_alphanumeric() || matches!(ch, '.' | '-') {
-                if ch == '.' {
-                    saw_domain_dot = true;
-                }
-                right += 1;
-            } else {
-                break;
-            }
-        }
-
-        let local_len = cursor.saturating_sub(left);
-        let domain_len = right.saturating_sub(cursor + 1);
-        if local_len == 0 || domain_len < 3 || !saw_domain_dot {
-            out_len_at.push(out.len());
-            out.push(chars[cursor]);
-            cursor += 1;
-            continue;
-        }
-
-        // The local part was already copied into `out` char-by-char in earlier
-        // iterations. Rewind to where it began so the whole local@domain span
-        // collapses to a single placeholder instead of leaking the name.
-        let local_start_len = out_len_at.get(left).copied().unwrap_or(out.len());
-        out.truncate(local_start_len);
-        out_len_at.truncate(left);
-
-        out.push_str("<email>");
-        // Keep `out_len_at` indexed by original char position so a later email
-        // in the same string still rewinds to the right spot: chars `left`
-        // through `right - 1` (local@domain) all collapse into the placeholder,
-        // each mapping to the byte where the placeholder started.
-        for _ in left..right {
-            out_len_at.push(local_start_len);
-        }
-        cursor = right;
-    }
-
-    out
-}
-
-/// Redact Battle.net BattleTags (`Name#1234`). The discriminator is the part
-/// that ties a tag to a specific account, so the whole `Name#1234` collapses
-/// to `<battletag>`. A BattleTag name is 3-12 chars (letters, digits, and on
-/// some locales accented letters) followed by `#` and 4-5 digits; we match
-/// that shape and ignore other `#` uses (e.g. `#define`, `channel #42`).
-fn redact_battletags(value: &str) -> String {
-    // A BattleTag always carries a `#`; without one the loop just copies.
-    if !value.contains('#') {
-        return value.to_string();
-    }
-
-    let chars: Vec<char> = value.chars().collect();
-    let mut out = String::with_capacity(value.len());
-    let mut i = 0usize;
-
-    while i < chars.len() {
-        if chars[i] != '#' {
-            out.push(chars[i]);
-            i += 1;
-            continue;
-        }
-
-        // Walk back over the name part.
-        let mut name_start = i;
-        while name_start > 0 {
-            let ch = chars[name_start - 1];
-            if ch.is_alphanumeric() {
-                name_start -= 1;
-            } else {
-                break;
-            }
-        }
-
-        // Walk forward over the digit discriminator.
-        let mut digits_end = i + 1;
-        while digits_end < chars.len() && chars[digits_end].is_ascii_digit() {
-            digits_end += 1;
-        }
-
-        let name_len = i - name_start;
-        let digit_len = digits_end - (i + 1);
-        // Blizzard names are 3-12 chars; the discriminator is 4-5 digits. A
-        // following alphanumeric run would mean we clipped a longer token, so
-        // bail and leave the `#` alone.
-        let trailing_ok = digits_end >= chars.len() || !chars[digits_end].is_alphanumeric();
-        if (3..=12).contains(&name_len) && (4..=5).contains(&digit_len) && trailing_ok {
-            // The name was already copied char-by-char; drop it before the tag.
-            for _ in 0..name_len {
-                out.pop();
-            }
-            out.push_str("<battletag>");
-            i = digits_end;
-        } else {
-            out.push(chars[i]);
-            i += 1;
-        }
-    }
-
-    out
-}
-
-/// Redact UUID / Riot PUUID tokens: canonical 8-4-4-4-12 hex with dashes, and
-/// bare 32-hex strings (PUUIDs are often logged dashless). Word boundaries are
-/// approximated by requiring the surrounding chars to be non-hex / non-dash so
-/// we don't clip a longer hex blob (hashes, keys) mid-stream.
-fn redact_uuid_like_tokens(value: &str) -> String {
-    // Both forms need at least 8 consecutive hex digits (first dashed group is
-    // 8, the bare form is 32). ASCII hex digits are single bytes, so a byte
-    // scan is equivalent to a char scan and avoids the char vector.
-    let mut hex_run = 0usize;
-    let mut has_hex_run = false;
-    for byte in value.bytes() {
-        if byte.is_ascii_hexdigit() {
-            hex_run += 1;
-            if hex_run >= 8 {
-                has_hex_run = true;
-                break;
-            }
-        } else {
-            hex_run = 0;
-        }
-    }
-    if !has_hex_run {
-        return value.to_string();
-    }
-
-    let chars: Vec<char> = value.chars().collect();
-    let mut out = String::with_capacity(value.len());
-    let mut i = 0usize;
-
-    let is_hex = |c: char| c.is_ascii_hexdigit();
-    let is_boundary_char = |c: char| !(c.is_ascii_hexdigit() || c == '-');
-
-    while i < chars.len() {
-        // Only consider a token start at a boundary (start of string or after a
-        // non-hex, non-dash char).
-        let at_boundary = i == 0 || is_boundary_char(chars[i - 1]);
-        if !at_boundary || !is_hex(chars[i]) {
-            out.push(chars[i]);
-            i += 1;
-            continue;
-        }
-
-        // Canonical 8-4-4-4-12 dashed form.
-        if let Some(end) = match_dashed_uuid(&chars, i) {
-            let trailing_ok = end >= chars.len() || is_boundary_char(chars[end]);
-            if trailing_ok {
-                out.push_str("<uuid>");
-                i = end;
-                continue;
-            }
-        }
-
-        // Bare 32-hex form (dashless PUUID).
-        let mut run_end = i;
-        while run_end < chars.len() && is_hex(chars[run_end]) {
-            run_end += 1;
-        }
-        let run_len = run_end - i;
-        let trailing_ok = run_end >= chars.len() || is_boundary_char(chars[run_end]);
-        if run_len == 32 && trailing_ok {
-            out.push_str("<uuid>");
-            i = run_end;
-            continue;
-        }
-
-        out.push(chars[i]);
-        i += 1;
-    }
-
-    out
-}
-
-/// Match a canonical 8-4-4-4-12 hex UUID starting at char index `start`.
-/// Returns the exclusive end char index on success.
-fn match_dashed_uuid(chars: &[char], start: usize) -> Option<usize> {
-    const GROUPS: [usize; 5] = [8, 4, 4, 4, 12];
-    let mut i = start;
-    for (group_idx, &group_len) in GROUPS.iter().enumerate() {
-        for _ in 0..group_len {
-            if i >= chars.len() || !chars[i].is_ascii_hexdigit() {
-                return None;
-            }
-            i += 1;
-        }
-        if group_idx < GROUPS.len() - 1 {
-            if i >= chars.len() || chars[i] != '-' {
-                return None;
-            }
-            i += 1;
-        }
-    }
-    Some(i)
-}
-
-// Env vars whose values are user-identifying paths, with the placeholder that
-// replaces them. Order matters and is preserved by the resolver below:
-// USERPROFILE first, HOME before the XDG dirs.
-const ENV_SCRUB_KEYS: [(&str, &str); 10] = [
-    ("USERPROFILE", "%USERPROFILE%"),
-    ("OneDrive", "%ONEDRIVE%"),
-    ("APPDATA", "%APPDATA%"),
-    ("LOCALAPPDATA", "%LOCALAPPDATA%"),
-    ("PROGRAMDATA", "%PROGRAMDATA%"),
-    ("TEMP", "%TEMP%"),
-    ("TMP", "%TEMP%"),
-    // Linux/macOS: AppContext::app_data_dir()/app_local_data_dir() resolve
-    // under $HOME (and under XDG_DATA_HOME/XDG_CONFIG_HOME when those are
-    // set), which embeds the OS account name. Without these, paths logged
-    // from config.rs's save_config_unlocked (portable/local config paths)
-    // leak the username on every successful config save.
-    ("HOME", "%HOME%"),
-    ("XDG_DATA_HOME", "%XDG_DATA_HOME%"),
-    ("XDG_CONFIG_HOME", "%XDG_CONFIG_HOME%"),
-];
-
-fn resolve_env_scrub_pairs() -> Vec<(String, &'static str)> {
-    ENV_SCRUB_KEYS
-        .iter()
-        .filter_map(|(env_key, placeholder)| {
-            std::env::var(env_key).ok().map(|path| (path, *placeholder))
-        })
-        .collect()
-}
-
-// These values are fixed for the process lifetime, so resolve them once
-// instead of paying 10 env lookups per sanitized field (4 fields per record).
-#[cfg(not(test))]
-fn resolved_env_scrub_pairs() -> Vec<(String, &'static str)> {
-    static ENV_SCRUB_CACHE: OnceLock<Vec<(String, &'static str)>> = OnceLock::new();
-    ENV_SCRUB_CACHE.get_or_init(resolve_env_scrub_pairs).clone()
-}
-
-// Tests mutate HOME / XDG_* at runtime, so they need a fresh read per call.
-#[cfg(test)]
-fn resolved_env_scrub_pairs() -> Vec<(String, &'static str)> {
-    resolve_env_scrub_pairs()
-}
-
-fn sanitize_log_text(value: &str) -> String {
-    // Order matters: collapse emails first (they can contain digits/hex), then
-    // BattleTags, then UUID/PUUID. We deliberately do NOT try to redact Steam
-    // login names or persona names here: they're free-form words with no stable
-    // shape, so any heuristic broad enough to catch them would also redact
-    // ordinary log text (verbs, product names). Steam account identifiers stay
-    // out of the log layer and are handled at the call sites instead.
-    let mut sanitized = redact_email_like_tokens(value);
-    sanitized = redact_battletags(&sanitized);
-    sanitized = redact_uuid_like_tokens(&sanitized);
-
-    for (path, placeholder) in resolved_env_scrub_pairs() {
-        sanitized = replace_case_insensitive(&sanitized, &path, placeholder);
-    }
-
-    sanitized
-}
-
-fn ensure_log_parent(path: &Path) -> Result<(), String> {
+fn ensure_parent(path: &Path) -> Result<(), String> {
     let parent = path
         .parent()
         .ok_or_else(|| "Log file path has no parent directory".to_string())?;
@@ -509,58 +220,198 @@ pub fn log_file_path(app_handle: &dyn AppContext) -> Result<PathBuf, String> {
     Ok(crate::storage::app_log_root(app_handle)?.join(LOG_FILE_NAME))
 }
 
-fn previous_log_file_path(app_handle: &dyn AppContext) -> Result<PathBuf, String> {
-    let current_path = log_file_path(app_handle)?;
-    Ok(current_path.with_file_name(PREVIOUS_LOG_FILE_NAME))
+/// `app.1.log` is the most recent rotated file, `app.4.log` the oldest.
+pub fn rotated_log_file_path(app_handle: &dyn AppContext, index: u32) -> Result<PathBuf, String> {
+    Ok(log_file_path(app_handle)?.with_file_name(format!("app.{index}.log")))
 }
 
-fn log_lock_file_path(app_handle: &dyn AppContext) -> Result<PathBuf, String> {
-    let current_path = log_file_path(app_handle)?;
-    Ok(current_path.with_file_name(LOG_LOCK_FILE_NAME))
+fn rotated_path(current: &Path, index: u32) -> PathBuf {
+    current.with_file_name(format!("app.{index}.log"))
 }
 
-pub fn begin_log_session(app_handle: &dyn AppContext) -> Result<(), String> {
-    // Best-effort logging must keep working even if a writer panicked.
-    let mut guard = log_sink().lock().unwrap_or_else(|e| e.into_inner());
-    // Hold the cross-process lock across the whole rotation so another instance
-    // (GUI vs CLI) can't append into app.log while we rename it out from under
-    // it. Acquired after the in-process mutex to keep a single lock order with
-    // `append_app_log`. Released when `_xproc` drops at the end of this fn.
-    let _xproc = CrossProcessLogGuard::acquire(app_handle);
-    // Release any handle from a previous session before rotating: Windows
-    // refuses the rename while the file is open.
-    *guard = None;
+pub fn log_lock_file_path(app_handle: &dyn AppContext) -> Result<PathBuf, String> {
+    Ok(log_file_path(app_handle)?.with_file_name(LOG_LOCK_FILE_NAME))
+}
 
-    let current_path = log_file_path(app_handle)?;
-    ensure_log_parent(&current_path)?;
+// ---------------------------------------------------------------------------
+// Rotation and retention
+// ---------------------------------------------------------------------------
 
-    let previous_path = previous_log_file_path(app_handle)?;
-    if previous_path.exists() {
-        let _ = fs::remove_file(&previous_path);
+/// Shift the chain, purge what falls outside the policy, open a fresh file.
+///
+/// Called with the sink locked. Writes its own notice directly into the new
+/// file rather than going through the normal emit path, which would deadlock on
+/// the mutex this is already holding.
+fn rotate(path: &Path, sink: &mut Sink, reason: &str) -> Result<(), String> {
+    let rotated_bytes = sink.size;
+
+    // Windows refuses to rename an open file.
+    sink.file = None;
+
+    let oldest = rotated_path(path, ROTATED_FILES_KEPT);
+    let _ = fs::remove_file(&oldest);
+    for index in (1..ROTATED_FILES_KEPT).rev() {
+        let from = rotated_path(path, index);
+        if from.exists() {
+            let _ = fs::rename(&from, rotated_path(path, index + 1));
+        }
+    }
+    if path.exists() {
+        fs::rename(path, rotated_path(path, 1))
+            .map_err(|error| format!("Could not rotate log file {}: {error}", path.display()))?;
     }
 
-    if current_path.exists() {
-        fs::rename(&current_path, &previous_path).map_err(|reason| {
-            format!(
-                "Could not move current log {} to previous log {}: {reason}",
-                current_path.display(),
-                previous_path.display()
-            )
-        })?;
+    // Every writer of this file has to learn that its open handle is stale.
+    let generation = sink.generation.wrapping_add(1);
+    sink.store_generation(generation);
+
+    sink.open_if_needed(path)?;
+
+    let purged = purge(path);
+
+    let notice = crate::diagnostics::event(&crate::diagnostics::catalog::LOG_ROTATED)
+        .source("log")
+        .msg("Log rotated")
+        .field("reason", reason)
+        .field("bytes", rotated_bytes)
+        .field("keptFiles", u64::from(ROTATED_FILES_KEPT))
+        .render();
+    sink.append(path, &notice)?;
+
+    if purged.files > 0 {
+        let notice = crate::diagnostics::event(&crate::diagnostics::catalog::LOG_RETENTION_PURGED)
+            .source("log")
+            .msg("Old log files removed")
+            .field("removedFiles", purged.files)
+            .field("freedBytes", purged.bytes)
+            .field("reason", purged.reason)
+            .render();
+        sink.append(path, &notice)?;
     }
-
-    fs::write(&current_path, "").map_err(|reason| {
-        format!(
-            "Could not initialize log file {}: {reason}",
-            current_path.display()
-        )
-    })?;
-
-    *guard = Some(open_append_handle(&current_path)?);
 
     Ok(())
 }
 
+#[derive(Default)]
+struct Purged {
+    files: u64,
+    bytes: u64,
+    reason: &'static str,
+}
+
+/// Delete rotated files that fall outside the retention policy. The file-count
+/// budget is already enforced by the shift above, so this only handles age.
+fn purge(current: &Path) -> Purged {
+    let mut purged = Purged {
+        reason: "age",
+        ..Default::default()
+    };
+    let max_age = std::time::Duration::from_secs(RETENTION_DAYS * 24 * 60 * 60);
+
+    for index in 1..=ROTATED_FILES_KEPT {
+        let path = rotated_path(current, index);
+        let Ok(meta) = fs::metadata(&path) else {
+            continue;
+        };
+        let too_old = meta
+            .modified()
+            .ok()
+            .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+            .is_some_and(|age| age > max_age);
+        if too_old {
+            let size = meta.len();
+            if fs::remove_file(&path).is_ok() {
+                purged.files += 1;
+                purged.bytes += size;
+            }
+        }
+    }
+
+    purged
+}
+
+// ---------------------------------------------------------------------------
+// Writing
+// ---------------------------------------------------------------------------
+
+/// Append one already-rendered line. The single writing path: every record,
+/// legacy or structured, goes through here and is therefore subject to the same
+/// lock, the same rotation and the same budget.
+pub(crate) fn write_line(app_handle: &dyn AppContext, line: &str) -> Result<(), String> {
+    with_sink(app_handle, |path, sink| {
+        sink.open_if_needed(path)?;
+        // Rotate before the write that would breach the cap, never after: the
+        // announced budget is a ceiling, not an average.
+        if sink.size > 0 && sink.size + line.len() as u64 + 1 > MAX_LOG_FILE_BYTES {
+            rotate(path, sink, "size")?;
+        }
+        sink.append(path, line)
+    })
+}
+
+/// Start a session: rotate the previous one out of the way, then say so.
+///
+/// Called once per process launch by the GUI. Everything else opens the sink
+/// lazily and appends.
+pub fn begin_log_session(app_handle: &dyn AppContext) -> Result<(), String> {
+    with_sink(app_handle, |path, sink| {
+        ensure_parent(path)?;
+        migrate_legacy_previous(path);
+        sink.open_if_needed(path)?;
+        if sink.size > 0 {
+            rotate(path, sink, "session")?;
+        }
+        Ok(())
+    })?;
+
+    // Both of these write records, so they run once the sink lock is gone.
+    crate::diagnostics::levels::expire_temporary_debug(app_handle);
+    emit_session_started(app_handle);
+
+    Ok(())
+}
+
+/// A file left by a build that only kept one previous session. Fold it into
+/// the numbered chain so it stays readable instead of being orphaned.
+fn migrate_legacy_previous(current: &Path) {
+    let legacy = current.with_file_name(LEGACY_PREVIOUS_LOG_FILE_NAME);
+    if !legacy.exists() {
+        return;
+    }
+    let first = rotated_path(current, 1);
+    if first.exists() {
+        // The chain already holds newer sessions; the orphan is the oldest
+        // thing here and the budget has no room for it.
+        let _ = fs::remove_file(&legacy);
+    } else {
+        let _ = fs::rename(&legacy, &first);
+    }
+}
+
+fn emit_session_started(app_handle: &dyn AppContext) {
+    let binary = std::env::current_exe()
+        .ok()
+        .and_then(|path| {
+            path.file_name()
+                .map(|name| name.to_string_lossy().to_string())
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+
+    crate::diagnostics::event(&crate::diagnostics::catalog::SESSION_STARTED)
+        .source("app")
+        .msg("Session started")
+        .field("appVersion", env!("CARGO_PKG_VERSION"))
+        .field("os", std::env::consts::OS)
+        .field("arch", std::env::consts::ARCH)
+        .field("binary", binary)
+        .emit(app_handle);
+}
+
+/// Legacy record, kept for the call sites that have not migrated.
+///
+/// The line shape is unchanged on purpose: readers of an existing `app.log`
+/// keep working, and [`crate::diagnostics::query`] parses both. New call sites
+/// should use [`crate::diagnostics::event`], which is queryable.
 pub fn append_app_log(
     app_handle: &dyn AppContext,
     level: &str,
@@ -576,32 +427,7 @@ pub fn append_app_log(
         "details": details.map(|value| trim_text(&sanitize_log_text(value), MAX_DETAILS_BYTES)),
     });
 
-    let mut guard = log_sink().lock().unwrap_or_else(|e| e.into_inner());
-    // Serialize the append against a cross-process rotation: without this an
-    // O_APPEND write here could land in app.log just as another instance
-    // renames it to app.previous.log. Same lock order as `begin_log_session`
-    // (in-process mutex first, then the OS lock). Released at fn return.
-    let _xproc = CrossProcessLogGuard::acquire(app_handle);
-
-    if guard.is_none() {
-        // Writer without a session (CLI, tests): open lazily and keep it.
-        let path = log_file_path(app_handle)?;
-        ensure_log_parent(&path)?;
-        *guard = Some(open_append_handle(&path)?);
-    }
-
-    let file = guard.as_mut().expect("log sink populated above");
-    if let Err(reason) = writeln!(file, "{record}") {
-        // Drop the dead handle so the next record reopens the file.
-        *guard = None;
-        let path = log_file_path(app_handle)?;
-        return Err(format!(
-            "Could not write log file {}: {reason}",
-            path.display()
-        ));
-    }
-
-    Ok(())
+    write_line(app_handle, &record.to_string())
 }
 
 pub fn install_panic_hook(app_handle: crate::AppCtx) {
@@ -642,268 +468,220 @@ pub fn install_panic_hook(app_handle: crate::AppCtx) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::diagnostics::test_support::TestCtx;
+    use serde_json::Value;
 
-    // Serializes the tests that mutate process-global HOME / XDG_* env vars.
-    // sanitize_log_text reads them at call time, so two of these running
-    // concurrently under cargo's parallel runner would clobber each other's
-    // setup (one test's HOME/XDG leaking into the other's assertion).
-    static ENV_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    #[test]
-    fn trim_text_shorter_than_max() {
-        assert_eq!(trim_text("hello", 10), "hello");
+    fn read_lines(path: &Path) -> Vec<Value> {
+        fs::read_to_string(path)
+            .unwrap_or_default()
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| serde_json::from_str(line).expect("every line must be JSON"))
+            .collect()
     }
 
+    // The 38 existing call sites still write this shape, and external readers
+    // (support, the user's own grep) already know it.
     #[test]
-    fn trim_text_exact_max() {
-        assert_eq!(trim_text("hello", 5), "hello");
-    }
+    fn the_legacy_line_shape_is_unchanged() {
+        let ctx = TestCtx::ctx("logging-legacy-shape");
+        append_app_log(&*ctx, "warning", "steam.switch", "hello", Some("detail")).expect("append");
 
-    #[test]
-    fn trim_text_truncates_at_boundary() {
-        assert_eq!(trim_text("hello world", 5), "hello");
-    }
-
-    #[test]
-    fn trim_text_respects_utf8_boundary() {
-        // é is 2 bytes in UTF-8, max_bytes=3 should not split it
-        let result = trim_text("héllo", 2);
-        assert_eq!(result, "h");
-    }
-
-    #[test]
-    fn trim_text_empty_string() {
-        assert_eq!(trim_text("", 10), "");
-    }
-
-    #[test]
-    fn replace_case_insensitive_basic() {
+        let path = log_file_path(&*ctx).expect("path");
+        let records = read_lines(&path);
+        assert_eq!(records.len(), 1);
+        let record = &records[0];
+        assert_eq!(record["level"], serde_json::json!("warning"));
+        assert_eq!(record["source"], serde_json::json!("steam.switch"));
+        assert_eq!(record["message"], serde_json::json!("hello"));
+        assert_eq!(record["details"], serde_json::json!("detail"));
+        assert!(record["tsMs"].as_u64().is_some());
         assert_eq!(
-            replace_case_insensitive("Hello WORLD", "world", "earth"),
-            "Hello earth"
+            record.as_object().expect("object").len(),
+            5,
+            "the facade must not grow columns"
         );
     }
 
     #[test]
-    fn replace_case_insensitive_multiple() {
-        assert_eq!(replace_case_insensitive("aAbBaA", "aa", "X"), "XbBX");
-    }
-
-    #[test]
-    fn replace_case_insensitive_empty_needle() {
-        assert_eq!(replace_case_insensitive("hello", "", "X"), "hello");
-    }
-
-    #[test]
-    fn replace_case_insensitive_no_match() {
-        assert_eq!(replace_case_insensitive("hello", "xyz", "X"), "hello");
-    }
-
-    #[test]
-    fn replace_case_insensitive_accented_username() {
-        // The log path lowercases the accented username differently than the
-        // env var; Unicode-aware folding must still match it.
-        assert_eq!(
-            replace_case_insensitive(
-                r"C:\Users\Jérôme\AppData",
-                r"C:\Users\JÉRÔME",
-                "%USERPROFILE%"
-            ),
-            r"%USERPROFILE%\AppData"
-        );
-    }
-
-    #[test]
-    fn replace_case_insensitive_accented_changes_length() {
-        // German ß lowercases to itself but uppercases to "SS": folding must
-        // not desync the offset map between lowercased and original.
-        assert_eq!(
-            replace_case_insensitive("straße end", "STRASSE", "X"),
-            "straße end"
-        );
-        assert_eq!(replace_case_insensitive("STRAßE x", "straße", "Y"), "Y x");
-    }
-
-    #[test]
-    fn redact_email_basic() {
-        // The whole local@domain collapses; the local part must not leak.
-        assert_eq!(redact_email_like_tokens("user@example.com"), "<email>");
-    }
-
-    #[test]
-    fn redact_email_drops_local_part_with_name() {
-        // Regression: previously left "jean.dupont<email>", leaking the name.
-        assert_eq!(
-            redact_email_like_tokens("jean.dupont@example.com"),
-            "<email>"
-        );
-    }
-
-    #[test]
-    fn redact_email_multiple() {
-        assert_eq!(
-            redact_email_like_tokens("a@b.co and c@d.com"),
-            "<email> and <email>"
-        );
-    }
-
-    #[test]
-    fn redact_email_no_email() {
-        assert_eq!(redact_email_like_tokens("hello world"), "hello world");
-    }
-
-    #[test]
-    fn redact_email_at_without_domain() {
-        assert_eq!(redact_email_like_tokens("just @ sign"), "just @ sign");
-    }
-
-    #[test]
-    fn redact_email_preserves_surrounding_text() {
-        assert_eq!(
-            redact_email_like_tokens("logged in as test@mail.com successfully"),
-            "logged in as <email> successfully"
-        );
-    }
-
-    #[test]
-    fn redact_email_accented_local_part() {
-        // Multibyte local part: the accented name must be dropped whole, not
-        // truncated at the first non-ASCII byte. The truncate-on-match rewinds
-        // `out` by recorded byte offsets, so the 2-byte `é` can't desync it.
-        assert_eq!(redact_email_like_tokens("jérôme@example.com"), "<email>");
-        assert_eq!(
-            redact_email_like_tokens("connecté en tant que jérôme@example.com ok"),
-            "connecté en tant que <email> ok"
-        );
-    }
-
-    #[test]
-    fn redact_email_accented_domain() {
-        // Non-ASCII tail in the domain must be consumed by the match instead of
-        // being left in clear after the placeholder.
-        assert_eq!(redact_email_like_tokens("john@domain.café"), "<email>");
-        assert_eq!(
-            redact_email_like_tokens("ping müller@firma.köln now"),
-            "ping <email> now"
-        );
-    }
-
-    #[test]
-    fn redact_battletag_basic() {
-        assert_eq!(
-            redact_battletags("playing as Hero#1234 now"),
-            "playing as <battletag> now"
-        );
-    }
-
-    #[test]
-    fn redact_battletag_five_digit_discriminator() {
-        assert_eq!(redact_battletags("Tag#12345"), "<battletag>");
-    }
-
-    #[test]
-    fn redact_battletag_ignores_non_tag_hashes() {
-        // Too few discriminator digits, or a name that's too short.
-        assert_eq!(redact_battletags("see channel #42"), "see channel #42");
-        assert_eq!(redact_battletags("#define FOO 1"), "#define FOO 1");
-        assert_eq!(redact_battletags("ab#1234"), "ab#1234");
-    }
-
-    #[test]
-    fn redact_uuid_dashed() {
-        assert_eq!(
-            redact_uuid_like_tokens("id=550e8400-e29b-41d4-a716-446655440000 done"),
-            "id=<uuid> done"
-        );
-    }
-
-    #[test]
-    fn redact_uuid_bare_32_hex() {
-        // Dashless PUUID form.
-        assert_eq!(
-            redact_uuid_like_tokens("puuid 550e8400e29b41d4a716446655440000 ok"),
-            "puuid <uuid> ok"
-        );
-    }
-
-    #[test]
-    fn redact_uuid_ignores_short_or_long_hex() {
-        // Not 32 hex chars, not a dashed UUID: left alone.
-        assert_eq!(redact_uuid_like_tokens("deadbeef"), "deadbeef");
-        assert_eq!(
-            redact_uuid_like_tokens("abc123def4567890abc123def4567890ab"),
-            "abc123def4567890abc123def4567890ab"
-        );
-    }
-
-    #[test]
-    fn sanitize_log_text_combines_redactions() {
-        let input = "user jean@mail.com Hero#1234 550e8400-e29b-41d4-a716-446655440000";
-        assert_eq!(sanitize_log_text(input), "user <email> <battletag> <uuid>");
-    }
-
-    // Regression: sanitize_log_text's env-var scrub list used to only cover
-    // Windows vars (USERPROFILE, APPDATA, ...), so a Linux/macOS path under
-    // $HOME (e.g. the portable/local config paths logged by
-    // config.rs's save_config_unlocked) leaked the OS account name into
-    // app.log, where it could later be exposed if the user shared the file,
-    // on every save.
-    #[test]
-    fn sanitize_log_text_scrubs_home_dir_path() {
-        let _env = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
-        let previous = std::env::var("HOME").ok();
-        std::env::set_var("HOME", "/home/alice");
-
-        let result = sanitize_log_text(
-            "Saved split app config /home/alice/.local/share/accshift/state/portable-config.json",
-        );
-
-        match previous {
-            Some(value) => std::env::set_var("HOME", value),
-            None => std::env::remove_var("HOME"),
+    fn the_active_file_stays_under_the_size_cap() {
+        let ctx = TestCtx::ctx("logging-rotation");
+        let path = log_file_path(&*ctx).expect("path");
+        // The facade caps a message at 512 bytes, so the line size is known:
+        // roughly 620 bytes each, and 12000 of them cross the 2 MiB cap three
+        // times over.
+        let filler = "x".repeat(4_000);
+        for _ in 0..12_000 {
+            append_app_log(&*ctx, "info", "test", &filler, None).expect("append");
         }
 
-        assert_eq!(
-            result,
-            "Saved split app config %HOME%/.local/share/accshift/state/portable-config.json"
+        let active = fs::metadata(&path).expect("metadata").len();
+        assert!(
+            active <= MAX_LOG_FILE_BYTES,
+            "active file is {active} bytes, cap is {MAX_LOG_FILE_BYTES}"
+        );
+        assert!(
+            rotated_path(&path, 1).exists(),
+            "crossing the cap must produce a rotated file"
+        );
+
+        // The announced budget is a ceiling for the whole chain, not per file.
+        let mut total = active;
+        for index in 1..=ROTATED_FILES_KEPT {
+            total += fs::metadata(rotated_path(&path, index))
+                .map(|meta| meta.len())
+                .unwrap_or(0);
+        }
+        assert!(
+            total <= disk_budget_bytes(),
+            "chain is {total} bytes, budget is {}",
+            disk_budget_bytes()
+        );
+        assert!(
+            !rotated_path(&path, ROTATED_FILES_KEPT + 1).exists(),
+            "nothing may survive past the last kept slot"
         );
     }
 
     #[test]
-    fn sanitize_log_text_scrubs_xdg_dirs() {
-        let _env = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
-        // Also pin HOME to a value that shares no substring with the XDG
-        // paths below: on a machine where HOME happens to already be set
-        // (e.g. Git Bash on Windows), the HOME substitution runs first in
-        // sanitize_log_text's loop and would otherwise eat part of the XDG
-        // path before the XDG substitution gets a chance to match it.
-        let previous_home = std::env::var("HOME").ok();
-        let previous_data = std::env::var("XDG_DATA_HOME").ok();
-        let previous_config = std::env::var("XDG_CONFIG_HOME").ok();
-        std::env::set_var("HOME", "/home/unrelated-sentinel");
-        std::env::set_var("XDG_DATA_HOME", "/home/alice/.local/share");
-        std::env::set_var("XDG_CONFIG_HOME", "/home/alice/.config");
+    fn rotation_announces_itself_in_the_new_file() {
+        let ctx = TestCtx::ctx("logging-rotation-notice");
+        let path = log_file_path(&*ctx).expect("path");
+        let filler = "x".repeat(4_000);
+        for _ in 0..4_000 {
+            append_app_log(&*ctx, "info", "test", &filler, None).expect("append");
+        }
 
-        let result = sanitize_log_text(
-            "paths /home/alice/.local/share/accshift and /home/alice/.config/accshift",
+        let first = read_lines(&path).into_iter().next().expect("a first line");
+        assert_eq!(first["code"], serde_json::json!("log.rotated"));
+        assert_eq!(first["fields"]["reason"], serde_json::json!("size"));
+        assert!(first["fields"]["bytes"].as_u64().is_some_and(|b| b > 0));
+    }
+
+    #[test]
+    fn a_session_rotates_the_previous_one_out_of_the_way() {
+        let ctx = TestCtx::ctx("logging-session");
+        append_app_log(&*ctx, "info", "test", "from the previous session", None).expect("append");
+
+        begin_log_session(&*ctx).expect("session");
+
+        let path = log_file_path(&*ctx).expect("path");
+        let previous = read_lines(&rotated_path(&path, 1));
+        assert_eq!(previous.len(), 1);
+        assert_eq!(
+            previous[0]["message"],
+            serde_json::json!("from the previous session")
         );
 
-        match previous_home {
-            Some(value) => std::env::set_var("HOME", value),
-            None => std::env::remove_var("HOME"),
-        }
-        match previous_data {
-            Some(value) => std::env::set_var("XDG_DATA_HOME", value),
-            None => std::env::remove_var("XDG_DATA_HOME"),
-        }
-        match previous_config {
-            Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
-            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        let current = read_lines(&path);
+        assert_eq!(current[0]["code"], serde_json::json!("log.rotated"));
+        assert!(
+            current
+                .iter()
+                .any(|record| record["code"] == serde_json::json!("app.session.started")),
+            "a session must be able to say when it started"
+        );
+    }
+
+    // An empty file is not worth a rotation slot: the CLI runs often and would
+    // otherwise push the GUI's history out of the chain in four invocations.
+    #[test]
+    fn an_empty_session_does_not_burn_a_slot() {
+        let ctx = TestCtx::ctx("logging-session-empty");
+        begin_log_session(&*ctx).expect("session");
+
+        let path = log_file_path(&*ctx).expect("path");
+        assert!(!rotated_path(&path, 1).exists());
+    }
+
+    #[test]
+    fn a_legacy_previous_file_joins_the_chain() {
+        let ctx = TestCtx::ctx("logging-legacy-migration");
+        let path = log_file_path(&*ctx).expect("path");
+        ensure_parent(&path).expect("parent");
+        fs::write(
+            path.with_file_name(LEGACY_PREVIOUS_LOG_FILE_NAME),
+            "{\"tsMs\":1,\"level\":\"info\",\"source\":\"old\",\"message\":\"kept\"}\n",
+        )
+        .expect("seed");
+
+        begin_log_session(&*ctx).expect("session");
+
+        assert!(!path.with_file_name(LEGACY_PREVIOUS_LOG_FILE_NAME).exists());
+        let migrated = read_lines(&rotated_path(&path, 1));
+        assert_eq!(migrated[0]["message"], serde_json::json!("kept"));
+    }
+
+    // The other process rotated. Our open handle now points at app.1.log, and
+    // appending into it would write the newest records into the oldest file.
+    #[test]
+    fn a_rotation_by_another_process_forces_a_reopen() {
+        let ctx = TestCtx::ctx("logging-generation");
+        append_app_log(&*ctx, "info", "test", "before", None).expect("append");
+        let path = log_file_path(&*ctx).expect("path");
+
+        // Simulate the peer: rename the file and bump the counter, exactly what
+        // `rotate` does, without going through this process' sink.
+        {
+            let mut map = sinks().lock().expect("sinks");
+            let sink = map.get_mut(&path).expect("sink");
+            let stale_generation = sink.generation;
+            sink.file = None;
+            fs::rename(&path, rotated_path(&path, 1)).expect("rename");
+
+            let lock_path = path.with_file_name(LOG_LOCK_FILE_NAME);
+            let lock = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&lock_path)
+                .expect("lock file");
+            let mut handle = &lock;
+            handle
+                .write_all(&(stale_generation + 1).to_le_bytes())
+                .expect("bump");
         }
 
+        append_app_log(&*ctx, "info", "test", "after", None).expect("append");
+
+        let current = read_lines(&path);
+        assert_eq!(current.len(), 1, "the new file holds only the new record");
+        assert_eq!(current[0]["message"], serde_json::json!("after"));
+        let rotated = read_lines(&rotated_path(&path, 1));
+        assert_eq!(rotated[0]["message"], serde_json::json!("before"));
+    }
+
+    #[test]
+    fn files_older_than_the_retention_window_are_purged() {
+        let ctx = TestCtx::ctx("logging-retention");
+        let path = log_file_path(&*ctx).expect("path");
+        ensure_parent(&path).expect("parent");
+
+        let stale = rotated_path(&path, 2);
+        fs::write(&stale, "{\"tsMs\":1}\n").expect("seed");
+        let ancient =
+            SystemTime::now() - std::time::Duration::from_secs((RETENTION_DAYS + 1) * 24 * 60 * 60);
+        let handle = OpenOptions::new().write(true).open(&stale).expect("open");
+        handle
+            .set_modified(ancient)
+            .expect("backdate the file so the sweep can see it as old");
+        drop(handle);
+
+        let purged = purge(&path);
+
+        assert_eq!(purged.files, 1);
+        assert!(!stale.exists());
+    }
+
+    #[test]
+    fn the_announced_budget_matches_the_policy() {
+        let policy = retention_policy();
         assert_eq!(
-            result,
-            "paths %XDG_DATA_HOME%/accshift and %XDG_CONFIG_HOME%/accshift"
+            policy["diskBudgetBytes"].as_u64(),
+            Some(disk_budget_bytes())
+        );
+        assert_eq!(
+            disk_budget_bytes(),
+            MAX_LOG_FILE_BYTES * (u64::from(ROTATED_FILES_KEPT) + 1)
         );
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,8 @@ answers.
   does it print, and what does each exit code mean?
 - [analytics.md](./analytics.md): what does the app send, what does it never
   send, and how do I turn it off, export it or delete it?
+- [logging.md](./logging.md): what does a log record contain, how do I replay a
+  failed attempt from its identifier, and how much disk does the log use?
 
 Elsewhere:
 

--- a/docs/log-catalog.json
+++ b/docs/log-catalog.json
@@ -1,0 +1,616 @@
+{
+  "events": [
+    {
+      "action": "Look for a locked file, an antivirus scan, or a launcher refusing to exit.",
+      "aliases": [],
+      "code": "anomaly.operation.slow",
+      "level": "warn",
+      "meaning": "An operation took far longer than its own rolling baseline.",
+      "optionalFields": [
+        {
+          "name": "platform",
+          "type": "string"
+        }
+      ],
+      "requiredFields": [
+        {
+          "name": "op",
+          "type": "string"
+        },
+        {
+          "name": "durMs",
+          "type": "integer"
+        },
+        {
+          "name": "baselineMs",
+          "type": "integer"
+        }
+      ]
+    },
+    {
+      "action": "Run the health checks for that platform; the launcher path or its config is likely stale.",
+      "aliases": [],
+      "code": "anomaly.platform.consecutive_failures",
+      "level": "warn",
+      "meaning": "A platform failed several operations in a row.",
+      "optionalFields": [
+        {
+          "name": "op",
+          "type": "string"
+        }
+      ],
+      "requiredFields": [
+        {
+          "name": "platform",
+          "type": "string"
+        },
+        {
+          "name": "failures",
+          "type": "integer"
+        }
+      ]
+    },
+    {
+      "action": "Treat the switch as failed: the target files were not replaced.",
+      "aliases": [],
+      "code": "anomaly.restore.no_write",
+      "level": "error",
+      "meaning": "A restore reported success without writing a single byte.",
+      "optionalFields": [
+        {
+          "name": "path",
+          "type": "string"
+        }
+      ],
+      "requiredFields": [
+        {
+          "name": "platform",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "action": "The account was probably not signed in when captured; recapture it.",
+      "aliases": [],
+      "code": "anomaly.snapshot.empty",
+      "level": "warn",
+      "meaning": "A session snapshot was captured but contains nothing.",
+      "optionalFields": [
+        {
+          "name": "path",
+          "type": "string"
+        }
+      ],
+      "requiredFields": [
+        {
+          "name": "platform",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "action": "None. Use the runId to scope everything that follows to this launch.",
+      "aliases": [],
+      "code": "app.session.started",
+      "level": "info",
+      "meaning": "A new accshift process started logging under this runId.",
+      "optionalFields": [
+        {
+          "name": "binary",
+          "type": "string"
+        }
+      ],
+      "requiredFields": [
+        {
+          "name": "appVersion",
+          "type": "string"
+        },
+        {
+          "name": "os",
+          "type": "string"
+        },
+        {
+          "name": "arch",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "action": "None. The user decides whether to paste it.",
+      "aliases": [],
+      "code": "diagnostics.bundle.written",
+      "level": "info",
+      "meaning": "A diagnostic report was written locally. Nothing was sent anywhere.",
+      "optionalFields": [],
+      "requiredFields": [
+        {
+          "name": "path",
+          "type": "string"
+        },
+        {
+          "name": "bytes",
+          "type": "integer"
+        }
+      ]
+    },
+    {
+      "action": "Reproduce the bug now; the level reverts without any further action.",
+      "aliases": [],
+      "code": "diagnostics.debug.enabled",
+      "level": "info",
+      "meaning": "Temporary verbose logging was turned on and will expire on its own.",
+      "optionalFields": [
+        {
+          "name": "modules",
+          "type": "string[]"
+        }
+      ],
+      "requiredFields": [
+        {
+          "name": "durationMs",
+          "type": "integer"
+        },
+        {
+          "name": "newLevel",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "action": "None.",
+      "aliases": [],
+      "code": "diagnostics.debug.expired",
+      "level": "info",
+      "meaning": "Temporary verbose logging reached its deadline and the normal level is back.",
+      "optionalFields": [],
+      "requiredFields": []
+    },
+    {
+      "action": "Fix the call site: the catalog entry lists what the code requires.",
+      "aliases": [],
+      "code": "diagnostics.event.invalid",
+      "level": "error",
+      "meaning": "An event was emitted with a missing or mistyped mandatory field.",
+      "optionalFields": [],
+      "requiredFields": [
+        {
+          "name": "offendingCode",
+          "type": "string"
+        },
+        {
+          "name": "defects",
+          "type": "string[]"
+        }
+      ]
+    },
+    {
+      "action": "None. Remember that a lowered level hides records permanently, not retroactively.",
+      "aliases": [],
+      "code": "diagnostics.level.changed",
+      "level": "info",
+      "meaning": "A per-module log level was changed at runtime.",
+      "optionalFields": [],
+      "requiredFields": [
+        {
+          "name": "module",
+          "type": "string"
+        },
+        {
+          "name": "newLevel",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "action": "None. Visible at debug level so a clean preflight is provable, not assumed.",
+      "aliases": [],
+      "code": "health.check.passed",
+      "level": "debug",
+      "meaning": "An invariant was verified and holds.",
+      "optionalFields": [
+        {
+          "name": "platform",
+          "type": "string"
+        },
+        {
+          "name": "detail",
+          "type": "string"
+        }
+      ],
+      "requiredFields": [
+        {
+          "name": "check",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "action": "Expect out-of-order timestamps; sort by runId then by file order, not by tsMs alone.",
+      "aliases": [],
+      "code": "health.clock.skew",
+      "level": "warn",
+      "meaning": "The system clock moved backwards compared to records already on disk.",
+      "optionalFields": [],
+      "requiredFields": [
+        {
+          "name": "skewMs",
+          "type": "integer"
+        }
+      ]
+    },
+    {
+      "action": "Free space on that volume; snapshot writes and log rotation both need room.",
+      "aliases": [],
+      "code": "health.disk.low",
+      "level": "warn",
+      "meaning": "The volume holding this path is close to full.",
+      "optionalFields": [],
+      "requiredFields": [
+        {
+          "name": "path",
+          "type": "string"
+        },
+        {
+          "name": "availableBytes",
+          "type": "integer"
+        },
+        {
+          "name": "requiredBytes",
+          "type": "integer"
+        }
+      ]
+    },
+    {
+      "action": "Close the launcher (or the other accshift instance) and retry.",
+      "aliases": [],
+      "code": "health.file.locked",
+      "level": "warn",
+      "meaning": "A file the operation must rewrite is held by another process.",
+      "optionalFields": [
+        {
+          "name": "platform",
+          "type": "string"
+        },
+        {
+          "name": "holder",
+          "type": "string"
+        }
+      ],
+      "requiredFields": [
+        {
+          "name": "path",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "action": "Quit the launcher, or let the switch close it (graceful, then force).",
+      "aliases": [],
+      "code": "health.launcher.running",
+      "level": "warn",
+      "meaning": "The launcher is still alive when the operation needs it stopped.",
+      "optionalFields": [],
+      "requiredFields": [
+        {
+          "name": "platform",
+          "type": "string"
+        },
+        {
+          "name": "processes",
+          "type": "string[]"
+        }
+      ]
+    },
+    {
+      "action": "Set the path override for that platform, or reinstall the launcher.",
+      "aliases": [],
+      "code": "health.path.missing",
+      "level": "error",
+      "meaning": "A path the operation needs does not exist.",
+      "optionalFields": [
+        {
+          "name": "platform",
+          "type": "string"
+        }
+      ],
+      "requiredFields": [
+        {
+          "name": "path",
+          "type": "string"
+        },
+        {
+          "name": "purpose",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "action": "Check the folder ACLs, an antivirus lock, or run the operation without elevation mismatch.",
+      "aliases": [],
+      "code": "health.path.permission_denied",
+      "level": "error",
+      "meaning": "A path exists but this process cannot write to it.",
+      "optionalFields": [
+        {
+          "name": "platform",
+          "type": "string"
+        },
+        {
+          "name": "reason",
+          "type": "string"
+        }
+      ],
+      "requiredFields": [
+        {
+          "name": "path",
+          "type": "string"
+        },
+        {
+          "name": "purpose",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "action": "Restore the .bak sibling if there is one, otherwise recapture the account.",
+      "aliases": [],
+      "code": "health.profile.corrupt",
+      "level": "error",
+      "meaning": "A stored profile or config file is not valid JSON any more.",
+      "optionalFields": [
+        {
+          "name": "platform",
+          "type": "string"
+        }
+      ],
+      "requiredFields": [
+        {
+          "name": "path",
+          "type": "string"
+        },
+        {
+          "name": "reason",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "action": "None, unless files vanish faster than you can read them: raise the budget then.",
+      "aliases": [],
+      "code": "log.retention.purged",
+      "level": "info",
+      "meaning": "Rotated log files were deleted to stay inside the announced disk budget.",
+      "optionalFields": [],
+      "requiredFields": [
+        {
+          "name": "removedFiles",
+          "type": "integer"
+        },
+        {
+          "name": "freedBytes",
+          "type": "integer"
+        },
+        {
+          "name": "reason",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "action": "None. Confirms the retention policy is running.",
+      "aliases": [],
+      "code": "log.rotated",
+      "level": "info",
+      "meaning": "The active log file was shifted to app.1.log and a fresh one opened.",
+      "optionalFields": [],
+      "requiredFields": [
+        {
+          "name": "reason",
+          "type": "string"
+        },
+        {
+          "name": "bytes",
+          "type": "integer"
+        },
+        {
+          "name": "keptFiles",
+          "type": "integer"
+        }
+      ]
+    },
+    {
+      "action": "Check free space and write permissions on the log directory.",
+      "aliases": [],
+      "code": "log.write.failed",
+      "level": "error",
+      "meaning": "A log record could not be written to disk and was dropped.",
+      "optionalFields": [
+        {
+          "name": "path",
+          "type": "string"
+        }
+      ],
+      "requiredFields": [
+        {
+          "name": "reason",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "action": "On outcome=failure, read errKind then the steps sharing this opId.",
+      "aliases": [],
+      "code": "op.finished",
+      "level": "info",
+      "meaning": "An operation ended; durMs and outcome say how long it took and how it went.",
+      "optionalFields": [
+        {
+          "name": "platform",
+          "type": "string"
+        },
+        {
+          "name": "steps",
+          "type": "integer"
+        },
+        {
+          "name": "detail",
+          "type": "string"
+        }
+      ],
+      "requiredFields": [
+        {
+          "name": "op",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "action": "None. Query by opId to replay the whole attempt.",
+      "aliases": [],
+      "code": "op.started",
+      "level": "debug",
+      "meaning": "A user-visible operation started and was assigned an opId.",
+      "optionalFields": [
+        {
+          "name": "platform",
+          "type": "string"
+        },
+        {
+          "name": "trigger",
+          "type": "string"
+        }
+      ],
+      "requiredFields": [
+        {
+          "name": "op",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "action": "None. The last step before a failure is where to start reading.",
+      "aliases": [],
+      "code": "op.step",
+      "level": "debug",
+      "meaning": "An operation reached a named step.",
+      "optionalFields": [
+        {
+          "name": "platform",
+          "type": "string"
+        },
+        {
+          "name": "detail",
+          "type": "string"
+        }
+      ],
+      "requiredFields": [
+        {
+          "name": "op",
+          "type": "string"
+        },
+        {
+          "name": "step",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "action": "None. entries=0 also raises anomaly.snapshot.empty.",
+      "aliases": [],
+      "code": "platform.snapshot.captured",
+      "level": "info",
+      "meaning": "A session snapshot was captured for an account.",
+      "optionalFields": [],
+      "requiredFields": [
+        {
+          "name": "platform",
+          "type": "string"
+        },
+        {
+          "name": "entries",
+          "type": "integer"
+        }
+      ]
+    },
+    {
+      "action": "None. bytes=0 also raises anomaly.restore.no_write.",
+      "aliases": [],
+      "code": "platform.snapshot.restored",
+      "level": "info",
+      "meaning": "A session snapshot was written back over the launcher's files.",
+      "optionalFields": [],
+      "requiredFields": [
+        {
+          "name": "platform",
+          "type": "string"
+        },
+        {
+          "name": "bytes",
+          "type": "integer"
+        }
+      ]
+    },
+    {
+      "action": "Replay the opId: the preceding op.step and health.* records name the blocking condition.",
+      "aliases": [],
+      "code": "platform.switch.failed",
+      "level": "error",
+      "meaning": "An account switch failed at a named stage.",
+      "optionalFields": [
+        {
+          "name": "reason",
+          "type": "string"
+        }
+      ],
+      "requiredFields": [
+        {
+          "name": "platform",
+          "type": "string"
+        },
+        {
+          "name": "stage",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "action": "None. Pairs with platform.switch.succeeded or .failed on the same opId.",
+      "aliases": [],
+      "code": "platform.switch.started",
+      "level": "info",
+      "meaning": "An account switch began for this platform.",
+      "optionalFields": [
+        {
+          "name": "mode",
+          "type": "string"
+        }
+      ],
+      "requiredFields": [
+        {
+          "name": "platform",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "action": "None.",
+      "aliases": [],
+      "code": "platform.switch.succeeded",
+      "level": "info",
+      "meaning": "The launcher was relaunched signed in as the requested account.",
+      "optionalFields": [
+        {
+          "name": "mode",
+          "type": "string"
+        }
+      ],
+      "requiredFields": [
+        {
+          "name": "platform",
+          "type": "string"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 2
+}

--- a/docs/log-schema.json
+++ b/docs/log-schema.json
@@ -1,0 +1,63 @@
+{
+  "$id": "https://accshift.app/schemas/log-record.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "One line of app.log. The file is JSONL: one record per line, never pretty-printed.",
+  "properties": {
+    "code": {
+      "description": "Catalog code. Every possible value is in log-catalog.json.",
+      "type": "string"
+    },
+    "durMs": {
+      "description": "Duration of the operation, on its closing record.",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "errKind": {
+      "description": "Machine-readable error family, so failures group without parsing msg.",
+      "type": "string"
+    },
+    "fields": {
+      "description": "Typed payload declared by the code. `_defects` lists validation failures, `_truncatedFields` counts values dropped or marked to fit the size budget.",
+      "type": "object"
+    },
+    "level": {
+      "description": "Severity. May be raised above the catalog default by the call site.",
+      "enum": ["trace", "debug", "info", "warn", "error"]
+    },
+    "msg": {
+      "description": "Human sentence. Never parse this: parse fields.",
+      "type": "string"
+    },
+    "opId": {
+      "description": "One per user-visible operation. Shared by every record of that attempt.",
+      "pattern": "^op-[0-9a-f]{12}$",
+      "type": "string"
+    },
+    "outcome": {
+      "description": "How an operation ended. Absent on records that do not close one.",
+      "enum": ["success", "failure", "cancelled"]
+    },
+    "runId": {
+      "description": "One per process launch. Scopes everything to a single session.",
+      "pattern": "^run-[0-9a-f]{12}$",
+      "type": "string"
+    },
+    "schemaVersion": {
+      "const": 2,
+      "description": "Version of this record shape. Version 1 is the legacy line: {tsMs, level, source, message, details}, no code and no fields."
+    },
+    "source": {
+      "description": "Dotted module the record came from, e.g. platform.steam. Drives the per-module level filter.",
+      "type": "string"
+    },
+    "tsMs": {
+      "description": "Unix milliseconds when the record was built.",
+      "minimum": 0,
+      "type": "integer"
+    }
+  },
+  "required": ["schemaVersion", "tsMs", "level", "code", "source", "runId", "fields"],
+  "title": "accshift log record",
+  "type": "object"
+}

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,329 @@
+# Logging and diagnostics
+
+The log is a diagnostic tool, not a stream of sentences. Every record carries a
+code from a closed catalog, a typed payload, the launch it belongs to and, for
+anything a user triggered, the operation it belongs to. That is what makes a
+failed attempt replayable from a single identifier instead of readable only by
+whoever wrote the message.
+
+## Where it lives
+
+The log directory is `logs/` under the app config directory:
+
+| OS      | Path                                                      |
+| ------- | --------------------------------------------------------- |
+| Windows | `%APPDATA%\com.accshift.desktop\logs`                     |
+| Linux   | `~/.config/com.accshift.desktop/logs`                     |
+| macOS   | `~/Library/Application Support/com.accshift.desktop/logs` |
+
+Debug builds add a `dev` segment (`logs/dev/`) so development never writes into
+the installed app's log.
+
+| File                       | What it is                                               |
+| -------------------------- | -------------------------------------------------------- |
+| `app.log`                  | Current log, JSONL, one record per line                  |
+| `app.1.log` to `app.4.log` | Rotated files, `app.1.log` being the most recent         |
+| `app.log.lock`             | Cross-process lock, plus the rotation generation counter |
+| `log-levels.json`          | Per-module levels and the temporary debug window         |
+| `anomalies.json`           | Failure streaks and duration baselines, across launches  |
+| `diagnostic-report.md`     | Last report written by `accshift diag bundle`            |
+
+`app.previous.log` is the legacy name of the single rotated file. It is
+migrated into `app.1.log` on the first launch that sees it, then never written
+again.
+
+## The record
+
+`docs/log-schema.json` is the generated JSON Schema, and it is the reference.
+The summary:
+
+| Column          | Always present | Meaning                                               |
+| --------------- | -------------- | ----------------------------------------------------- |
+| `schemaVersion` | yes            | `2`. Version 1 is the legacy line described below     |
+| `tsMs`          | yes            | Unix milliseconds when the record was built           |
+| `level`         | yes            | `trace`, `debug`, `info`, `warn`, `error`             |
+| `code`          | yes            | Catalog code. Every possible value is in the catalog  |
+| `source`        | yes            | Dotted module, for example `platform.steam`           |
+| `runId`         | yes            | `run-<12 hex>`, one per process launch                |
+| `fields`        | yes            | Typed payload declared by the code                    |
+| `msg`           | no             | Human sentence. Never parse this, parse `fields`      |
+| `opId`          | no             | `op-<12 hex>`, shared by every record of one attempt  |
+| `durMs`         | no             | Duration, on the record that closes an operation      |
+| `outcome`       | no             | `success`, `failure` or `cancelled`                   |
+| `errKind`       | no             | Error family, so failures group without parsing `msg` |
+
+One record, as it is actually written, on a single line:
+
+```text
+{"schemaVersion":2,"tsMs":1770000000000,"level":"error","code":"platform.switch.failed","source":"platform.steam","runId":"run-4f2a1c9d0e77","opId":"op-91b3ce70aa42","durMs":1840,"outcome":"failure","errKind":"client_running","msg":"Steam refused to exit","fields":{"platform":"steam","step":"kill-launcher"}}
+```
+
+Field names never collide with columns: a catalog field called `level` or
+`code` would make a filter silently match the wrong thing, so a test rejects
+one at build time. That is why the level-change event carries `newLevel` and
+the self-report event carries `offendingCode`.
+
+Two synthetic keys can appear inside `fields`: `_defects` lists declaration
+violations of the emitting call site, and `_truncatedFields` counts values
+dropped or shortened to fit the per-record size budget.
+
+Version 1 records, written by the legacy `append_app_log` facade, have exactly
+`tsMs`, `level`, `source`, `message` and `details`. Queries treat them as the
+code `legacy.record` so they still show up in a search rather than being
+skipped as unparsable.
+
+## Codes
+
+`crates/accshift-core/src/diagnostics/catalog.rs` is the single source of
+truth. The `event_catalog!` macro declares, for each code: its default level,
+what it means, what to do about it, its required fields with their types, its
+optional fields, and any former spelling kept as an alias.
+
+Consequences worth knowing:
+
+- A code that is not in the catalog does not compile. `event()` takes a
+  `&'static EventCode`, and those only exist as catalog constants.
+- A missing required field, or a field of the wrong type, fails the tests. In
+  debug builds it panics at the call site; in release it writes a second record
+  under `diagnostics.event.invalid` naming the offending code, so a broken call
+  site is findable rather than silent.
+- A code is never renamed without an alias. Old spellings keep resolving in
+  `--code` filters and in `--explain`, which is what lets a log written by an
+  older build stay queryable.
+
+`docs/log-catalog.json` is generated from the catalog and holds the 29 codes
+with their meaning, their action and their fields. Regenerate it after touching
+the catalog:
+
+```bash
+ACCSHIFT_UPDATE_DOCS=1 cargo test -p accshift-core   # regenerate both files
+accshift diag schema --write docs                    # same, from a built CLI
+cargo test -p accshift-core                          # fails if they drifted
+```
+
+The check compares the parsed value, not the bytes, so the repository
+formatter stays free to lay those files out as it likes.
+
+The families, in order of how often they matter:
+
+| Prefix                | What it covers                                          |
+| --------------------- | ------------------------------------------------------- |
+| `op.*`                | Operation opened, stepped, closed                       |
+| `platform.*`          | Switch and snapshot outcomes                            |
+| `health.*`            | Invariant results: paths, locks, launchers, disk, clock |
+| `anomaly.*`           | Patterns visible only across several runs               |
+| `log.*`               | Rotation, retention, write failures                     |
+| `diagnostics.*`       | Level changes, debug window, report written             |
+| `app.session.started` | One per launch, with the environment                    |
+
+## Operations
+
+Anything a user triggers opens an operation. It gets an `opId`, every record
+below it carries that same id, and the closing record carries the duration and
+the outcome.
+
+```rust
+let op = ops::start(&ctx, "platform.switch").platform("steam").trigger("gui").begin();
+op.step("kill-launcher");
+op.event(&catalog::HEALTH_LAUNCHER_RUNNING)
+    .field("platform", "steam")
+    .emit(&*op.ctx());
+op.fail("client_running", "Steam refused to exit");
+```
+
+`with_operation` wraps a `Result`-returning body and closes the operation from
+its outcome, mapping the error to the `errKind` vocabulary. An operation
+dropped without an explicit verdict closes itself as `cancelled` with a message
+saying so, so an early return or a panic still leaves a closing line rather
+than a hole.
+
+The GUI's diagnostic check and report actions are traced end to end and return
+their `opId` in the answer, which is the intended pattern for a UI: show the
+error, quote the id, let the user paste it into
+`accshift diag logs --op <id>`. The account switch chain is not instrumented
+yet; that migration is deliberately separate from this layer.
+
+## Levels
+
+The default level is `info`. Levels are per module, resolved by longest
+matching prefix on `source`, dot-bounded: an override on `platform` covers
+`platform.steam`, an override on `platform.steam` wins over it, and neither
+touches `platformer`.
+
+```bash
+accshift diag level                        # show the current levels
+accshift diag level --set debug            # change the default
+accshift diag level --module platform.steam --set trace
+accshift diag level --module platform.steam --reset
+accshift diag level --debug-for 15m        # temporary, reverts on its own
+accshift diag level --debug-for 15m --module platform.steam
+accshift diag level --stop-debug           # end the window now
+```
+
+A temporary window can only make logging more verbose, never quieter, and it is
+capped at one hour. It expires on its own: the next launch, or the next level
+lookup after the deadline, closes it and writes `diagnostics.debug.expired`.
+Nobody has to remember to turn it off, and nobody has to edit a file: the state
+lives in `log-levels.json`, written by the commands above.
+
+## Health invariants
+
+Invariants run before a risky action rather than after it fails. Each result is
+a code with an action attached, so a reader never has to look it up.
+
+| Check            | Code on failure                 | What it means                                |
+| ---------------- | ------------------------------- | -------------------------------------------- |
+| Path exists      | `health.path.missing`           | The configured directory or file is gone     |
+| Path writable    | `health.path.permission_denied` | It exists but a write probe fails            |
+| File unlocked    | `health.file.locked`            | Another process holds it                     |
+| Launcher stopped | `health.launcher.running`       | A process that must be closed is alive       |
+| Profile parses   | `health.profile.corrupt`        | A JSON file the action depends on is invalid |
+| Free space       | `health.disk.low`               | Less than the caller requires is available   |
+| Clock sane       | `health.clock.skew`             | System time moved backwards past tolerance   |
+
+A pass writes `health.check.passed` at `debug`, so a green run costs nothing at
+the default level but is there when the window is open.
+
+Callers describe what they need and let the report say what holds:
+
+```rust
+let report = health::Preflight::new()
+    .platform("steam")
+    .require_writable_path(&config_dir, "steam config")
+    .require_unlocked_file(&loginusers_vdf)
+    .require_stopped(&["steam.exe"])
+    .require_valid_json(&accounts_json)
+    .require_free_space(&config_dir, 8 * 1024 * 1024)
+    .run_and_emit(&ctx, Some(op.id()));
+if let Some(reason) = report.blocking_reason() {
+    return Err(reason);
+}
+```
+
+The startup report checks the log root is writable, that 32 MiB is free, and
+that the clock is sane.
+
+## Anomaly counters
+
+Some problems only exist across runs, so a few counters survive in
+`anomalies.json`:
+
+| Code                                    | Trigger                                         |
+| --------------------------------------- | ----------------------------------------------- |
+| `anomaly.platform.consecutive_failures` | 3 failures in a row on one platform             |
+| `anomaly.operation.slow`                | Far above this operation's own rolling baseline |
+| `anomaly.snapshot.empty`                | A snapshot captured nothing                     |
+| `anomaly.restore.no_write`              | A restore wrote nothing                         |
+
+The slow-operation baseline is a rolling mean and variance over successful runs
+only, so an early-aborting failure cannot drag the mean down and make everything
+else look slow. It needs 8 samples before it accuses anything, and it requires
+both 3 sigma and 1.5 times the mean, with a 750 ms floor, so a fast stable
+operation is never reported for a few extra milliseconds.
+
+## Rotation, retention and disk budget
+
+| Setting                       | Value   |
+| ----------------------------- | ------- |
+| Maximum size of `app.log`     | 2 MiB   |
+| Rotated files kept            | 4       |
+| Maximum age of a rotated file | 14 days |
+| Announced disk budget         | 10 MiB  |
+
+Rotation happens before the write that would breach the cap, never after, so
+the cap holds. Files older than the retention window are purged at rotation and
+the purge writes `log.retention.purged`.
+
+The CLI and the GUI write the same file, and both take the same exclusive lock
+on `app.log.lock`. Since rotation renames the file another process may be
+holding open, the first 8 bytes of that lock file hold a generation counter:
+a rotating process bumps it, and any peer that finds a newer generation than
+its own drops its handle and reopens `app.log` instead of appending into a file
+that is now named `app.1.log`.
+
+## What never reaches the log
+
+The redaction applies to messages and, recursively, to every string reachable
+from `fields`, including object keys. It removes email addresses, BattleTags,
+UUIDs and PUUIDs, and rewrites paths that contain the OS account name into a
+placeholder.
+
+A log record never contains a token, a password, a cookie, the contents of a
+`.maFile`, or a path still carrying an unredacted system user name. Identifiers
+with no stable shape, Steam login names and persona names in particular, are
+kept out at the call sites, because any pattern broad enough to catch them
+would also eat ordinary words.
+
+Nothing here reaches the network. The diagnostic report is a local file, and
+none of this data joins the analytics described in
+[analytics.md](./analytics.md).
+
+## Reading the log
+
+```bash
+accshift diag logs                              # last 200 records
+accshift diag logs --op op-91b3ce70aa42         # one attempt, in order
+accshift diag logs --run run-4f2a1c9d0e77       # one launch
+accshift diag logs --level warn --since 6h
+accshift diag logs --code platform.switch.failed --code anomaly.operation.slow
+accshift diag logs --source platform --platform steam --contains vdf
+accshift diag logs --all --json > log.jsonl
+accshift diag explain platform.switch.failed
+accshift diag check
+accshift diag bundle
+```
+
+Filters combine with AND. `--since` accepts `90s`, `30m`, `6h`, `7d`, and a
+bare number is minutes. `--code` resolves aliases, so an old spelling finds
+records written under the new one and the reverse. Piping switches the output
+to the `accshift.v1` JSON envelope; a terminal gets a table. Rotated files are
+searched too, oldest first, and the result reports how many lines were scanned
+and how many could not be parsed.
+
+The GUI exposes the same surface through one command, `diagnostics`, taking a
+tagged request (`logs`, `summary`, `explain`, `check`, `levels`, `setLevel`,
+`startTemporaryDebug`, `stopTemporaryDebug`, `bundle`, `schema`).
+
+## The diagnostic report
+
+```bash
+accshift diag bundle                 # writes diagnostic-report.md, says where
+accshift diag bundle --print         # also prints it
+accshift diag bundle --op op-91b3ce70aa42 --level debug --records 500
+accshift diag bundle --no-config     # leave the configuration out entirely
+```
+
+One file, pasteable, capped at 256 KiB, holding: app and OS version, the health
+invariants, the anomaly counters, log storage state, current levels, a redacted
+configuration summary, the codes present with what to do about each, and the
+recent log as JSONL. The log tail is the only section that gets cut, and the
+cut is announced in the file.
+
+The configuration summary is deny-by-default: any key whose name suggests a
+secret becomes `<set>` or `<unset>`, booleans and numbers are kept, and a
+string is kept only if its key is on the allow-list, otherwise it becomes
+`<redacted len=N>`. A new config field is therefore redacted until someone
+decides it is safe, not the reverse.
+
+## Debugging with this
+
+For an agent or a human working from a failure report:
+
+1. Get the `opId` from the user, or find the failure:
+   `accshift diag logs --level error --since 24h --json`.
+2. Replay the whole attempt in order: `accshift diag logs --op <id> --json`.
+   The last `op.step` before the failing record is where it broke, and
+   `errKind` on the closing record says which family it belongs to.
+3. Ask what the code means and what to do:
+   `accshift diag explain <code>` returns the meaning, the action and the
+   declared fields.
+4. Check whether it is a state problem rather than a code problem:
+   `accshift diag check` runs the invariants.
+5. Ask whether it repeats: `anomaly.*` codes in
+   `accshift diag logs --code anomaly.platform.consecutive_failures`.
+6. Need more detail: `accshift diag level --debug-for 15m --module <module>`,
+   reproduce, read again. The window closes itself.
+7. Everything at once for a report: `accshift diag bundle --print`.
+
+Parse `fields`, never `msg`. Codes and field names are stable, message wording
+is not.

--- a/src-tauri/src/commands_diagnostics.rs
+++ b/src-tauri/src/commands_diagnostics.rs
@@ -1,0 +1,316 @@
+//! Diagnostics exposed to the UI.
+//!
+//! One command, one tagged request, so the whole surface costs a single
+//! registration line and the frontend gets a discriminated union it can type.
+//!
+//! Everything here reads or writes files inside the log directory. Nothing
+//! reaches the network, and nothing feeds the telemetry: the diagnostic report
+//! is a local file the user reads before deciding whether to share it.
+
+use crate::ctx;
+use accshift_core::diagnostics::{
+    bundle,
+    event::{Level, Outcome},
+    health, levels, ops, query, schema,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "action", rename_all = "camelCase")]
+pub enum DiagnosticsRequest {
+    /// Log records matching a filter, newest last.
+    #[serde(rename_all = "camelCase")]
+    Logs {
+        #[serde(default)]
+        codes: Vec<String>,
+        #[serde(default)]
+        min_level: Option<String>,
+        #[serde(default)]
+        op_id: Option<String>,
+        #[serde(default)]
+        run_id: Option<String>,
+        #[serde(default)]
+        platform: Option<String>,
+        #[serde(default)]
+        source: Option<String>,
+        #[serde(default)]
+        since_ms: Option<u64>,
+        #[serde(default)]
+        contains: Option<String>,
+        #[serde(default)]
+        limit: Option<usize>,
+    },
+    /// What is in the log right now, per code and per level.
+    Summary,
+    /// The catalog entry behind one code.
+    Explain { code: String },
+    /// Run the health invariants.
+    Check,
+    /// Current per-module levels and the temporary window, if any.
+    Levels,
+    /// Change one module's level, or the default when `module` is absent.
+    /// A null `level` drops the override.
+    #[serde(rename_all = "camelCase")]
+    SetLevel {
+        #[serde(default)]
+        module: Option<String>,
+        #[serde(default)]
+        level: Option<String>,
+    },
+    /// Turn on verbose logging for a while. It reverts on its own.
+    #[serde(rename_all = "camelCase")]
+    StartTemporaryDebug {
+        duration_ms: u64,
+        #[serde(default)]
+        modules: Vec<String>,
+        #[serde(default)]
+        level: Option<String>,
+    },
+    /// End the temporary window now.
+    StopTemporaryDebug,
+    /// Write the diagnostic report and return where it went.
+    #[serde(rename_all = "camelCase")]
+    Bundle {
+        #[serde(default)]
+        records: Option<usize>,
+        #[serde(default)]
+        min_level: Option<String>,
+        #[serde(default)]
+        op_id: Option<String>,
+        #[serde(default)]
+        include_config: Option<bool>,
+        /// Return the report text as well as its path.
+        #[serde(default)]
+        include_text: bool,
+    },
+    /// The record schema, the catalog and the retention policy.
+    Schema,
+}
+
+fn parse_level(value: &str) -> Result<Level, String> {
+    Level::parse(value).ok_or_else(|| format!("unknown_level:{value}"))
+}
+
+/// Single entry point for every diagnostic action.
+///
+/// `async` so the file reads run on the blocking pool rather than the UI
+/// thread, like the rest of the IO-touching commands.
+#[tauri::command(async)]
+pub fn diagnostics(
+    app_handle: tauri::AppHandle,
+    request: DiagnosticsRequest,
+) -> Result<Value, String> {
+    let context = ctx(&app_handle);
+
+    match request {
+        DiagnosticsRequest::Logs {
+            codes,
+            min_level,
+            op_id,
+            run_id,
+            platform,
+            source,
+            since_ms,
+            contains,
+            limit,
+        } => {
+            let filter = query::Filter {
+                codes,
+                min_level: min_level.as_deref().map(parse_level).transpose()?,
+                op_id,
+                run_id,
+                platform,
+                source,
+                outcome: None,
+                since_ms: since_ms.map(u128::from),
+                until_ms: None,
+                contains,
+                limit: Some(limit.unwrap_or(200)),
+            };
+            let result = query::search(&context, &filter)?;
+            Ok(json!({
+                "records": result.entries.iter().map(|entry| entry.raw.clone()).collect::<Vec<_>>(),
+                "scanned": result.scanned,
+                "unparsable": result.unparsable,
+                "droppedByLimit": result.dropped_by_limit,
+                "files": result.files,
+            }))
+        }
+
+        DiagnosticsRequest::Summary => query::summary(&context),
+
+        DiagnosticsRequest::Explain { code } => {
+            query::explain(&code).ok_or_else(|| format!("unknown_code:{code}"))
+        }
+
+        // Traced end to end: the invariant records carry this operation's
+        // `opId`, so `accshift diag logs --op <id>` replays the whole check,
+        // and the answer hands that id back for the UI to quote.
+        DiagnosticsRequest::Check => {
+            let op = ops::start(&context, "diagnostics.check")
+                .trigger("gui")
+                .begin();
+            op.step("invariants");
+            let report = health::startup_report(&context);
+            health::emit(&context, &report, Some(op.id()), None);
+
+            let mut payload = report.to_json();
+            payload["opId"] = json!(op.id());
+
+            match report.blocking_reason() {
+                Some(reason) => {
+                    op.finish(Outcome::Failure, Some("invariant_failed"), Some(&reason))
+                }
+                None => op.succeed(),
+            }
+            Ok(payload)
+        }
+
+        DiagnosticsRequest::Levels => {
+            Ok(levels::load(&context).to_json(accshift_core::diagnostics::event::now_unix_ms()))
+        }
+
+        DiagnosticsRequest::SetLevel { module, level } => {
+            let level = level.as_deref().map(parse_level).transpose()?;
+            let config = levels::set_level(&context, module.as_deref(), level)?;
+            Ok(config.to_json(accshift_core::diagnostics::event::now_unix_ms()))
+        }
+
+        DiagnosticsRequest::StartTemporaryDebug {
+            duration_ms,
+            modules,
+            level,
+        } => {
+            let level = match level.as_deref() {
+                Some(level) => parse_level(level)?,
+                None => Level::Debug,
+            };
+            let config = levels::start_temporary_debug(&context, level, modules, duration_ms)?;
+            Ok(config.to_json(accshift_core::diagnostics::event::now_unix_ms()))
+        }
+
+        DiagnosticsRequest::StopTemporaryDebug => {
+            let config = levels::stop_temporary_debug(&context)?;
+            Ok(config.to_json(accshift_core::diagnostics::event::now_unix_ms()))
+        }
+
+        DiagnosticsRequest::Bundle {
+            records,
+            min_level,
+            op_id,
+            include_config,
+            include_text,
+        } => {
+            let defaults = bundle::Options::default();
+            let options = bundle::Options {
+                records: records.unwrap_or(defaults.records),
+                min_level: min_level
+                    .as_deref()
+                    .map(parse_level)
+                    .transpose()?
+                    .unwrap_or(defaults.min_level),
+                op_id,
+                include_config: include_config.unwrap_or(true),
+                app_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            };
+            let op = ops::start(&context, "diagnostics.bundle")
+                .trigger("gui")
+                .begin();
+            op.step("render");
+            let written = bundle::write(&context, &options);
+            let (path, bytes) = match written {
+                Ok(written) => written,
+                Err(error) => {
+                    op.finish(Outcome::Failure, Some("write_failed"), Some(&error));
+                    return Err(error);
+                }
+            };
+
+            let text = if include_text {
+                op.step("read-back");
+                std::fs::read_to_string(&path).ok()
+            } else {
+                None
+            };
+            let op_id = op.id().to_string();
+            op.succeed();
+
+            Ok(json!({
+                "path": path.display().to_string(),
+                "bytes": bytes,
+                "text": text,
+                "opId": op_id,
+            }))
+        }
+
+        DiagnosticsRequest::Schema => Ok(schema::to_json()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The frontend sends camelCase. A mismatch here fails at runtime with a
+    // deserialization error nobody reads, so it is worth a test.
+    #[test]
+    fn the_request_shape_is_the_one_the_ui_sends() {
+        let request: DiagnosticsRequest = serde_json::from_value(json!({
+            "action": "logs",
+            "codes": ["op.finished"],
+            "minLevel": "warn",
+            "opId": "op-0123456789ab",
+            "limit": 50,
+        }))
+        .expect("logs request");
+        match request {
+            DiagnosticsRequest::Logs {
+                codes,
+                min_level,
+                op_id,
+                limit,
+                ..
+            } => {
+                assert_eq!(codes, ["op.finished"]);
+                assert_eq!(min_level.as_deref(), Some("warn"));
+                assert_eq!(op_id.as_deref(), Some("op-0123456789ab"));
+                assert_eq!(limit, Some(50));
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+
+        let request: DiagnosticsRequest = serde_json::from_value(json!({
+            "action": "startTemporaryDebug",
+            "durationMs": 900_000,
+            "modules": ["platform.steam"],
+        }))
+        .expect("temporary debug request");
+        match request {
+            DiagnosticsRequest::StartTemporaryDebug {
+                duration_ms,
+                modules,
+                level,
+            } => {
+                assert_eq!(duration_ms, 900_000);
+                assert_eq!(modules, ["platform.steam"]);
+                assert!(level.is_none());
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_action_with_no_payload_needs_no_payload() {
+        for action in ["summary", "check", "levels", "stopTemporaryDebug", "schema"] {
+            serde_json::from_value::<DiagnosticsRequest>(json!({ "action": action }))
+                .unwrap_or_else(|error| panic!("{action} must deserialize alone: {error}"));
+        }
+    }
+
+    #[test]
+    fn an_unknown_level_is_refused_before_anything_is_written() {
+        assert_eq!(parse_level("loud"), Err("unknown_level:loud".to_string()));
+        assert_eq!(parse_level("warning"), Ok(Level::Warn));
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,6 +9,7 @@ use tauri::Manager;
 
 mod app_runtime;
 mod commands;
+mod commands_diagnostics;
 mod commands_telemetry;
 mod tauri_context;
 mod telemetry_runtime;
@@ -420,6 +421,7 @@ fn main() {
             // Utility
             commands::open_url,
             commands::open_logs_folder,
+            commands_diagnostics::diagnostics,
             // Window
             commands::minimize_window,
             commands::toggle_maximize_window,


### PR DESCRIPTION
## Summary

log records now carry a schema version, a code from a compiled catalog, a typed field bag, a runId and, for user-triggered work, an opId with durMs and outcome, so one failed attempt replays from a single identifier. rotation holds an announced 10 MiB budget through a generation counter in the existing app.log.lock, which keeps the CLI and the GUI sharing the file. adds per-module levels with a self-closing verbose window, seven health invariants, cross-run anomaly counters, `accshift diag logs|explain|check|level|bundle|schema`, and docs/logging.md.

`append_app_log` stays a facade with identical behaviour: the 38 existing call sites and platforms/ are untouched, their migration comes later. src-tauri gets two lines, `mod commands_diagnostics;` and one handler entry.

worth a look: health results are redacted in `CheckResult::to_json` and `blocking_reason`, not only on the way to app.log, because the diagnostic report prints them and that file is the one users paste. the report itself is local, redacted by default, and no telemetry event was added.

## Related issue

none.

## Tested on

- [x] Windows
- [ ] macOS
- [ ] Linux

## Checklist

- [x] CI checks pass locally (see [CONTRIBUTING.md](.github/CONTRIBUTING.md))
- [x] Docs or wiki updated if the change is user-facing
- [x] No secrets, session tokens or captured account data in the diff
