### PR TITLE
refactor: one rule table for the surfaces, one decision for the drop

### DIFF
--- a/src/lib/shared/dragAndDrop.svelte.ts
+++ b/src/lib/shared/dragAndDrop.svelte.ts
@@ -1,4 +1,5 @@
 import type { ItemRef } from "../features/folders/types";
+import { previewIndexAt } from "./dropGeometry";
 import { moveItem, reorderItems, getFolder, isFolderDescendant } from "../features/folders/store";
 
 const DRAG_THRESHOLD = 5;
@@ -91,68 +92,63 @@ export function createDragManager(options: DragManagerOptions) {
     dragOldIndex = items.findIndex((i) => i.id === dragItem!.id);
   }
 
+  /**
+   * What the pointer is over, as one value rather than three flags.
+   *
+   * The three states used to be decided and written in the same breath, which
+   * meant every one of them had to remember to clear the other two. Naming
+   * them first means the flags are assigned once, from one answer.
+   */
+  type DropTarget =
+    | { kind: "none" }
+    | { kind: "back" }
+    | { kind: "folder"; id: string }
+    | { kind: "reorder" };
+
+  function dropTargetAt(el: HTMLElement | null): DropTarget {
+    if (!el) return { kind: "none" };
+    const hover = el.closest(
+      "[data-folder-id], [data-back-card], [data-account-id]",
+    ) as HTMLElement | null;
+    // Anything that is not one of those cards is the grid itself, so the drag
+    // is a reorder rather than a move into something.
+    if (!hover) return { kind: "reorder" };
+
+    const { backCard, folderId, sectionCard } = hover.dataset;
+    if (backCard) return { kind: "back" };
+    if (!folderId) return { kind: "reorder" };
+    if (dragItem?.type === "folder") {
+      // A folder cannot swallow itself or its own subtree.
+      if (isFolderDescendant(folderId, dragItem.id)) return { kind: "reorder" };
+      // In sections mode a section takes accounts, never another folder:
+      // folders reorder among the sections instead.
+      if (dragInSectionsMode && sectionCard === "true") return { kind: "reorder" };
+    }
+    return { kind: "folder", id: folderId };
+  }
+
   function updateDragAt(clientX: number, clientY: number) {
     if (!isDragging) return;
 
     // Hit-test before touching the ghost style so the layout read does not
     // force a reflow right after a write in the same frame.
-    const el = document.elementFromPoint(clientX, clientY) as HTMLElement | null;
+    const target = dropTargetAt(document.elementFromPoint(clientX, clientY) as HTMLElement | null);
 
     if (ghostEl) {
       ghostEl.style.left = `${clientX - ghostOffsetX}px`;
       ghostEl.style.top = `${clientY - ghostOffsetY}px`;
     }
 
-    if (!el) {
-      dragOverFolderId = null;
-      dragOverBack = false;
+    dragOverBack = target.kind === "back";
+    dragOverFolderId = target.kind === "folder" ? target.id : null;
+    if (target.kind !== "reorder") {
       previewIndex = null;
       return;
     }
-
-    const hover = el.closest(
-      "[data-folder-id], [data-back-card], [data-account-id]",
-    ) as HTMLElement | null;
-    const isSectionHover = hover?.dataset.sectionCard === "true";
-
-    if (hover?.dataset.backCard) {
-      dragOverBack = true;
-      dragOverFolderId = null;
-      previewIndex = null;
-    } else if (
-      hover?.dataset.folderId &&
-      !(dragItem?.type === "folder" && isFolderDescendant(hover.dataset.folderId, dragItem.id)) &&
-      !(dragInSectionsMode && dragItem?.type === "folder" && isSectionHover)
-    ) {
-      dragOverFolderId = hover.dataset.folderId!;
-      dragOverBack = false;
-      previewIndex = null;
-    } else {
-      dragOverFolderId = null;
-      dragOverBack = false;
-      if (slotRects.length > 0 && dragOldIndex >= 0) {
-        let bestIdx = 0;
-        let bestDist = Infinity;
-        for (let i = 0; i < slotRects.length; i++) {
-          const r = slotRects[i];
-          const dist =
-            (clientX - (r.left + r.width / 2)) ** 2 + (clientY - (r.top + r.height / 2)) ** 2;
-          if (dist < bestDist) {
-            bestDist = dist;
-            bestIdx = i;
-          }
-        }
-        const r = slotRects[bestIdx];
-        let dropIdx: number;
-        if (dragIsListMode) {
-          dropIdx = clientY > r.top + r.height / 2 ? bestIdx + 1 : bestIdx;
-        } else {
-          dropIdx = clientX > r.left + r.width / 2 ? bestIdx + 1 : bestIdx;
-        }
-        const insertAt = dropIdx > dragOldIndex ? dropIdx - 1 : dropIdx;
-        previewIndex = Math.max(0, Math.min(insertAt, slotRects.length - 1));
-      }
-    }
+    // Left alone when the layout offers no slot: a drag never changes the
+    // snapshot it started with, so there is nothing new to show.
+    const at = previewIndexAt(clientX, clientY, slotRects, dragOldIndex, dragIsListMode);
+    if (at !== null) previewIndex = at;
   }
 
   function handleGridMouseDown(e: MouseEvent) {
@@ -295,14 +291,24 @@ export function createDragManager(options: DragManagerOptions) {
     cancelDrag();
   }
 
+  /**
+   * Eats the click the browser fires right after a drag release, so dropping a
+   * card never also activates it. Cleared on the next tick because a release
+   * that emits no click at all would otherwise leave the guard armed for the
+   * next real one.
+   */
+  function swallowNextClick() {
+    eatNextClick = true;
+    setTimeout(() => {
+      eatNextClick = false;
+    }, 0);
+  }
+
   function handleDocMouseUp() {
     if (dragCancelled) {
       // Release after an Escape cancel: swallow the mouseup and its click.
       dragCancelled = false;
-      eatNextClick = true;
-      setTimeout(() => {
-        eatNextClick = false;
-      }, 0);
+      swallowNextClick();
       return;
     }
 
@@ -351,11 +357,7 @@ export function createDragManager(options: DragManagerOptions) {
       options.onRefresh();
     }
 
-    eatNextClick = true;
-    // If no click event is emitted, clear the guard on the next tick.
-    setTimeout(() => {
-      eatNextClick = false;
-    }, 0);
+    swallowNextClick();
     cancelDrag();
   }
 

--- a/src/lib/shared/dropGeometry.test.ts
+++ b/src/lib/shared/dropGeometry.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { previewIndexAt, type SlotRect } from "./dropGeometry";
+
+/** Four 100x100 cards in a row, gapless, starting at the origin. */
+const ROW: SlotRect[] = [0, 1, 2, 3].map((i) => ({
+  left: i * 100,
+  top: 0,
+  width: 100,
+  height: 100,
+}));
+
+/** The same four stacked, which is what list mode lays out. */
+const COLUMN: SlotRect[] = [0, 1, 2, 3].map((i) => ({
+  left: 0,
+  top: i * 100,
+  width: 100,
+  height: 100,
+}));
+
+describe("previewIndexAt", () => {
+  it("has nowhere to drop when the layout was never measured", () => {
+    expect(previewIndexAt(50, 50, [], 0, false)).toBeNull();
+    expect(previewIndexAt(50, 50, ROW, -1, false)).toBeNull();
+  });
+
+  it("drops before the nearest card when the pointer is on its leading half", () => {
+    expect(previewIndexAt(210, 50, ROW, 0, false)).toBe(1);
+  });
+
+  it("drops after the nearest card when the pointer is past its middle", () => {
+    expect(previewIndexAt(260, 50, ROW, 0, false)).toBe(2);
+  });
+
+  it("reads the vertical axis in list mode and the horizontal one in a grid", () => {
+    // Same point, same slots: only the axis that decides before-or-after moves.
+    expect(previewIndexAt(60, 240, COLUMN, 3, true)).toBe(2);
+    expect(previewIndexAt(60, 260, COLUMN, 3, true)).toBe(3);
+  });
+
+  it("closes the gap the card left behind when it moves forward", () => {
+    // Card 0 dropped past card 2: without the shift it would land at 3 and sit
+    // one slot too far, because removing it first pulls everything left.
+    expect(previewIndexAt(260, 50, ROW, 0, false)).toBe(2);
+    // Moving backwards leaves the tail untouched, so no shift applies.
+    expect(previewIndexAt(30, 50, ROW, 3, false)).toBe(0);
+  });
+
+  it("never points outside the list", () => {
+    expect(previewIndexAt(-5000, 50, ROW, 2, false)).toBe(0);
+    expect(previewIndexAt(5000, 50, ROW, 0, false)).toBe(3);
+  });
+
+  it("resolves a pointer that is inside no card at all", () => {
+    // Gutters: cards occupy 0-100, 120-220, 240-340, 360-460.
+    const gapped: SlotRect[] = [0, 1, 2, 3].map((i) => ({
+      left: i * 120,
+      top: 0,
+      width: 100,
+      height: 100,
+    }));
+    // 115 is between card 0 and card 1, nearer to card 1's centre.
+    expect(previewIndexAt(115, 50, gapped, 3, false)).toBe(1);
+  });
+});

--- a/src/lib/shared/dropGeometry.ts
+++ b/src/lib/shared/dropGeometry.ts
@@ -1,0 +1,58 @@
+/**
+ * Where a dragged card would land, from geometry alone.
+ *
+ * Split out of the drag manager because it is the one part of a drag that
+ * needs no DOM, no reactive state and no folder store: given the slot
+ * rectangles captured when the drag started and a pointer position, the answer
+ * is arithmetic. That makes it the part a test can actually pin down.
+ */
+
+/** The part of a `DOMRect` the drop calculation reads. */
+export interface SlotRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Index the dragged card would take if it were dropped here, or `null` when
+ * the layout offers nowhere to drop: an empty grid, or a card whose own index
+ * was never resolved.
+ *
+ * The pointer picks the nearest slot centre, then the side it fell on decides
+ * whether the card goes before or after that slot. Dropping past your own old
+ * position shifts the target back by one, because removing the card first
+ * closes the gap it left behind.
+ */
+export function previewIndexAt(
+  clientX: number,
+  clientY: number,
+  slots: readonly SlotRect[],
+  oldIndex: number,
+  listMode: boolean,
+): number | null {
+  if (slots.length === 0 || oldIndex < 0) return null;
+
+  let nearest = 0;
+  let nearestDistance = Infinity;
+  for (let i = 0; i < slots.length; i++) {
+    const slot = slots[i];
+    const distance =
+      (clientX - (slot.left + slot.width / 2)) ** 2 + (clientY - (slot.top + slot.height / 2)) ** 2;
+    if (distance < nearestDistance) {
+      nearestDistance = distance;
+      nearest = i;
+    }
+  }
+
+  const slot = slots[nearest];
+  // A list stacks vertically, a grid flows horizontally, so the axis that
+  // decides "before or after" is the one the cards advance along.
+  const past = listMode
+    ? clientY > slot.top + slot.height / 2
+    : clientX > slot.left + slot.width / 2;
+  const dropIndex = past ? nearest + 1 : nearest;
+  const insertAt = dropIndex > oldIndex ? dropIndex - 1 : dropIndex;
+  return Math.max(0, Math.min(insertAt, slots.length - 1));
+}

--- a/src/lib/theme/surfaceOpacities.test.ts
+++ b/src/lib/theme/surfaceOpacities.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { getThemeDefinition, resolveThemeSurfaceOpacities } from "./themes";
+
+const IDS = ["dark", "light", "midnight", "glass-dark", "glass-light", "liquid-glass"];
+const PERCENTS = [0, 25, 42, 55, 80, 100];
+
+/**
+ * Every built-in theme, six slider positions, backdrop present and absent.
+ *
+ * These are the exact numbers the app painted with, captured before the four
+ * surface rules became a table. A cap, a bump or a floor edited by accident
+ * shows up here as a changed line instead of as a slightly wrong shade nobody
+ * notices. Regenerate from a run, never by hand.
+ */
+const GOLDEN = [
+  'dark 0 true {"windowOpacity":0,"cardOpacity":0.66,"hoverOpacity":0.72,"mutedOpacity":0.72,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'dark 0 false {"windowOpacity":0,"cardOpacity":0.66,"hoverOpacity":0.72,"mutedOpacity":0.72,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'dark 25 true {"windowOpacity":0.25,"cardOpacity":0.66,"hoverOpacity":0.72,"mutedOpacity":0.72,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'dark 25 false {"windowOpacity":0.25,"cardOpacity":0.66,"hoverOpacity":0.72,"mutedOpacity":0.72,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'dark 42 true {"windowOpacity":0.42,"cardOpacity":0.66,"hoverOpacity":0.72,"mutedOpacity":0.72,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'dark 42 false {"windowOpacity":0.42,"cardOpacity":0.66,"hoverOpacity":0.72,"mutedOpacity":0.72,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'dark 55 true {"windowOpacity":0.55,"cardOpacity":0.6900000000000001,"hoverOpacity":0.75,"mutedOpacity":0.73,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'dark 55 false {"windowOpacity":0.55,"cardOpacity":0.6900000000000001,"hoverOpacity":0.75,"mutedOpacity":0.73,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'dark 80 true {"windowOpacity":0.8,"cardOpacity":0.9400000000000001,"hoverOpacity":1,"mutedOpacity":0.98,"elevatedOpacity":1,"overlayOpacity":1,"isLiquid":false}',
+  'dark 80 false {"windowOpacity":0.8,"cardOpacity":0.9400000000000001,"hoverOpacity":1,"mutedOpacity":0.98,"elevatedOpacity":1,"overlayOpacity":1,"isLiquid":false}',
+  'dark 100 true {"windowOpacity":1,"cardOpacity":1,"hoverOpacity":1,"mutedOpacity":1,"elevatedOpacity":1,"overlayOpacity":1,"isLiquid":false}',
+  'dark 100 false {"windowOpacity":1,"cardOpacity":1,"hoverOpacity":1,"mutedOpacity":1,"elevatedOpacity":1,"overlayOpacity":1,"isLiquid":false}',
+  'light 0 true {"windowOpacity":0,"cardOpacity":0.66,"hoverOpacity":0.72,"mutedOpacity":0.72,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'light 0 false {"windowOpacity":0,"cardOpacity":0.66,"hoverOpacity":0.72,"mutedOpacity":0.72,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'light 25 true {"windowOpacity":0.25,"cardOpacity":0.66,"hoverOpacity":0.72,"mutedOpacity":0.72,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'light 25 false {"windowOpacity":0.25,"cardOpacity":0.66,"hoverOpacity":0.72,"mutedOpacity":0.72,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'light 42 true {"windowOpacity":0.42,"cardOpacity":0.66,"hoverOpacity":0.72,"mutedOpacity":0.72,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'light 42 false {"windowOpacity":0.42,"cardOpacity":0.66,"hoverOpacity":0.72,"mutedOpacity":0.72,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'light 55 true {"windowOpacity":0.55,"cardOpacity":0.6900000000000001,"hoverOpacity":0.75,"mutedOpacity":0.73,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'light 55 false {"windowOpacity":0.55,"cardOpacity":0.6900000000000001,"hoverOpacity":0.75,"mutedOpacity":0.73,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'light 80 true {"windowOpacity":0.8,"cardOpacity":0.9400000000000001,"hoverOpacity":1,"mutedOpacity":0.98,"elevatedOpacity":1,"overlayOpacity":1,"isLiquid":false}',
+  'light 80 false {"windowOpacity":0.8,"cardOpacity":0.9400000000000001,"hoverOpacity":1,"mutedOpacity":0.98,"elevatedOpacity":1,"overlayOpacity":1,"isLiquid":false}',
+  'light 100 true {"windowOpacity":1,"cardOpacity":1,"hoverOpacity":1,"mutedOpacity":1,"elevatedOpacity":1,"overlayOpacity":1,"isLiquid":false}',
+  'light 100 false {"windowOpacity":1,"cardOpacity":1,"hoverOpacity":1,"mutedOpacity":1,"elevatedOpacity":1,"overlayOpacity":1,"isLiquid":false}',
+  'midnight 0 true {"windowOpacity":0,"cardOpacity":0.66,"hoverOpacity":0.72,"mutedOpacity":0.72,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'midnight 0 false {"windowOpacity":0,"cardOpacity":0.66,"hoverOpacity":0.72,"mutedOpacity":0.72,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'midnight 25 true {"windowOpacity":0.25,"cardOpacity":0.66,"hoverOpacity":0.72,"mutedOpacity":0.72,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'midnight 25 false {"windowOpacity":0.25,"cardOpacity":0.66,"hoverOpacity":0.72,"mutedOpacity":0.72,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'midnight 42 true {"windowOpacity":0.42,"cardOpacity":0.66,"hoverOpacity":0.72,"mutedOpacity":0.72,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'midnight 42 false {"windowOpacity":0.42,"cardOpacity":0.66,"hoverOpacity":0.72,"mutedOpacity":0.72,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'midnight 55 true {"windowOpacity":0.55,"cardOpacity":0.6900000000000001,"hoverOpacity":0.75,"mutedOpacity":0.73,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'midnight 55 false {"windowOpacity":0.55,"cardOpacity":0.6900000000000001,"hoverOpacity":0.75,"mutedOpacity":0.73,"elevatedOpacity":0.78,"overlayOpacity":0.86,"isLiquid":false}',
+  'midnight 80 true {"windowOpacity":0.8,"cardOpacity":0.9400000000000001,"hoverOpacity":1,"mutedOpacity":0.98,"elevatedOpacity":1,"overlayOpacity":1,"isLiquid":false}',
+  'midnight 80 false {"windowOpacity":0.8,"cardOpacity":0.9400000000000001,"hoverOpacity":1,"mutedOpacity":0.98,"elevatedOpacity":1,"overlayOpacity":1,"isLiquid":false}',
+  'midnight 100 true {"windowOpacity":1,"cardOpacity":1,"hoverOpacity":1,"mutedOpacity":1,"elevatedOpacity":1,"overlayOpacity":1,"isLiquid":false}',
+  'midnight 100 false {"windowOpacity":1,"cardOpacity":1,"hoverOpacity":1,"mutedOpacity":1,"elevatedOpacity":1,"overlayOpacity":1,"isLiquid":false}',
+  'glass-dark 0 true {"windowOpacity":0.55,"cardOpacity":0.65,"hoverOpacity":0.73,"mutedOpacity":0.6900000000000001,"elevatedOpacity":0.75,"overlayOpacity":0.86,"isLiquid":false}',
+  'glass-dark 0 false {"windowOpacity":0.96,"cardOpacity":0.72,"hoverOpacity":0.7999999999999999,"mutedOpacity":0.78,"elevatedOpacity":0.85,"overlayOpacity":1,"isLiquid":false}',
+  'glass-dark 25 true {"windowOpacity":0.55,"cardOpacity":0.65,"hoverOpacity":0.73,"mutedOpacity":0.6900000000000001,"elevatedOpacity":0.75,"overlayOpacity":0.86,"isLiquid":false}',
+  'glass-dark 25 false {"windowOpacity":0.96,"cardOpacity":0.72,"hoverOpacity":0.7999999999999999,"mutedOpacity":0.78,"elevatedOpacity":0.85,"overlayOpacity":1,"isLiquid":false}',
+  'glass-dark 42 true {"windowOpacity":0.55,"cardOpacity":0.65,"hoverOpacity":0.73,"mutedOpacity":0.6900000000000001,"elevatedOpacity":0.75,"overlayOpacity":0.86,"isLiquid":false}',
+  'glass-dark 42 false {"windowOpacity":0.96,"cardOpacity":0.72,"hoverOpacity":0.7999999999999999,"mutedOpacity":0.78,"elevatedOpacity":0.85,"overlayOpacity":1,"isLiquid":false}',
+  'glass-dark 55 true {"windowOpacity":0.55,"cardOpacity":0.65,"hoverOpacity":0.73,"mutedOpacity":0.6900000000000001,"elevatedOpacity":0.75,"overlayOpacity":0.86,"isLiquid":false}',
+  'glass-dark 55 false {"windowOpacity":0.96,"cardOpacity":0.72,"hoverOpacity":0.7999999999999999,"mutedOpacity":0.78,"elevatedOpacity":0.85,"overlayOpacity":1,"isLiquid":false}',
+  'glass-dark 80 true {"windowOpacity":0.55,"cardOpacity":0.65,"hoverOpacity":0.73,"mutedOpacity":0.6900000000000001,"elevatedOpacity":0.75,"overlayOpacity":0.86,"isLiquid":false}',
+  'glass-dark 80 false {"windowOpacity":0.96,"cardOpacity":0.72,"hoverOpacity":0.7999999999999999,"mutedOpacity":0.78,"elevatedOpacity":0.85,"overlayOpacity":1,"isLiquid":false}',
+  'glass-dark 100 true {"windowOpacity":0.55,"cardOpacity":0.65,"hoverOpacity":0.73,"mutedOpacity":0.6900000000000001,"elevatedOpacity":0.75,"overlayOpacity":0.86,"isLiquid":false}',
+  'glass-dark 100 false {"windowOpacity":0.96,"cardOpacity":0.72,"hoverOpacity":0.7999999999999999,"mutedOpacity":0.78,"elevatedOpacity":0.85,"overlayOpacity":1,"isLiquid":false}',
+  'glass-light 0 true {"windowOpacity":0.55,"cardOpacity":0.65,"hoverOpacity":0.73,"mutedOpacity":0.6900000000000001,"elevatedOpacity":0.75,"overlayOpacity":0.86,"isLiquid":false}',
+  'glass-light 0 false {"windowOpacity":0.96,"cardOpacity":0.72,"hoverOpacity":0.7999999999999999,"mutedOpacity":0.78,"elevatedOpacity":0.85,"overlayOpacity":1,"isLiquid":false}',
+  'glass-light 25 true {"windowOpacity":0.55,"cardOpacity":0.65,"hoverOpacity":0.73,"mutedOpacity":0.6900000000000001,"elevatedOpacity":0.75,"overlayOpacity":0.86,"isLiquid":false}',
+  'glass-light 25 false {"windowOpacity":0.96,"cardOpacity":0.72,"hoverOpacity":0.7999999999999999,"mutedOpacity":0.78,"elevatedOpacity":0.85,"overlayOpacity":1,"isLiquid":false}',
+  'glass-light 42 true {"windowOpacity":0.55,"cardOpacity":0.65,"hoverOpacity":0.73,"mutedOpacity":0.6900000000000001,"elevatedOpacity":0.75,"overlayOpacity":0.86,"isLiquid":false}',
+  'glass-light 42 false {"windowOpacity":0.96,"cardOpacity":0.72,"hoverOpacity":0.7999999999999999,"mutedOpacity":0.78,"elevatedOpacity":0.85,"overlayOpacity":1,"isLiquid":false}',
+  'glass-light 55 true {"windowOpacity":0.55,"cardOpacity":0.65,"hoverOpacity":0.73,"mutedOpacity":0.6900000000000001,"elevatedOpacity":0.75,"overlayOpacity":0.86,"isLiquid":false}',
+  'glass-light 55 false {"windowOpacity":0.96,"cardOpacity":0.72,"hoverOpacity":0.7999999999999999,"mutedOpacity":0.78,"elevatedOpacity":0.85,"overlayOpacity":1,"isLiquid":false}',
+  'glass-light 80 true {"windowOpacity":0.55,"cardOpacity":0.65,"hoverOpacity":0.73,"mutedOpacity":0.6900000000000001,"elevatedOpacity":0.75,"overlayOpacity":0.86,"isLiquid":false}',
+  'glass-light 80 false {"windowOpacity":0.96,"cardOpacity":0.72,"hoverOpacity":0.7999999999999999,"mutedOpacity":0.78,"elevatedOpacity":0.85,"overlayOpacity":1,"isLiquid":false}',
+  'glass-light 100 true {"windowOpacity":0.55,"cardOpacity":0.65,"hoverOpacity":0.73,"mutedOpacity":0.6900000000000001,"elevatedOpacity":0.75,"overlayOpacity":0.86,"isLiquid":false}',
+  'glass-light 100 false {"windowOpacity":0.96,"cardOpacity":0.72,"hoverOpacity":0.7999999999999999,"mutedOpacity":0.78,"elevatedOpacity":0.85,"overlayOpacity":1,"isLiquid":false}',
+  'liquid-glass 0 true {"windowOpacity":0.18,"cardOpacity":0.13,"hoverOpacity":0.21,"mutedOpacity":0.16,"elevatedOpacity":0.34,"overlayOpacity":0.86,"isLiquid":true}',
+  'liquid-glass 0 false {"windowOpacity":0.96,"cardOpacity":0.72,"hoverOpacity":0.7999999999999999,"mutedOpacity":0.78,"elevatedOpacity":0.85,"overlayOpacity":1,"isLiquid":false}',
+  'liquid-glass 25 true {"windowOpacity":0.18,"cardOpacity":0.13,"hoverOpacity":0.21,"mutedOpacity":0.16,"elevatedOpacity":0.34,"overlayOpacity":0.86,"isLiquid":true}',
+  'liquid-glass 25 false {"windowOpacity":0.96,"cardOpacity":0.72,"hoverOpacity":0.7999999999999999,"mutedOpacity":0.78,"elevatedOpacity":0.85,"overlayOpacity":1,"isLiquid":false}',
+  'liquid-glass 42 true {"windowOpacity":0.18,"cardOpacity":0.13,"hoverOpacity":0.21,"mutedOpacity":0.16,"elevatedOpacity":0.34,"overlayOpacity":0.86,"isLiquid":true}',
+  'liquid-glass 42 false {"windowOpacity":0.96,"cardOpacity":0.72,"hoverOpacity":0.7999999999999999,"mutedOpacity":0.78,"elevatedOpacity":0.85,"overlayOpacity":1,"isLiquid":false}',
+  'liquid-glass 55 true {"windowOpacity":0.18,"cardOpacity":0.13,"hoverOpacity":0.21,"mutedOpacity":0.16,"elevatedOpacity":0.34,"overlayOpacity":0.86,"isLiquid":true}',
+  'liquid-glass 55 false {"windowOpacity":0.96,"cardOpacity":0.72,"hoverOpacity":0.7999999999999999,"mutedOpacity":0.78,"elevatedOpacity":0.85,"overlayOpacity":1,"isLiquid":false}',
+  'liquid-glass 80 true {"windowOpacity":0.18,"cardOpacity":0.13,"hoverOpacity":0.21,"mutedOpacity":0.16,"elevatedOpacity":0.34,"overlayOpacity":0.86,"isLiquid":true}',
+  'liquid-glass 80 false {"windowOpacity":0.96,"cardOpacity":0.72,"hoverOpacity":0.7999999999999999,"mutedOpacity":0.78,"elevatedOpacity":0.85,"overlayOpacity":1,"isLiquid":false}',
+  'liquid-glass 100 true {"windowOpacity":0.18,"cardOpacity":0.13,"hoverOpacity":0.21,"mutedOpacity":0.16,"elevatedOpacity":0.34,"overlayOpacity":0.86,"isLiquid":true}',
+  'liquid-glass 100 false {"windowOpacity":0.96,"cardOpacity":0.72,"hoverOpacity":0.7999999999999999,"mutedOpacity":0.78,"elevatedOpacity":0.85,"overlayOpacity":1,"isLiquid":false}',
+];
+
+function measured(): string[] {
+  const rows: string[] = [];
+  for (const id of IDS) {
+    const theme = getThemeDefinition(id);
+    for (const percent of PERCENTS) {
+      for (const backdropAvailable of [true, false]) {
+        const values = resolveThemeSurfaceOpacities(theme, percent, { backdropAvailable });
+        rows.push(`${id} ${percent} ${backdropAvailable} ${JSON.stringify(values)}`);
+      }
+    }
+  }
+  return rows;
+}
+
+describe("surface opacity rules", () => {
+  it("paints every built-in theme exactly as before the table", () => {
+    expect(measured()).toEqual(GOLDEN);
+  });
+
+  it("clamps a slider value outside 0 to 100", () => {
+    const dark = getThemeDefinition("dark");
+    expect(resolveThemeSurfaceOpacities(dark, -40).windowOpacity).toBe(0);
+    expect(resolveThemeSurfaceOpacities(dark, 400).windowOpacity).toBe(1);
+  });
+});

--- a/src/lib/theme/themes.ts
+++ b/src/lib/theme/themes.ts
@@ -414,6 +414,62 @@ export function themeUsesLiquidGlass(theme: AppThemeDefinition): boolean {
   return documentIsLiquidGlass(theme.document, getThemeDocument);
 }
 
+/**
+ * How solid one card surface sits above the window fill.
+ *
+ * The four of them answer the same question and differ only in numbers: a
+ * fixed alpha while the live backdrop does the work, otherwise the base plus a
+ * bump, held between a floor and a cap. Written once, a fifth surface is a row
+ * here rather than a fourth copy of the same three-way ternary.
+ */
+interface SurfaceRule {
+  /** Used as-is while the liquid backdrop is live. */
+  liquid: number;
+  /** Cap, bump and floor on a glass theme with no live backdrop. */
+  glass: readonly [cap: number, bump: number, floor: number];
+  /** The same three on a regular theme. */
+  plain: readonly [cap: number, bump: number, floor: number];
+}
+
+const SURFACE_RULES = {
+  card: { liquid: 0.13, glass: [0.72, 0.1, 0.4], plain: [1, 0.14, 0.66] },
+  // Hover has no glass floor of its own: it is built on the card, which
+  // already floors at 0.4, so anything lower cannot reach it.
+  hover: { liquid: 0.21, glass: [0.8, 0.08, 0], plain: [1, 0.06, 0.72] },
+  muted: { liquid: 0.16, glass: [0.78, 0.14, 0.46], plain: [1, 0.18, 0.72] },
+  elevated: { liquid: 0.34, glass: [0.85, 0.2, 0.55], plain: [1, 0.22, 0.78] },
+} as const satisfies Record<string, SurfaceRule>;
+
+function surfaceOpacity(
+  rule: SurfaceRule,
+  base: number,
+  isLiquid: boolean,
+  glass: boolean,
+): number {
+  if (isLiquid) return rule.liquid;
+  const [cap, bump, floor] = glass ? rule.glass : rule.plain;
+  return Math.min(cap, Math.max(base + bump, floor));
+}
+
+/**
+ * How solid the window itself is.
+ *
+ * A regular theme follows the slider. A glass theme ignores it: the fill is
+ * what its blur was designed against, and with no backdrop to blur it falls
+ * back to near-solid so the text stays readable.
+ */
+function windowFill(
+  theme: AppThemeDefinition,
+  rawOpacity: number,
+  backdropAvailable: boolean,
+  liquid: boolean,
+): number {
+  if (!theme.glass) return rawOpacity;
+  if (!backdropAvailable) return 0.96;
+  if (liquid) return GLASS_WINDOW_OPACITY["liquid-glass"];
+  return GLASS_WINDOW_OPACITY[theme.id] ?? 0.55;
+}
+
 export function resolveThemeSurfaceOpacities(
   theme: AppThemeDefinition,
   backgroundOpacityPercent: number,
@@ -425,33 +481,14 @@ export function resolveThemeSurfaceOpacities(
   const backdropAvailable = opts.backdropAvailable !== false;
   const liquid = themeUsesLiquidGlass(theme);
   const isLiquid = liquid && backdropAvailable;
-  const windowOpacity = theme.glass
-    ? backdropAvailable
-      ? liquid
-        ? GLASS_WINDOW_OPACITY["liquid-glass"]
-        : (GLASS_WINDOW_OPACITY[theme.id] ?? 0.55)
-      : 0.96
-    : rawOpacity;
-  const cardOpacity = isLiquid
-    ? 0.13
-    : theme.glass
-      ? Math.min(0.72, Math.max(windowOpacity + 0.1, 0.4))
-      : Math.min(1, Math.max(windowOpacity + 0.14, 0.66));
-  const hoverOpacity = isLiquid
-    ? 0.21
-    : theme.glass
-      ? Math.min(0.8, cardOpacity + 0.08)
-      : Math.min(1, Math.max(cardOpacity + 0.06, 0.72));
-  const mutedOpacity = isLiquid
-    ? 0.16
-    : theme.glass
-      ? Math.min(0.78, Math.max(windowOpacity + 0.14, 0.46))
-      : Math.min(1, Math.max(windowOpacity + 0.18, 0.72));
-  const elevatedOpacity = isLiquid
-    ? 0.34
-    : theme.glass
-      ? Math.min(0.85, Math.max(windowOpacity + 0.2, 0.55))
-      : Math.min(1, Math.max(windowOpacity + 0.22, 0.78));
+  const glass = theme.glass === true;
+  const windowOpacity = windowFill(theme, rawOpacity, backdropAvailable, liquid);
+  const cardOpacity = surfaceOpacity(SURFACE_RULES.card, windowOpacity, isLiquid, glass);
+  // Hover builds on the card rather than on the window: the two must stay a
+  // step apart whatever the slider does to the fill underneath them.
+  const hoverOpacity = surfaceOpacity(SURFACE_RULES.hover, cardOpacity, isLiquid, glass);
+  const mutedOpacity = surfaceOpacity(SURFACE_RULES.muted, windowOpacity, isLiquid, glass);
+  const elevatedOpacity = surfaceOpacity(SURFACE_RULES.elevated, windowOpacity, isLiquid, glass);
   const overlayOpacity = Math.min(1, Math.max(windowOpacity + 0.3, 0.86));
   return {
     windowOpacity,


### PR DESCRIPTION
`resolveThemeSurfaceOpacities` wrote the same three-way ternary once per surface, differing only in numbers. those numbers are now a `SURFACE_RULES` table of cap, bump and floor, read by `surfaceOpacity`. the nested ternary deciding the window alpha became `windowFill`, four guards. a fifth surface is a row instead of a fourth copy. one asymmetry that used to be invisible is now stated: hover has no glass floor of its own because it builds on the card, which already floors at 0.4.

`updateDragAt` had three branches assigning the same three variables, so each one had to remember to clear the other two. `dropTargetAt` now answers what the pointer is over as a single value, and the flags are assigned once. the slot arithmetic moved to `dropGeometry.ts`, testable because it needs no dom. `swallowNextClick` names a block written twice verbatim in `handleDocMouseUp`.

measured with the complexity audit, not by hand: `resolveThemeSurfaceOpacities` 15 to 3, `updateDragAt` 24 to 6, repo total above 15 ccn 36 to 34 over 1668 functions.

behaviour proved before the change, not after. a golden table pins the six built-in themes across six slider positions with the backdrop on and off, 72 rows captured from a real run, byte-identical afterwards. `previewIndexAt` was checked against a verbatim copy of the old inline block over 20000 random layouts, no divergence.

- [x] `vp check`, `svelte-check`, `vp build`
- [x] `vitest` 233 passing
- [ ] app launched by hand
