### PR TITLE
fix(telemetry): deploy the worker from CI, report the operations that never fired

### DIFF
--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -1,0 +1,59 @@
+name: Deploy telemetry worker
+
+# The Worker was deployed by hand, so `server/src/index.ts` and the live
+# endpoint drifted apart: v1.0.3 shipped `surface`, `ui_language`,
+# `enabled_platforms` and eight other properties that the deployed revision
+# had never heard of and dropped on the floor. Every one of them read as null
+# in PostHog for three weeks and nothing anywhere said so.
+#
+# A merge to main that touches `server/` is now the deploy. Nothing to
+# remember, and no way for the two to disagree again.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "server/**"
+      - ".github/workflows/worker.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Two deploys racing would leave the live Worker on whichever finished last,
+# not on the newest commit.
+concurrency:
+  group: deploy-telemetry-worker
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Only used for the Node runtime here; the Worker itself is a plain pnpm
+      # package driven through corepack, exactly as CI does it.
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@313600b80b104eadebb9111787d37a2e83e014ca # v1.17.0
+        with:
+          node-version: 22
+          cache: true
+
+      - name: Install server dependencies
+        run: corepack pnpm --dir server install --frozen-lockfile
+
+      # CI already typechecks on the pull request. Repeated here because this
+      # job is what reaches production, and a green PR that went stale behind a
+      # merge must not push a broken Worker.
+      - name: Typecheck
+        run: corepack pnpm --dir server exec tsc --noEmit
+
+      - name: Deploy
+        run: corepack pnpm --dir server exec wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/crates/accshift-core/src/telemetry/events.rs
+++ b/crates/accshift-core/src/telemetry/events.rs
@@ -169,6 +169,9 @@ pub const OPERATIONS: &[&str] = &[
     "account_add",
     "account_forget",
     "profile_capture",
+    // Reserved. Roblox's session probe swallows every per-account failure and
+    // answers with a list either way, so there is no failure for the command
+    // to report yet.
     "session_check",
     "bulk_edit",
     "game_settings_copy",

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -104,6 +104,15 @@ Steam, in either direction.
 installation that predates the release introducing it, it fires on the first
 launch after the update rather than on the day it was installed.
 
+Between 5 and 24 August 2026 the server was running a revision older than the
+app. Version 1.0.3 started sending eleven properties it did not recognise, and
+an unrecognised property is dropped rather than stored, so `surface`, the OS
+and architecture identifiers, `success`, `error_code`, `operation`, `command`
+and every field of `settings_snapshot` are empty on the events recorded in that
+window. Less was collected than this page describes, never more. Deploying the
+server is now part of merging a change to it, so the two cannot drift apart
+again.
+
 This table is checked against the code on every release. Where this page and the
 code disagree, the code is right and the page is a bug worth reporting.
 

--- a/server/README.md
+++ b/server/README.md
@@ -162,8 +162,30 @@ property the app had learned to send in between.
 
 It needs two repository secrets:
 
-- `CLOUDFLARE_API_TOKEN`, scoped to "Edit Cloudflare Workers" on this account
-- `CLOUDFLARE_ACCOUNT_ID`
+- `CLOUDFLARE_API_TOKEN`
+- `CLOUDFLARE_ACCOUNT_ID`, the id `npx wrangler whoami` prints
+
+The `wrangler login` session on a developer's machine cannot be reused here: it
+is an OAuth session, not a credential a runner can carry. Create an API token
+instead, from the "Edit Cloudflare Workers" template (Cloudflare dashboard, My
+Profile, API Tokens, Create Token). The template fills the permission list but
+leaves both resource selectors empty, and each one has to be set:
+
+- Account Resources: include the account that owns the Worker.
+- Zone Resources: include the zone of the `routes` custom domain. The template
+  carries `Zone > Workers Routes > Edit` precisely for this. Every
+  `wrangler deploy` reattaches the custom domain, so a token missing the zone
+  fails at that step rather than at upload.
+
+Verify the token before trusting the workflow with it, since a scope mistake
+only surfaces on the next merge:
+
+```bash
+CLOUDFLARE_API_TOKEN=... CLOUDFLARE_ACCOUNT_ID=... npx wrangler deploy
+```
+
+A successful run prints `Deployed accshift-telemetry triggers` followed by the
+custom domain, which is the line proving the zone permission resolved.
 
 Deploying by hand stays available for a fork or an emergency:
 

--- a/server/README.md
+++ b/server/README.md
@@ -154,9 +154,26 @@ but do not do it casually.
 
 ### Deploy
 
+A merge to `main` that touches `server/` deploys the Worker
+(`.github/workflows/worker.yml`). Nothing else does, and nothing has to be
+remembered: this workflow exists because the manual step was skipped once and
+the live Worker sat three weeks behind `index.ts`, silently dropping every
+property the app had learned to send in between.
+
+It needs two repository secrets:
+
+- `CLOUDFLARE_API_TOKEN`, scoped to "Edit Cloudflare Workers" on this account
+- `CLOUDFLARE_ACCOUNT_ID`
+
+Deploying by hand stays available for a fork or an emergency:
+
 ```bash
 pnpm deploy
 ```
+
+Whichever route it takes, verify the deploy landed rather than trusting a green
+job: send one event and check that a property added since the last deploy is
+present on it, not null.
 
 ### Local dev
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,5 +1,5 @@
 use crate::ctx;
-use crate::platforms::{require_service, SetupStatus};
+use crate::platforms::{ids, require_service, SetupStatus};
 use crate::telemetry;
 use crate::telemetry_runtime::TelemetryState;
 use accshift_core::error::PlatformError;
@@ -46,6 +46,37 @@ where
         f(c)
     })
     .await
+}
+
+/// Reports a failed operation to telemetry, then hands the result straight
+/// back to the caller.
+///
+/// Both halves of the event come from closed vocabularies:
+/// `telemetry::OPERATIONS` for the name, `error_code_for_kind` for the typed
+/// error family. Wrapping a command in this therefore cannot turn a message,
+/// a path or an account name into a property, whatever the failure carried.
+///
+/// It exists because `operation_failed` declared eleven operations and only
+/// ever emitted one: every other feature failed silently as far as any
+/// dashboard was concerned, so "which one breaks on real machines" had no
+/// answer. Only the `Err` branch touches the queue; a success costs nothing.
+fn track_operation<T>(
+    app_handle: &tauri::AppHandle,
+    operation: &str,
+    platform_id: Option<&str>,
+    result: Result<T, PlatformError>,
+) -> Result<T, PlatformError> {
+    if let Err(error) = &result {
+        app_handle
+            .state::<TelemetryState>()
+            .handle
+            .track(telemetry::Event::OperationFailed {
+                operation: operation.to_string(),
+                platform: platform_id.map(str::to_string),
+                error_code: telemetry::error_code_for_kind(error.kind).to_string(),
+            });
+    }
+    result
 }
 
 #[tauri::command]
@@ -227,7 +258,6 @@ fn emit_first_run_once(app_handle: &tauri::AppHandle, tstate: &TelemetryState) {
 /// Every `accounts_snapshot` emitted by those releases therefore says nothing
 /// about Steam, and no dashboard can reconstruct it.
 fn emit_accounts_snapshots(app_handle: &tauri::AppHandle, tstate: &TelemetryState) {
-    use crate::platforms::ids;
     let c = ctx(app_handle);
     let cfg = crate::config::load_config(&c);
     // Steam is the one platform whose accounts need a disk read rather than a
@@ -400,10 +430,11 @@ pub async fn platform_forget_account(
 ) -> Result<(), PlatformError> {
     let service = require_service(&platform_id)?;
     let c = ctx(&app_handle);
-    run_locked_blocking("platform_forget_account", c, move |c| {
+    let result = run_locked_blocking("platform_forget_account", c, move |c| {
         service.forget_account(c, &account_id)
     })
-    .await
+    .await;
+    track_operation(&app_handle, "account_forget", Some(&platform_id), result)
 }
 
 #[tauri::command]
@@ -416,10 +447,16 @@ pub async fn platform_begin_setup(
     let c = ctx(&app_handle);
     // Setup flows can stop launchers and touch live auth files before they
     // persist config, so they need the same operation lock as switch/forget.
-    run_locked_blocking("platform_begin_setup", c, move |c| {
+    // A setup that never opens is invisible to the add funnel otherwise: the
+    // frontend swallows this error into a toast, so no `account_add_started`
+    // and no failure is recorded. The typed kind here is also the only place
+    // the funnel gets a real reason (`client_not_installed`, `client_running`)
+    // instead of the `other` a mid-flow failure collapses to.
+    let result = run_locked_blocking("platform_begin_setup", c, move |c| {
         service.begin_setup(c, params)
     })
-    .await
+    .await;
+    track_operation(&app_handle, "account_add", Some(&platform_id), result)
 }
 
 #[tauri::command]
@@ -1043,9 +1080,11 @@ pub async fn cs2_bridge_fetch(
     app_handle: tauri::AppHandle,
     client: tauri::State<'_, reqwest::Client>,
 ) -> Result<Vec<crate::platforms::steam::cs2_bridge::Cs2BridgeAccount>, PlatformError> {
-    crate::platforms::steam::cs2_bridge::fetch_accounts(&ctx(&app_handle), client.inner())
-        .await
-        .map_err(Into::into)
+    let result =
+        crate::platforms::steam::cs2_bridge::fetch_accounts(&ctx(&app_handle), client.inner())
+            .await
+            .map_err(Into::into);
+    track_operation(&app_handle, "cs2_bridge_fetch", Some(ids::STEAM), result)
 }
 
 /// Check a la demande d'un compte (declenche au switch). `None` si le bridge
@@ -1103,8 +1142,13 @@ pub async fn steam_get_profile_infos(
     std::collections::HashMap<String, crate::platforms::steam::profile::ProfileInfo>,
     PlatformError,
 > {
-    crate::platforms::steam::get_profile_infos(ctx(&app_handle), steam_ids, client.inner().clone())
-        .await
+    let result = crate::platforms::steam::get_profile_infos(
+        ctx(&app_handle),
+        steam_ids,
+        client.inner().clone(),
+    )
+    .await;
+    track_operation(&app_handle, "avatar_refresh", Some(ids::STEAM), result)
 }
 
 #[tauri::command]
@@ -1113,8 +1157,13 @@ pub async fn steam_get_player_bans(
     steam_ids: Vec<String>,
     client: tauri::State<'_, reqwest::Client>,
 ) -> Result<Vec<crate::platforms::steam::bans::BanInfo>, PlatformError> {
-    crate::platforms::steam::get_player_bans(ctx(&app_handle), steam_ids, client.inner().clone())
-        .await
+    let result = crate::platforms::steam::get_player_bans(
+        ctx(&app_handle),
+        steam_ids,
+        client.inner().clone(),
+    )
+    .await;
+    track_operation(&app_handle, "ban_check", Some(ids::STEAM), result)
 }
 
 #[tauri::command]
@@ -1125,10 +1174,11 @@ pub async fn steam_copy_game_settings(
     app_id: String,
 ) -> Result<(), PlatformError> {
     let c = ctx(&app_handle);
-    run_locked_blocking("steam_copy_game_settings", c, move |c| {
+    let result = run_locked_blocking("steam_copy_game_settings", c, move |c| {
         crate::platforms::steam::copy_game_settings(c, from_steam_id, to_steam_id, app_id)
     })
-    .await
+    .await;
+    track_operation(&app_handle, "game_settings_copy", Some(ids::STEAM), result)
 }
 
 #[tauri::command(async)]
@@ -1165,10 +1215,11 @@ pub async fn steam_bulk_edit(
     request: crate::platforms::steam::bulk_edit::BulkEditRequest,
 ) -> Result<crate::platforms::steam::bulk_edit::BulkEditResult, PlatformError> {
     let c = ctx(&app_handle);
-    run_locked_blocking("steam_bulk_edit", c, move |c| {
+    let result = run_locked_blocking("steam_bulk_edit", c, move |c| {
         crate::platforms::steam::bulk_edit(c, request)
     })
-    .await
+    .await;
+    track_operation(&app_handle, "bulk_edit", Some(ids::STEAM), result)
 }
 
 #[tauri::command(async)]
@@ -1190,10 +1241,11 @@ pub async fn riot_capture_profile(
     profile_id: String,
 ) -> Result<(), PlatformError> {
     let c = ctx(&app_handle);
-    run_locked_blocking("riot_capture_profile", c, move |c| {
+    let result = run_locked_blocking("riot_capture_profile", c, move |c| {
         crate::platforms::riot::capture_profile(c, profile_id).map_err(Into::into)
     })
-    .await
+    .await;
+    track_operation(&app_handle, "profile_capture", Some(ids::RIOT), result)
 }
 
 // ---------------------------------------------------------------------------
@@ -1228,13 +1280,18 @@ pub async fn roblox_add_account_by_cookie(
     cookie: String,
     client: tauri::State<'_, reqwest::Client>,
 ) -> Result<crate::platforms::roblox::RobloxAccount, PlatformError> {
-    crate::platforms::roblox::add_account_by_cookie(
+    // The cookie paste is a second way into "add a Roblox account", next to
+    // Quick Login, and it never went through the add-flow controller that
+    // reports the other platforms. Its failures land here; its start and its
+    // success are reported by the settings tab that owns the form.
+    let result = crate::platforms::roblox::add_account_by_cookie(
         ctx(&app_handle),
         cookie,
         client.inner().clone(),
     )
     .await
-    .map_err(Into::into)
+    .map_err(Into::into);
+    track_operation(&app_handle, "account_add", Some(ids::ROBLOX), result)
 }
 
 #[cfg(windows)]
@@ -1284,4 +1341,32 @@ pub fn save_custom_theme(
 #[tauri::command(async)]
 pub fn delete_custom_theme(app_handle: tauri::AppHandle, theme_id: String) -> Result<(), String> {
     crate::themes::delete_custom_theme(&ctx(&app_handle), &theme_id)
+}
+
+#[cfg(test)]
+mod tests {
+    /// Guards every `track_operation` call site against a typo.
+    ///
+    /// `code_from` maps an unlisted operation onto `other` rather than
+    /// dropping it, which is the right behaviour on the wire and the worst one
+    /// to debug: a misspelt name produces a plausible event that quietly joins
+    /// the pile of unclassified failures. Reading the call sites out of the
+    /// source keeps this from becoming a second list that drifts from them.
+    #[test]
+    fn tracked_operations_are_in_the_vocabulary() {
+        let source = include_str!("commands.rs");
+        // Assembled at runtime so the marker never appears whole in this file:
+        // written as one literal, the scan below would match its own source.
+        let marker = format!("{}(&app_handle, {}", "track_operation", '"');
+        let mut sites = 0;
+        for call in source.split(marker.as_str()).skip(1) {
+            let name = call.split('"').next().expect("operation name literal");
+            assert!(
+                crate::telemetry::OPERATIONS.contains(&name),
+                "`{name}` is not in telemetry::OPERATIONS and would be reported as `other`"
+            );
+            sites += 1;
+        }
+        assert!(sites >= 8, "expected the wired call sites, found {sites}");
+    }
 }

--- a/src/lib/platforms/roblox/RobloxSettingsTab.svelte
+++ b/src/lib/platforms/roblox/RobloxSettingsTab.svelte
@@ -6,6 +6,7 @@
   import { addToast } from "$lib/features/notifications/store.svelte";
   import { addAccountByCookie } from "./robloxApi";
   import { clearRobloxSessionExpired } from "./warnings";
+  import { trackAccountAdded, trackAccountAddStarted } from "$lib/app/telemetryClient";
 
   let {
     settings = $bindable(),
@@ -28,8 +29,15 @@
     if (!trimmed || isAdding) return;
     isAdding = true;
     errorMessage = "";
+    // The cookie paste is the second door into "add a Roblox account" and it
+    // bypasses the add-flow controller, which is where every other platform
+    // reports its funnel. Roblox therefore counted zero adds forever while
+    // reporting a hundred snapshots. The failure half is reported backend-side
+    // by `roblox_add_account_by_cookie`, which has the typed error kind.
+    trackAccountAddStarted("roblox");
     try {
       const account = await addAccountByCookie(trimmed);
+      trackAccountAdded("roblox");
       // The paste may re-link an account previously flagged as expired; the
       // fresh cookie supersedes that state.
       clearRobloxSessionExpired(account.userId);

--- a/src/lib/theme/schema.ts
+++ b/src/lib/theme/schema.ts
@@ -84,14 +84,11 @@ const FORBIDDEN_CSS: ReadonlyArray<{ label: string; pattern: RegExp }> = [
 // `url` and a hex-escaped `url(` match the same constructs a style tag would.
 function normalizeCssForSafety(css: string): string {
   const withoutComments = css.replace(/\/\*[\s\S]*?\*\//g, "");
-  return withoutComments.replace(
-    /\\([0-9a-fA-F]{1,6})(?:\r\n|[ \t\f\n\r])?/g,
-    (_, hex: string) => {
-      const code = Number.parseInt(hex, 16);
-      if (code === 0 || code > 0x10ffff) return "";
-      return String.fromCodePoint(code);
-    },
-  );
+  return withoutComments.replace(/\\([0-9a-fA-F]{1,6})(?:\r\n|[ \t\f\n\r])?/g, (_, hex: string) => {
+    const code = Number.parseInt(hex, 16);
+    if (code === 0 || code > 0x10ffff) return "";
+    return String.fromCodePoint(code);
+  });
 }
 
 /** The construct that makes this CSS unusable, or null when it is clean. */

--- a/src/lib/theme/themes.ts
+++ b/src/lib/theme/themes.ts
@@ -427,7 +427,9 @@ export function resolveThemeSurfaceOpacities(
   const isLiquid = liquid && backdropAvailable;
   const windowOpacity = theme.glass
     ? backdropAvailable
-      ? (liquid ? GLASS_WINDOW_OPACITY["liquid-glass"] : (GLASS_WINDOW_OPACITY[theme.id] ?? 0.55))
+      ? liquid
+        ? GLASS_WINDOW_OPACITY["liquid-glass"]
+        : (GLASS_WINDOW_OPACITY[theme.id] ?? 0.55)
       : 0.96
     : rawOpacity;
   const cardOpacity = isLiquid


### PR DESCRIPTION
la question de depart: gog et jagex sont absents du graphe telemetrie. reponse courte, ils ont zero event de n'importe quel type, et la raison pour laquelle on ne peut pas trancher entre "personne ne les utilise" et "personne ne les active" est un bug de pipeline.

## le worker en prod est en retard

`server/src/index.ts` se deploie a la main. e038b43 (5 aout) lui a appris onze proprietes, v1.0.3 les envoie depuis le 5 aout, et `wrangler deploy` n'est jamais passe. le worker live jette tout ce qu'il ne connait pas.

sur les 2061 events des vingt derniers jours:

| propriete | present |
| --- | --- |
| `app_version` | 2061 |
| `country` | 2045 |
| `locale` | 1879 |
| `duration_ms` | 1062 |
| `os`, `arch`, `surface` | 0 |
| `success`, `error_code`, `operation`, `command` | 0 |

et les 128 `settings_snapshot` (5 au 24 aout, tous mode B) arrivent avec `ui_language`, `enabled_platforms`, `personas_enabled` et `streamer_mode` a null. `enabled_platforms` est exactement le champ qui repond a "est-ce que quelqu'un active gog ou jagex sans jamais y mettre de compte".

`.github/workflows/worker.yml` fait du merge sur `main` touchant `server/` le deploiement, avec typecheck avant. il faut deux secrets sur le repo:

- `CLOUDFLARE_API_TOKEN`, scope "Edit Cloudflare Workers"
- `CLOUDFLARE_ACCOUNT_ID`

sans eux le job echoue, il ne deploie rien de casse.

## les operations qui ne partaient jamais

`telemetry::OPERATIONS` declare onze operations. `commands.rs` en emettait une seule (`account_add`, avec `error_code` code en dur a `other`).

`track_operation` habille les neuf commandes qui echouent avec un `PlatformErrorKind` type:

| operation | commande |
| --- | --- |
| `account_forget` | `platform_forget_account` |
| `account_add` | `platform_begin_setup`, `roblox_add_account_by_cookie` |
| `profile_capture` | `riot_capture_profile` |
| `bulk_edit` | `steam_bulk_edit` |
| `game_settings_copy` | `steam_copy_game_settings` |
| `cs2_bridge_fetch` | `cs2_bridge_fetch` |
| `avatar_refresh` | `steam_get_profile_infos` |
| `ban_check` | `steam_get_player_bans` |

`platform_begin_setup` est le plus gros trou des huit: `addNew` dans `useAccountLoader.svelte.ts` avale l'erreur dans un toast, donc un setup qui ne s'ouvre pas ne produisait rien du tout, ni `account_add_started` ni echec.

`session_check` reste non branche et c'est commente dans `events.rs`: `dead_session_user_ids` avale chaque sonde et rend une liste dans tous les cas, il n'y a pas d'echec a rapporter.

## roblox, 108 snapshots et zero ajout

`RobloxSettingsTab.svelte` colle le cookie directement dans `roblox_add_account_by_cookie`, a cote du controleur par lequel toutes les autres plateformes passent. le debut et le succes sont rapportes cote front, l'echec cote rust ou le `PlatformErrorKind` existe.

## garde-fou

`code_from` mappe un nom inconnu sur `other` au lieu de le jeter, ce qui est le bon comportement sur le fil et le pire a debugger: une faute de frappe donne un event plausible qui rejoint le tas des echecs non classes. `tracked_operations_are_in_the_vocabulary` lit les sites d'appel dans la source plutot que de tenir une seconde liste. verifie dans les deux sens: `ban_check` renomme en `ban_chekc` fait tomber le test.

## commit de forme

`vp check` echoue sur `main` depuis #51, `src/lib/theme/schema.ts` et `themes.ts` sont partis non formates. commit separe, sortie de `vp check --fix`, sinon la CI de cette PR est rouge pour une raison qui n'est pas la sienne.

## verifie

```
cargo clippy --workspace -- -D warnings   No issues found
cargo fmt --all --check                   ok
cargo test --workspace                    517 passed, 1 ignored
vitest run                                220 passed
svelte-check                              0 errors
vp check                                  207 files formatted, 0 errors
```

pas verifie: le deploiement lui-meme. le job n'a jamais tourne, et il ne peut pas tourner avant que les deux secrets existent et que ca soit merge sur `main`. une fois passe, la preuve est un event avec `surface` non null, pas un job vert.

## pas dans cette PR

- ligne 2 du `README.md` et `shortDescription` de `tauri.conf.json` annoncent six plateformes sur neuf, GOG, Jagex et Discord sont absents. rien a voir avec la telemetrie mais ca contribue probablement au zero de gog et jagex.
- une plateforme ajoutee par descripteur utilisateur remonte en `other` via `platform_code`, ce qui est le bon comportement (un id nomme par l'utilisateur est une donnee utilisateur) mais merite d'etre su avant de lire un graphe par plateforme.
- `platform_dry_run` n'a pas d'entree dans le vocabulaire. laisse tel quel: une plateforme sans plan repond par une erreur normale, l'instrumenter ne ferait que du bruit.
